### PR TITLE
Adjust formatting rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,11 +14,11 @@ IncludeCategories:
   - Regex:           '<.*'
     Priority:        2
 IndentWidth: 4
-IndentWrappedFunctionNames: true
 InsertBraces: true
 InsertNewlineAtEOF: true
 LineEnding: LF
 NamespaceIndentation: All
+PenaltyReturnTypeOnItsOwnLine: 300
 QualifierAlignment: Left
 SeparateDefinitionBlocks: Always
 SortIncludes: CaseSensitive

--- a/include/c_api.h
+++ b/include/c_api.h
@@ -23,70 +23,85 @@ typedef bool (*ggapiLifecycleCallback)(
     uintptr_t callbackContext, uint32_t moduleHandle, uint32_t phaseOrd, uint32_t dataStruct
 );
 
-extern "C" [[maybe_unused]] EXPORT bool
-    greengrass_lifecycle(uint32_t moduleHandle, uint32_t phase, uint32_t data) noexcept;
+extern "C" [[maybe_unused]] EXPORT bool greengrass_lifecycle(
+    uint32_t moduleHandle, uint32_t phase, uint32_t data
+) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t ggapiClaimThread() noexcept;
 extern "C" [[maybe_unused]] IMPEXP bool ggapiReleaseThread() noexcept;
 extern "C" [[maybe_unused]] IMPEXP void ggapiSetError(uint32_t errorOrd) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t ggapiGetError() noexcept;
 
 extern "C" [[maybe_unused]] IMPEXP uint32_t
-    ggapiGetStringOrdinal(const char *bytes, size_t len) noexcept;
+ggapiGetStringOrdinal(const char *bytes, size_t len) noexcept;
 extern "C" [[maybe_unused]] IMPEXP size_t
-    ggapiGetOrdinalString(uint32_t ord, char *bytes, size_t len) noexcept;
+ggapiGetOrdinalString(uint32_t ord, char *bytes, size_t len) noexcept;
 extern "C" [[maybe_unused]] IMPEXP size_t ggapiGetOrdinalStringLen(uint32_t ord) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t ggapiCreateStruct(uint32_t anchorHandle) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t ggapiCreateList(uint32_t anchorHandle) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t ggapiCreateBuffer(uint32_t anchorHandle) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t
-    ggapiCreateBlob(uint32_t anchorHandle, const char *bytes, size_t len) noexcept;
-extern "C" [[maybe_unused]] IMPEXP bool
-    ggapiStructPutInt64(uint32_t structHandle, uint32_t ord, uint64_t value) noexcept;
-extern "C" [[maybe_unused]] IMPEXP bool
-    ggapiStructPutFloat64(uint32_t structHandle, uint32_t ord, double value) noexcept;
+ggapiCreateBlob(uint32_t anchorHandle, const char *bytes, size_t len) noexcept;
+extern "C" [[maybe_unused]] IMPEXP bool ggapiStructPutInt64(
+    uint32_t structHandle, uint32_t ord, uint64_t value
+) noexcept;
+extern "C" [[maybe_unused]] IMPEXP bool ggapiStructPutFloat64(
+    uint32_t structHandle, uint32_t ord, double value
+) noexcept;
 extern "C" [[maybe_unused]] IMPEXP bool ggapiStructPutString(
     uint32_t structHandle, uint32_t ord, const char *bytes, size_t len
 ) noexcept;
-extern "C" [[maybe_unused]] IMPEXP bool
-    ggapiStructPutHandle(uint32_t structHandle, uint32_t ord, uint32_t nestedHandle) noexcept;
-extern "C" [[maybe_unused]] IMPEXP bool
-    ggapiStructHasKey(uint32_t structHandle, uint32_t ord) noexcept;
+extern "C" [[maybe_unused]] IMPEXP bool ggapiStructPutHandle(
+    uint32_t structHandle, uint32_t ord, uint32_t nestedHandle
+) noexcept;
+extern "C" [[maybe_unused]] IMPEXP bool ggapiStructHasKey(
+    uint32_t structHandle, uint32_t ord
+) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint64_t
-    ggapiStructGetInt64(uint32_t structHandle, uint32_t ord) noexcept;
-extern "C" [[maybe_unused]] IMPEXP double
-    ggapiStructGetFloat64(uint32_t structHandle, uint32_t ord) noexcept;
+ggapiStructGetInt64(uint32_t structHandle, uint32_t ord) noexcept;
+extern "C" [[maybe_unused]] IMPEXP double ggapiStructGetFloat64(
+    uint32_t structHandle, uint32_t ord
+) noexcept;
 extern "C" [[maybe_unused]] IMPEXP size_t
-    ggapiStructGetStringLen(uint32_t structHandle, uint32_t ord) noexcept;
+ggapiStructGetStringLen(uint32_t structHandle, uint32_t ord) noexcept;
 extern "C" [[maybe_unused]] IMPEXP size_t
-    ggapiStructGetString(uint32_t structHandle, uint32_t ord, char *buffer, size_t buflen) noexcept;
+ggapiStructGetString(uint32_t structHandle, uint32_t ord, char *buffer, size_t buflen) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t
-    ggapiStructGetHandle(uint32_t structHandle, uint32_t ord) noexcept;
-extern "C" [[maybe_unused]] IMPEXP bool
-    ggapiListPutInt64(uint32_t listHandle, int32_t idx, uint64_t value) noexcept;
-extern "C" [[maybe_unused]] IMPEXP bool
-    ggapiListPutFloat64(uint32_t listHandle, int32_t idx, double value) noexcept;
-extern "C" [[maybe_unused]] IMPEXP bool
-    ggapiListPutString(uint32_t listHandle, int32_t idx, const char *bytes, size_t len) noexcept;
-extern "C" [[maybe_unused]] IMPEXP bool
-    ggapiListPutHandle(uint32_t listHandle, int32_t idx, uint32_t nestedHandle) noexcept;
-extern "C" [[maybe_unused]] IMPEXP bool
-    ggapiListInsertInt64(uint32_t listHandle, int32_t idx, uint64_t value) noexcept;
-extern "C" [[maybe_unused]] IMPEXP bool
-    ggapiListInsertFloat64(uint32_t listHandle, int32_t idx, double value) noexcept;
-extern "C" [[maybe_unused]] IMPEXP bool
-    ggapiListInsertString(uint32_t listHandle, int32_t idx, const char *bytes, size_t len) noexcept;
-extern "C" [[maybe_unused]] IMPEXP bool
-    ggapiListInsertHandle(uint32_t listHandle, int32_t idx, uint32_t nestedHandle) noexcept;
+ggapiStructGetHandle(uint32_t structHandle, uint32_t ord) noexcept;
+extern "C" [[maybe_unused]] IMPEXP bool ggapiListPutInt64(
+    uint32_t listHandle, int32_t idx, uint64_t value
+) noexcept;
+extern "C" [[maybe_unused]] IMPEXP bool ggapiListPutFloat64(
+    uint32_t listHandle, int32_t idx, double value
+) noexcept;
+extern "C" [[maybe_unused]] IMPEXP bool ggapiListPutString(
+    uint32_t listHandle, int32_t idx, const char *bytes, size_t len
+) noexcept;
+extern "C" [[maybe_unused]] IMPEXP bool ggapiListPutHandle(
+    uint32_t listHandle, int32_t idx, uint32_t nestedHandle
+) noexcept;
+extern "C" [[maybe_unused]] IMPEXP bool ggapiListInsertInt64(
+    uint32_t listHandle, int32_t idx, uint64_t value
+) noexcept;
+extern "C" [[maybe_unused]] IMPEXP bool ggapiListInsertFloat64(
+    uint32_t listHandle, int32_t idx, double value
+) noexcept;
+extern "C" [[maybe_unused]] IMPEXP bool ggapiListInsertString(
+    uint32_t listHandle, int32_t idx, const char *bytes, size_t len
+) noexcept;
+extern "C" [[maybe_unused]] IMPEXP bool ggapiListInsertHandle(
+    uint32_t listHandle, int32_t idx, uint32_t nestedHandle
+) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint64_t
-    ggapiListGetInt64(uint32_t structHandle, int32_t idx) noexcept;
-extern "C" [[maybe_unused]] IMPEXP double
-    ggapiListGetFloat64(uint32_t structHandle, int32_t idx) noexcept;
+ggapiListGetInt64(uint32_t structHandle, int32_t idx) noexcept;
+extern "C" [[maybe_unused]] IMPEXP double ggapiListGetFloat64(
+    uint32_t structHandle, int32_t idx
+) noexcept;
 extern "C" [[maybe_unused]] IMPEXP size_t
-    ggapiListGetStringLen(uint32_t listHandle, int32_t idx) noexcept;
+ggapiListGetStringLen(uint32_t listHandle, int32_t idx) noexcept;
 extern "C" [[maybe_unused]] IMPEXP size_t
-    ggapiListGetString(uint32_t structHandle, int32_t idx, char *buffer, size_t buflen) noexcept;
+ggapiListGetString(uint32_t structHandle, int32_t idx, char *buffer, size_t buflen) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t
-    ggapiListGetHandle(uint32_t listHandle, int32_t idx) noexcept;
+ggapiListGetHandle(uint32_t listHandle, int32_t idx) noexcept;
 extern "C" [[maybe_unused]] IMPEXP bool ggapiBufferPut(
     uint32_t listHandle, int32_t idx, const uint8_t *buffer, uint32_t buflen
 ) noexcept;
@@ -94,12 +109,13 @@ extern "C" [[maybe_unused]] IMPEXP bool ggapiBufferInsert(
     uint32_t listHandle, int32_t idx, const uint8_t *buffer, uint32_t buflen
 ) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t
-    ggapiBufferGet(uint32_t listHandle, int32_t idx, uint8_t *buffer, uint32_t buflen) noexcept;
-extern "C" [[maybe_unused]] IMPEXP bool
-    ggapiBufferResize(uint32_t structHandle, uint32_t newSize) noexcept;
+ggapiBufferGet(uint32_t listHandle, int32_t idx, uint8_t *buffer, uint32_t buflen) noexcept;
+extern "C" [[maybe_unused]] IMPEXP bool ggapiBufferResize(
+    uint32_t structHandle, uint32_t newSize
+) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t ggapiGetSize(uint32_t structHandle) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t
-    ggapiAnchorHandle(uint32_t anchorHandle, uint32_t objectHandle) noexcept;
+ggapiAnchorHandle(uint32_t anchorHandle, uint32_t objectHandle) noexcept;
 extern "C" [[maybe_unused]] IMPEXP bool ggapiReleaseHandle(uint32_t objectHandle) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t ggapiGetCurrentTask(void) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t ggapiSubscribeToTopic(
@@ -109,7 +125,7 @@ extern "C" [[maybe_unused]] IMPEXP uint32_t ggapiSubscribeToTopic(
     uintptr_t callbackContext
 ) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t
-    ggapiSendToTopic(uint32_t topicOrd, uint32_t callStruct, int32_t timeout) noexcept;
+ggapiSendToTopic(uint32_t topicOrd, uint32_t callStruct, int32_t timeout) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t ggapiSendToTopicAsync(
     uint32_t topicOrd,
     uint32_t callStruct,
@@ -119,7 +135,7 @@ extern "C" [[maybe_unused]] IMPEXP uint32_t ggapiSendToTopicAsync(
 ) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t ggapiCallNext(uint32_t dataStruct) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t
-    ggapiWaitForTaskCompleted(uint32_t asyncTask, int32_t timeout) noexcept;
+ggapiWaitForTaskCompleted(uint32_t asyncTask, int32_t timeout) noexcept;
 extern "C" [[maybe_unused]] IMPEXP uint32_t ggapiRegisterPlugin(
     uint32_t moduleHandle,
     uint32_t componentName,
@@ -128,5 +144,6 @@ extern "C" [[maybe_unused]] IMPEXP uint32_t ggapiRegisterPlugin(
 ) noexcept;
 
 // Used only by top-level executable
-extern "C" [[maybe_unused]] IMPEXP int
-    ggapiMainThread(int argc, char *argv[], char *envp[]) noexcept;
+extern "C" [[maybe_unused]] IMPEXP int ggapiMainThread(
+    int argc, char *argv[], char *envp[]
+) noexcept;

--- a/include/cpp_api.h
+++ b/include/cpp_api.h
@@ -46,8 +46,9 @@ namespace ggapi {
     void callApi(const std::function<void()> &fn);
 
     // Helper functions for consistent string copy pattern
-    inline std::string
-        stringFillHelper(size_t strLen, const std::function<size_t(char *, size_t)> &stringFillFn) {
+    inline std::string stringFillHelper(
+        size_t strLen, const std::function<size_t(char *, size_t)> &stringFillFn
+    ) {
         if(strLen == 0) {
             return {};
         }
@@ -190,8 +191,9 @@ namespace ggapi {
         [[nodiscard]] Scope sendToTopicAsync(
             StringOrd topic, Struct message, topicCallback_t result, int32_t timeout = -1
         );
-        [[nodiscard]] static Struct
-            sendToTopic(StringOrd topic, Struct message, int32_t timeout = -1);
+        [[nodiscard]] static Struct sendToTopic(
+            StringOrd topic, Struct message, int32_t timeout = -1
+        );
         [[nodiscard]] Struct waitForTaskCompleted(int32_t timeout = -1);
         [[nodiscard]] Scope registerPlugin(StringOrd componentName, lifecycleCallback_t callback);
         [[nodiscard]] static Scope thisTask();

--- a/src/layered-plugin/layered_plugin.cpp
+++ b/src/layered-plugin/layered_plugin.cpp
@@ -7,8 +7,9 @@ const ggapi::StringOrd DISCOVER_PHASE{"discover"};
 
 void doDiscoverPhase(ggapi::Scope moduleHandle, ggapi::Struct phaseData);
 
-extern "C" [[maybe_unused]] EXPORT bool
-    greengrass_lifecycle(uint32_t moduleHandle, uint32_t phase, uint32_t data) noexcept {
+extern "C" [[maybe_unused]] EXPORT bool greengrass_lifecycle(
+    uint32_t moduleHandle, uint32_t phase, uint32_t data
+) noexcept {
     std::cout << "Running layered lifecycle plugins... " << ggapi::StringOrd{phase}.toString()
               << std::endl;
     ggapi::StringOrd phaseOrd{phase};

--- a/src/mqtt-plugin/mqtt-plugin.cpp
+++ b/src/mqtt-plugin/mqtt-plugin.cpp
@@ -68,8 +68,9 @@ ggapi::Struct publishHandler(ggapi::Scope task, ggapi::StringOrd, ggapi::Struct 
     return task.createStruct();
 }
 
-extern "C" bool
-    greengrass_lifecycle(uint32_t moduleHandle, uint32_t phase, uint32_t data) noexcept {
+extern "C" bool greengrass_lifecycle(
+    uint32_t moduleHandle, uint32_t phase, uint32_t data
+) noexcept {
     ggapi::StringOrd phaseOrd{phase};
 
     std::cout << "[mqtt-plugin] Running lifecycle phase " << phaseOrd.toString() << std::endl;

--- a/src/nucleus-core/config/config_manager.cpp
+++ b/src/nucleus-core/config/config_manager.cpp
@@ -114,8 +114,9 @@ namespace config {
         watcher->initialized(ref<Topics>(), subKey, reasons);
     }
 
-    Topic &
-        Topic::addWatcher(const std::shared_ptr<Watcher> &watcher, config::WhatHappened reasons) {
+    Topic &Topic::addWatcher(
+        const std::shared_ptr<Watcher> &watcher, config::WhatHappened reasons
+    ) {
         _parent->addWatcher(_value.getNameOrd(), watcher, reasons);
         return *this;
     }
@@ -125,13 +126,15 @@ namespace config {
         return !_watching.empty();
     }
 
-    std::optional<std::vector<std::shared_ptr<Watcher>>>
-        Topics::filterWatchers(config::WhatHappened reasons) const {
+    std::optional<std::vector<std::shared_ptr<Watcher>>> Topics::filterWatchers(
+        config::WhatHappened reasons
+    ) const {
         return filterWatchers({}, reasons);
     }
 
-    std::optional<std::vector<std::shared_ptr<Watcher>>>
-        Topics::filterWatchers(data::StringOrd key, config::WhatHappened reasons) const {
+    std::optional<std::vector<std::shared_ptr<Watcher>>> Topics::filterWatchers(
+        data::StringOrd key, config::WhatHappened reasons
+    ) const {
         if(!hasWatchers()) {
             return {};
         }
@@ -222,8 +225,9 @@ namespace config {
         }
     }
 
-    std::shared_ptr<Topics>
-        Topics::createInteriorChild(data::StringOrd nameOrd, const Timestamp &timestamp) {
+    std::shared_ptr<Topics> Topics::createInteriorChild(
+        data::StringOrd nameOrd, const Timestamp &timestamp
+    ) {
         Element leaf = createChild(nameOrd, [this, &timestamp, nameOrd](auto ord) {
             std::shared_ptr<Topics> parent{ref<Topics>()};
             std::shared_ptr<Topics> nested{std::make_shared<Topics>(_environment, parent, nameOrd)};
@@ -232,8 +236,9 @@ namespace config {
         return leaf.getTopicsRef();
     }
 
-    std::shared_ptr<Topics>
-        Topics::createInteriorChild(std::string_view sv, const Timestamp &timestamp) {
+    std::shared_ptr<Topics> Topics::createInteriorChild(
+        std::string_view sv, const Timestamp &timestamp
+    ) {
         data::StringOrd handle = _environment.stringTable.getOrCreateOrd(std::string(sv));
         return createInteriorChild(handle, timestamp);
     }

--- a/src/nucleus-core/config/config_manager.h
+++ b/src/nucleus-core/config/config_manager.h
@@ -256,8 +256,9 @@ namespace config {
 
         bool hasWatchers() const;
 
-        std::optional<std::vector<std::shared_ptr<Watcher>>>
-            filterWatchers(data::StringOrd subKey, WhatHappened reasons) const;
+        std::optional<std::vector<std::shared_ptr<Watcher>>> filterWatchers(
+            data::StringOrd subKey, WhatHappened reasons
+        ) const;
 
         std::optional<std::vector<std::shared_ptr<Watcher>>> filterWatchers(WhatHappened reasons
         ) const;

--- a/src/nucleus-core/data/string_table.h
+++ b/src/nucleus-core/data/string_table.h
@@ -19,15 +19,15 @@ namespace data {
 
     public:
         struct CompEq {
-            [[nodiscard]] bool
-                operator()(const InternedString &a, const InternedString &b) const noexcept {
+            [[nodiscard]] bool operator()(const InternedString &a, const InternedString &b)
+                const noexcept {
                 return a._value == b._value;
             }
         };
 
         struct CompLess {
-            [[nodiscard]] bool
-                operator()(const InternedString &a, const InternedString &b) const noexcept {
+            [[nodiscard]] bool operator()(const InternedString &a, const InternedString &b)
+                const noexcept {
                 return a._value < b._value;
             }
         };

--- a/src/nucleus-core/data/tracked_object.cpp
+++ b/src/nucleus-core/data/tracked_object.cpp
@@ -42,8 +42,9 @@ namespace data {
         _roots.erase(anchor.getHandle());
     }
 
-    std::vector<ObjectAnchor>
-        TrackingScope::getRootsHelper(const std::weak_ptr<TrackingScope> &assumedOwner) {
+    std::vector<ObjectAnchor> TrackingScope::getRootsHelper(
+        const std::weak_ptr<TrackingScope> &assumedOwner
+    ) {
         std::shared_lock guard{_mutex};
         std::vector<ObjectAnchor> copy;
         for(const auto &i : _roots) {

--- a/src/nucleus-core/lifecycle/kernel_command_line.h
+++ b/src/nucleus-core/lifecycle/kernel_command_line.h
@@ -34,10 +34,12 @@ namespace lifecycle {
         );
         std::filesystem::path deTilde(std::string_view s) const; // assumes lock
                                                                  // held
-        static std::filesystem::path
-            resolve(const std::filesystem::path &first, const std::filesystem::path &second);
-        static std::filesystem::path
-            resolve(const std::filesystem::path &first, std::string_view second);
+        static std::filesystem::path resolve(
+            const std::filesystem::path &first, const std::filesystem::path &second
+        );
+        static std::filesystem::path resolve(
+            const std::filesystem::path &first, std::string_view second
+        );
 
     public:
         explicit KernelCommandLine(data::Global &global) : _global{global} {

--- a/src/nucleus-core/pubsub/local_topics.h
+++ b/src/nucleus-core/pubsub/local_topics.h
@@ -78,8 +78,9 @@ namespace pubsub {
             const std::shared_ptr<data::StructModelBase> &result
         ) override;
 
-        static std::unique_ptr<tasks::SubTask>
-            of(data::StringOrd topicOrd, std::unique_ptr<AbstractCallback> callback);
+        static std::unique_ptr<tasks::SubTask> of(
+            data::StringOrd topicOrd, std::unique_ptr<AbstractCallback> callback
+        );
     };
 
     //

--- a/src/nucleus-core/tasks/task.cpp
+++ b/src/nucleus-core/tasks/task.cpp
@@ -167,8 +167,9 @@ namespace tasks {
         }
     }
 
-    void
-        TaskThread::taskStealing(const std::shared_ptr<Task> &blockingTask, const ExpireTime &end) {
+    void TaskThread::taskStealing(
+        const std::shared_ptr<Task> &blockingTask, const ExpireTime &end
+    ) {
         // this loop is entered when we have an associated task
         while(!blockingTask->isCompleted()) {
             std::shared_ptr<Task> task = pickupTask(blockingTask);

--- a/src/nucleus-core/tasks/task.h
+++ b/src/nucleus-core/tasks/task.h
@@ -226,8 +226,9 @@ namespace tasks {
 
         data::ObjectAnchor createTask();
         std::shared_ptr<Task> acquireTaskForWorker(TaskThread *worker);
-        std::shared_ptr<Task>
-            acquireTaskWhenStealing(TaskThread *worker, const std::shared_ptr<Task> &priorityTask);
+        std::shared_ptr<Task> acquireTaskWhenStealing(
+            TaskThread *worker, const std::shared_ptr<Task> &priorityTask
+        );
         bool allocateNextWorker();
         void queueTask(const std::shared_ptr<Task> &task);
     };

--- a/src/sample-mqtt-user/sample-mqtt-user.cpp
+++ b/src/sample-mqtt-user/sample-mqtt-user.cpp
@@ -16,8 +16,9 @@ static const Keys keys;
 
 void threadFn();
 
-extern "C" bool
-    greengrass_lifecycle(uint32_t moduleHandle, uint32_t phase, uint32_t data) noexcept {
+extern "C" bool greengrass_lifecycle(
+    uint32_t moduleHandle, uint32_t phase, uint32_t data
+) noexcept {
     ggapi::StringOrd phaseOrd{phase};
     std::cout << "[sample-mqtt-user] Running lifecycle phase " << phaseOrd.toString() << std::endl;
     if(phaseOrd == keys.run) {

--- a/src/simple-plugin1/simple_plugin1.cpp
+++ b/src/simple-plugin1/simple_plugin1.cpp
@@ -41,8 +41,9 @@ void doStartPhase() {
 void doRunPhase() {
 }
 
-extern "C" bool
-    greengrass_lifecycle(uint32_t moduleHandle, uint32_t phase, uint32_t data) noexcept {
+extern "C" bool greengrass_lifecycle(
+    uint32_t moduleHandle, uint32_t phase, uint32_t data
+) noexcept {
     std::cout << "Running lifecycle plugins 1... " << ggapi::StringOrd{phase}.toString()
               << std::endl;
     const auto &keys = Keys::get();

--- a/src/simple-plugin2/simple_plugin2.cpp
+++ b/src/simple-plugin2/simple_plugin2.cpp
@@ -25,8 +25,9 @@ std::thread asyncThread;
 
 void asyncThreadFn();
 
-extern "C" [[maybe_unused]] EXPORT bool
-    greengrass_lifecycle(uint32_t moduleHandle, uint32_t phase, uint32_t data) noexcept {
+extern "C" [[maybe_unused]] EXPORT bool greengrass_lifecycle(
+    uint32_t moduleHandle, uint32_t phase, uint32_t data
+) noexcept {
     std::cout << "Running lifecycle plugins 2... " << ggapi::StringOrd{phase}.toString()
               << std::endl;
     ggapi::StringOrd phaseOrd{phase};
@@ -37,8 +38,9 @@ extern "C" [[maybe_unused]] EXPORT bool
     return true;
 }
 
-ggapi::Struct
-    publishToIoTCoreListener(ggapi::Scope task, ggapi::StringOrd topic, ggapi::Struct callData) {
+ggapi::Struct publishToIoTCoreListener(
+    ggapi::Scope task, ggapi::StringOrd topic, ggapi::Struct callData
+) {
     // real work
     std::string destTopic{callData.get<std::string>(keys.topicName)};
     int qos{callData.get<int>(keys.qos)};
@@ -51,8 +53,9 @@ ggapi::Struct
     return response;
 }
 
-ggapi::Struct
-    publishToIoTCoreResponder(ggapi::Scope task, ggapi::StringOrd topic, ggapi::Struct respData) {
+ggapi::Struct publishToIoTCoreResponder(
+    ggapi::Scope task, ggapi::StringOrd topic, ggapi::Struct respData
+) {
     if(!respData) {
         // unhandled
         return respData;


### PR DESCRIPTION
Indenting the wrapped function name was confusing to read with same-line block braces. Also adjusts the break-after-type penalty so that the code will usually break the parameters onto next line instead.