### PR TITLE
Fix CMake to include nucleus-core for its targets

### DIFF
--- a/src/nucleus-core/CMakeLists.txt
+++ b/src/nucleus-core/CMakeLists.txt
@@ -36,34 +36,33 @@ add_library(nucleus-core SHARED
         api/plugins.cpp
         api/pubsub.cpp
         api/tasks.cpp
-        config/config_manager.cpp config/config_manager.h
-        config/json_helper.cpp config/json_helper.h
-        config/transaction_log.cpp config/transaction_log.h
-        config/watcher.h
-        config/yaml_helper.cpp config/yaml_helper.h
-        data/environment.cpp data/environment.h
-        data/handle_table.cpp data/handle_table.h
-        data/safe_handle.cpp data/safe_handle.h
-        data/shared_buffer.cpp data/shared_buffer.h
-        data/shared_list.cpp data/shared_list.h
-        data/shared_struct.cpp data/shared_struct.h
-        data/string_table.cpp data/string_table.h
-        data/struct_model.cpp data/struct_model.h
-        data/tracked_object.cpp data/tracked_object.h
-        deployment/deployment_model.cpp deployment/deployment_model.h
-        lifecycle/command_line.cpp lifecycle/command_line.h
-        lifecycle/kernel.cpp lifecycle/kernel.h
-        plugins/plugin_loader.cpp plugins/plugin_loader.h
-        pubsub/local_topics.cpp pubsub/local_topics.h
-        tasks/expire_time.h
-        tasks/sub_task.h
-        tasks/task.cpp tasks/task.h
-        util/commitable_file.cpp util/commitable_file.h
-        util/nucleus_paths.cpp util/nucleus_paths.h
-        util/permissions.cpp util/permissions.h
+        config/config_manager.cpp
+        config/json_helper.cpp
+        config/transaction_log.cpp
+        config/yaml_helper.cpp
+        data/environment.cpp
+        data/handle_table.cpp
+        data/safe_handle.cpp
+        data/shared_buffer.cpp
+        data/shared_list.cpp
+        data/shared_struct.cpp
+        data/string_table.cpp
+        data/struct_model.cpp
+        data/tracked_object.cpp
+        deployment/deployment_model.cpp
+        lifecycle/command_line.cpp
+        lifecycle/kernel.cpp
+        plugins/plugin_loader.cpp
+        pubsub/local_topics.cpp
+        tasks/task.cpp
+        util/commitable_file.cpp
+        util/nucleus_paths.cpp
+        util/permissions.cpp
         )
 target_link_libraries(nucleus-core Threads::Threads ${CMAKE_DL_LIBS} yaml-cpp)
-target_include_directories(nucleus-core PRIVATE . ${rapidjson_SOURCE_DIR}/include)
+target_include_directories(nucleus-core
+        PRIVATE ${rapidjson_SOURCE_DIR}/include
+        PUBLIC .)
 
 add_custom_command(TARGET nucleus-core
         POST_BUILD


### PR DESCRIPTION
**Issue**
Plugins cannot find nucleus-core header files

**Description of changes**
Include nucleus-core header files publicly