### PR TITLE
Introduce ability to terminate Nucleus + fixes

### DIFF
--- a/nucleus/CMakeLists.txt
+++ b/nucleus/CMakeLists.txt
@@ -73,7 +73,8 @@ add_library(nucleus-obj OBJECT
         src/tasks/task.cpp src/tasks/task.hpp
         src/util/commitable_file.cpp src/util/commitable_file.hpp
         src/util/nucleus_paths.cpp src/util/nucleus_paths.hpp
-        src/util/permissions.cpp src/util/permissions.hpp)
+        src/util/permissions.cpp src/util/permissions.hpp
+        )
 target_link_libraries(nucleus-obj
         PUBLIC gg_plugin_api
         PRIVATE Threads::Threads ${CMAKE_DL_LIBS} yaml-cpp)
@@ -107,15 +108,21 @@ target_link_libraries(greengrass-lite nucleus-core)
 # Build unit tests
 #
 add_executable(nucleus-tests
+        tests/test_tools.hpp
+        tests/test_ggroot.hpp
+
         tests/api/buffer_tests.cpp
         tests/api/list_tests.cpp
         tests/api/pubsub_tests.cpp
         tests/api/struct_tests.cpp
         tests/data/string_ord_tests.cpp
+        tests/lifecycle/kernel_tests.cpp
         tests/pubsub/pubsub_tests.cpp
+        tests/tasks/task_tests.cpp
         )
 target_link_libraries(nucleus-tests PRIVATE nucleus-lib Catch2::Catch2WithMain)
-target_include_directories(nucleus-tests PRIVATE src)
+target_include_directories(nucleus-tests
+        PRIVATE src tests ${rapidjson_SOURCE_DIR}/include)
 include(CTest)
 include(Catch)
 catch_discover_tests(nucleus-tests)

--- a/nucleus/src/api/main.cpp
+++ b/nucleus/src/api/main.cpp
@@ -20,8 +20,7 @@ int ggapiMainThread(int argc, char *argv[], char *envp[]) noexcept {
             kernel.preLaunch(commandLine);
         }
         // Never returns unless signalled
-        kernel.launch();
-        return 0; // never reached
+        return kernel.launch();
     } catch(...) {
         // TODO: log errors
         std::terminate(); // terminate on exception

--- a/nucleus/src/api/pubsub.cpp
+++ b/nucleus/src/api/pubsub.cpp
@@ -1,4 +1,5 @@
 #include "data/globals.hpp"
+#include "tasks/expire_time.hpp"
 #include <cpp_api.hpp>
 
 class NativeCallback : public pubsub::AbstractCallback {
@@ -71,7 +72,7 @@ static inline data::ObjHandle pubSubTaskCommon(
     // Fill out task
     std::shared_ptr<data::StructModelBase> callDataStruct{
         global.environment.handleTable.getObject<data::StructModelBase>(callStructHandle)};
-    ExpireTime expireTime = global.environment.translateExpires(timeout);
+    tasks::ExpireTime expireTime = global.environment.translateExpires(timeout);
     newTaskObj->setTimeout(expireTime);
     if(listenerHandle) {
         std::shared_ptr<pubsub::Listener> explicitReceiver =

--- a/nucleus/src/api/tasks.cpp
+++ b/nucleus/src/api/tasks.cpp
@@ -1,4 +1,5 @@
 #include "data/globals.hpp"
+#include "tasks/expire_time.hpp"
 #include <cpp_api.hpp>
 
 uint32_t ggapiClaimThread() noexcept {
@@ -25,6 +26,10 @@ uint32_t ggapiGetCurrentTask() noexcept {
     return ggapi::trapErrorReturn<uint32_t>([]() { return tasks::Task::getThreadSelf().asInt(); });
 }
 
+//
+// Cause the current thread to block waiting on the provided task, either until it has
+// completed, or cancelled (including time-out).
+//
 uint32_t ggapiWaitForTaskCompleted(uint32_t asyncTask, int32_t timeout) noexcept {
     return ggapi::trapErrorReturn<uint32_t>([asyncTask, timeout]() {
         data::Global &global = data::Global::self();
@@ -33,11 +38,26 @@ uint32_t ggapiWaitForTaskCompleted(uint32_t asyncTask, int32_t timeout) noexcept
             global.environment.handleTable.getObject<tasks::Task>(parentTask)};
         std::shared_ptr<tasks::Task> asyncTaskObj{
             global.environment.handleTable.getObject<tasks::Task>(data::ObjHandle{asyncTask})};
-        ExpireTime expireTime = global.environment.translateExpires(timeout);
+        tasks::ExpireTime expireTime = global.environment.translateExpires(timeout);
         if(asyncTaskObj->waitForCompletion(expireTime)) {
             return parentTaskObj->anchor(asyncTaskObj->getData()).getHandle().asInt();
         } else {
             return static_cast<uint32_t>(0);
         }
+    });
+}
+
+//
+// Cause specified task to exit immediately if/when idle. If specified task is executing a sub-task
+// the sub-task will be completed first. Consider this function to cancel any and all
+// 'ggapiWaitForTaskCompleted' operations on the given task.
+//
+bool ggapiCancelTask(uint32_t asyncTask) noexcept {
+    return ggapi::trapErrorReturn<bool>([asyncTask]() {
+        data::Global &global = data::Global::self();
+        std::shared_ptr<tasks::Task> asyncTaskObj{
+            global.environment.handleTable.getObject<tasks::Task>(data::ObjHandle{asyncTask})};
+        asyncTaskObj->cancelTask();
+        return true;
     });
 }

--- a/nucleus/src/config/config_manager.cpp
+++ b/nucleus/src/config/config_manager.cpp
@@ -188,16 +188,11 @@ namespace config {
         return newCopy;
     }
 
-    void Topics::put(const data::StringOrd handle, const data::StructElement &element) {
+    void Topics::putImpl(const data::StringOrd handle, const data::StructElement &element) {
         updateChild(TopicElement{handle, Timestamp::never(), element});
     }
 
-    void Topics::put(const std::string_view sv, const data::StructElement &element) {
-        data::StringOrd handle = _environment.stringTable.getOrCreateOrd(std::string(sv));
-        put(handle, element);
-    }
-
-    bool Topics::hasKey(const data::StringOrd handle) const {
+    bool Topics::hasKeyImpl(const data::StringOrd handle) const {
         //_environment.stringTable.assertStringHandle(handle);
         data::StringOrd key = TopicElement::getKey(_environment, handle);
         std::shared_lock guard{_mutex};
@@ -318,7 +313,7 @@ namespace config {
         return getTopic(handle);
     }
 
-    data::StructElement Topics::get(data::StringOrd handle) const {
+    data::StructElement Topics::getImpl(data::StringOrd handle) const {
         // needed for base class
         data::StringOrd key = TopicElement::getKey(_environment, handle);
         std::shared_lock guard{_mutex};
@@ -328,11 +323,6 @@ namespace config {
         } else {
             return {};
         }
-    }
-
-    data::StructElement Topics::get(const std::string_view sv) const {
-        data::StringOrd handle = _environment.stringTable.getOrCreateOrd(std::string(sv));
-        return get(handle);
     }
 
     std::shared_ptr<ConfigNode> Topics::getNode(data::StringOrd handle) {

--- a/nucleus/src/config/config_manager.hpp
+++ b/nucleus/src/config/config_manager.hpp
@@ -258,11 +258,9 @@ namespace config {
         // Overrides for StructModelBase
         // Don't use directly, but behave correctly when used via API
 
-        void put(data::StringOrd handle, const data::StructElement &element) override;
-        void put(std::string_view sv, const data::StructElement &element) override;
-        data::StructElement get(data::StringOrd handle) const override;
-        data::StructElement get(std::string_view name) const override;
-        bool hasKey(data::StringOrd handle) const override;
+        void putImpl(data::StringOrd handle, const data::StructElement &element) override;
+        data::StructElement getImpl(data::StringOrd handle) const override;
+        bool hasKeyImpl(data::StringOrd handle) const override;
         [[nodiscard]] std::vector<data::StringOrd> getKeys() const override;
         uint32_t size() const override;
         std::shared_ptr<data::StructModelBase> copy() const override;

--- a/nucleus/src/data/environment.cpp
+++ b/nucleus/src/data/environment.cpp
@@ -1,8 +1,9 @@
 #include "environment.hpp"
+#include "tasks/expire_time.hpp"
 
-ExpireTime data::Environment::translateExpires(int32_t delta) {
+tasks::ExpireTime data::Environment::translateExpires(int32_t delta) {
     // override this to enable time-based testing
-    return ExpireTime::fromNow(delta);
+    return tasks::ExpireTime::fromNowMillis(delta);
 }
 
 namespace data {

--- a/nucleus/src/data/environment.hpp
+++ b/nucleus/src/data/environment.hpp
@@ -37,6 +37,6 @@ namespace data {
         std::mutex cycleCheckMutex;
         virtual ~Environment() = default;
 
-        virtual ExpireTime translateExpires(int32_t delta);
+        virtual tasks::ExpireTime translateExpires(int32_t delta);
     };
 } // namespace data

--- a/nucleus/src/data/shared_struct.cpp
+++ b/nucleus/src/data/shared_struct.cpp
@@ -33,19 +33,14 @@ namespace data {
         return newCopy;
     }
 
-    void SharedStruct::put(const StringOrd handle, const StructElement &element) {
+    void SharedStruct::putImpl(const StringOrd handle, const StructElement &element) {
         checkedPut(element, [this, handle](auto &el) {
             std::unique_lock guard{_mutex};
             _elements.emplace(handle, el);
         });
     }
 
-    void SharedStruct::put(const std::string_view sv, const StructElement &element) {
-        Handle handle = _environment.stringTable.getOrCreateOrd(std::string(sv));
-        put(handle, element);
-    }
-
-    bool SharedStruct::hasKey(const StringOrd handle) const {
+    bool SharedStruct::hasKeyImpl(const StringOrd handle) const {
         //_environment.stringTable.assertStringHandle(handle);
         std::shared_lock guard{_mutex};
         auto i = _elements.find(handle);
@@ -68,12 +63,7 @@ namespace data {
         return _elements.size();
     }
 
-    StructElement SharedStruct::get(const std::string_view sv) const {
-        Handle handle = _environment.stringTable.getOrCreateOrd(std::string(sv));
-        return get(handle);
-    }
-
-    StructElement SharedStruct::get(StringOrd handle) const {
+    StructElement SharedStruct::getImpl(StringOrd handle) const {
         //_environment.stringTable.assertStringHandle(handle);
         std::shared_lock guard{_mutex};
         auto i = _elements.find(handle);

--- a/nucleus/src/data/shared_struct.hpp
+++ b/nucleus/src/data/shared_struct.hpp
@@ -18,14 +18,10 @@ namespace data {
         }
 
         uint32_t size() const override;
-        void put(StringOrd handle, const StructElement &element) override;
-        void put(std::string_view sv, const StructElement &element) override;
-        bool hasKey(StringOrd handle) const override;
-
+        void putImpl(StringOrd handle, const StructElement &element) override;
+        bool hasKeyImpl(StringOrd handle) const override;
         std::vector<data::StringOrd> getKeys() const override;
-
-        StructElement get(StringOrd handle) const override;
-        StructElement get(std::string_view sv) const override;
+        StructElement getImpl(StringOrd handle) const override;
         std::shared_ptr<StructModelBase> copy() const override;
     };
 

--- a/nucleus/src/data/struct_model.cpp
+++ b/nucleus/src/data/struct_model.cpp
@@ -26,4 +26,32 @@ namespace data {
         // cycleGuard may still be locked - intentional
         putAction(element);
     }
+
+    void StructModelBase::put(std::string_view sv, const StructElement &element) {
+        Handle handle = _environment.stringTable.getOrCreateOrd(std::string(sv));
+        putImpl(handle, element);
+    }
+
+    void StructModelBase::put(data::StringOrd handle, const data::StructElement &element) {
+        putImpl(handle, element);
+    }
+
+    bool StructModelBase::hasKey(const std::string_view sv) const {
+        Handle handle = _environment.stringTable.getOrCreateOrd(std::string(sv));
+        return hasKeyImpl(handle);
+    }
+
+    bool StructModelBase::hasKey(data::StringOrd handle) const {
+        return hasKeyImpl(handle);
+    }
+
+    StructElement StructModelBase::get(const std::string_view sv) const {
+        Handle handle = _environment.stringTable.getOrCreateOrd(std::string(sv));
+        return getImpl(handle);
+    }
+
+    StructElement StructModelBase::get(data::StringOrd handle) const {
+        return getImpl(handle);
+    }
+
 } // namespace data

--- a/nucleus/src/lifecycle/kernel.hpp
+++ b/nucleus/src/lifecycle/kernel.hpp
@@ -4,6 +4,7 @@
 #include "data/globals.hpp"
 #include "deployment/deployment_model.hpp"
 #include "deployment/device_configuration.hpp"
+#include "tasks/expire_time.hpp"
 #include "util/nucleus_paths.hpp"
 #include <filesystem>
 #include <optional>
@@ -39,9 +40,11 @@ namespace lifecycle {
         data::Global &_global;
         std::shared_ptr<util::NucleusPaths> _nucleusPaths;
         std::shared_ptr<RootPathWatcher> _rootPathWatcher;
+        tasks::FixedTaskThreadScope _mainThread;
         std::unique_ptr<config::TlogWriter> _tlog;
         deployment::DeploymentStage _deploymentStageAtLaunch{deployment::DeploymentStage::DEFAULT};
         std::unique_ptr<deployment::DeviceConfiguration> _deviceConfiguration{nullptr};
+        std::atomic_int _exitCode{0};
 
     public:
         explicit Kernel(data::Global &global);
@@ -55,10 +58,12 @@ namespace lifecycle {
         static constexpr auto DEFAULT_BOOTSTRAP_CONFIG_TLOG_FILE{"bootstrap.tlog"};
         static constexpr auto SERVICE_DIGEST_TOPIC_KEY{"service-digest"};
         static constexpr auto DEPLOYMENT_STAGE_LOG_KEY{"stage"};
+        static constexpr auto SHUTDOWN_TIMEOUT_SECONDS{30};
+        static constexpr auto SERVICE_SHUTDOWN_TIMEOUT_SECONDS{5};
         const data::StringOrdInit SERVICES_TOPIC_KEY{"services"};
 
         void preLaunch(CommandLine &commandLine);
-        void launch();
+        int launch();
         static void overrideConfigLocation(
             CommandLine &commandLine, const std::filesystem::path &configFile
         );
@@ -76,6 +81,17 @@ namespace lifecycle {
         void writeEffectiveConfigAsTransactionLog(const std::filesystem::path &tlogFile);
         void writeEffectiveConfig();
         void writeEffectiveConfig(const std::filesystem::path &configFile);
+        std::shared_ptr<config::Topics> findServiceTopic(const std::string_view &serviceName);
+
+        void stopAllServices(std::chrono::seconds timeoutSeconds);
+        void shutdown(std::chrono::seconds timeoutSeconds, int exitCode);
+        void shutdown(
+            std::chrono::seconds timeoutSeconds = std::chrono::seconds(SHUTDOWN_TIMEOUT_SECONDS)
+        );
+
+        void softShutdown(
+            std::chrono::seconds expireTime = std::chrono::seconds(SHUTDOWN_TIMEOUT_SECONDS)
+        );
 
         std::shared_ptr<util::NucleusPaths> getPaths() {
             return _nucleusPaths;
@@ -85,6 +101,8 @@ namespace lifecycle {
             return _global.environment.configManager;
         }
 
-        std::shared_ptr<config::Topics> findServiceTopic(const std::string_view &serviceName);
+        void setExitCode(int exitCode) {
+            _exitCode.store(exitCode);
+        }
     };
 } // namespace lifecycle

--- a/nucleus/src/tasks/expire_time.hpp
+++ b/nucleus/src/tasks/expire_time.hpp
@@ -3,79 +3,96 @@
 #include <chrono>
 #include <ctime>
 
-//
-// this class is used for timeouts, which depends on steady_clock rather than
-// epoch assumes conversion with milliseconds
-//
-class ExpireTime {
-private:
-    std::chrono::time_point<std::chrono::steady_clock> _steadyTime;
+namespace tasks { //
 
-public:
-    ExpireTime(const ExpireTime &) = default;
-    ExpireTime(ExpireTime &&) = default;
-    ~ExpireTime() = default;
-    ExpireTime &operator=(const ExpireTime &) = default;
-    ExpireTime &operator=(ExpireTime &&) = default;
+    // this class is used for timeouts, which depends on steady_clock rather than
+    // epoch assumes conversion with milliseconds
+    //
+    class ExpireTime {
+    private:
+        std::chrono::time_point<std::chrono::steady_clock> _steadyTime;
 
-    explicit ExpireTime(std::chrono::time_point<std::chrono::steady_clock> time)
-        : _steadyTime{time} {
-    }
+    public:
+        ExpireTime(const ExpireTime &) = default;
+        ExpireTime(ExpireTime &&) = default;
+        ~ExpireTime() = default;
+        ExpireTime &operator=(const ExpireTime &) = default;
+        ExpireTime &operator=(ExpireTime &&) = default;
 
-    explicit operator std::chrono::time_point<std::chrono::steady_clock>() const {
-        return _steadyTime;
-    }
+        explicit ExpireTime(std::chrono::time_point<std::chrono::steady_clock> time)
+            : _steadyTime{time} {
+        }
 
-    [[nodiscard]] static ExpireTime infinite() {
-        return ExpireTime(std::chrono::time_point<std::chrono::steady_clock>::max());
-    }
+        explicit operator std::chrono::time_point<std::chrono::steady_clock>() const {
+            return _steadyTime;
+        }
 
-    [[nodiscard]] static ExpireTime fromNow(int32_t smallDelta) {
-        if(smallDelta < 0) {
-            // negative means max time
+        [[nodiscard]] static ExpireTime infinite() {
             return ExpireTime(std::chrono::time_point<std::chrono::steady_clock>::max());
         }
-        return fromNow(std::chrono::milliseconds(smallDelta));
-    }
 
-    [[nodiscard]] static ExpireTime fromNow(std::chrono::milliseconds delta) {
-        if(delta == std::chrono::milliseconds::max()) {
-            return infinite();
+        [[nodiscard]] static ExpireTime fromNowMillis(int32_t smallDelta) {
+            if(smallDelta < 0) {
+                // negative means max time
+                return ExpireTime(std::chrono::time_point<std::chrono::steady_clock>::max());
+            }
+            return fromNow(std::chrono::milliseconds(smallDelta));
         }
-        return ExpireTime(std::chrono::steady_clock::now() + delta);
-    }
 
-    [[nodiscard]] static ExpireTime now() {
-        return ExpireTime(std::chrono::steady_clock::now());
-    }
+        [[nodiscard]] static ExpireTime fromNowSecs(int32_t delta) {
+            if(delta < 0) {
+                // negative means max time
+                return ExpireTime(std::chrono::time_point<std::chrono::steady_clock>::max());
+            }
+            return fromNow(std::chrono::seconds(delta));
+        }
 
-    [[nodiscard]] std::chrono::milliseconds remaining() const {
-        return std::chrono::duration_cast<std::chrono::milliseconds>(
-            _steadyTime - std::chrono::steady_clock::now()
-        );
-    }
+        [[nodiscard]] static ExpireTime fromNow(std::chrono::milliseconds delta) {
+            if(delta == std::chrono::milliseconds::max()) {
+                return infinite();
+            }
+            return ExpireTime(std::chrono::steady_clock::now() + delta);
+        }
 
-    [[nodiscard]] bool operator<(const ExpireTime &other) const {
-        return _steadyTime < other._steadyTime;
-    }
+        [[nodiscard]] static ExpireTime fromNow(std::chrono::seconds delta) {
+            if(delta == std::chrono::seconds::max()) {
+                return infinite();
+            }
+            return ExpireTime(std::chrono::steady_clock::now() + delta);
+        }
 
-    [[nodiscard]] bool operator<=(const ExpireTime &other) const {
-        return _steadyTime <= other._steadyTime;
-    }
+        [[nodiscard]] static ExpireTime now() {
+            return ExpireTime(std::chrono::steady_clock::now());
+        }
 
-    [[nodiscard]] bool operator>(const ExpireTime &other) const {
-        return _steadyTime > other._steadyTime;
-    }
+        [[nodiscard]] std::chrono::milliseconds remaining() const {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(
+                _steadyTime - std::chrono::steady_clock::now()
+            );
+        }
 
-    [[nodiscard]] bool operator>=(const ExpireTime &other) const {
-        return _steadyTime >= other._steadyTime;
-    }
+        [[nodiscard]] bool operator<(const ExpireTime &other) const {
+            return _steadyTime < other._steadyTime;
+        }
 
-    [[nodiscard]] bool operator==(const ExpireTime &other) const {
-        return _steadyTime == other._steadyTime;
-    }
+        [[nodiscard]] bool operator<=(const ExpireTime &other) const {
+            return _steadyTime <= other._steadyTime;
+        }
 
-    [[nodiscard]] bool operator!=(const ExpireTime &other) const {
-        return _steadyTime != other._steadyTime;
-    }
-};
+        [[nodiscard]] bool operator>(const ExpireTime &other) const {
+            return _steadyTime > other._steadyTime;
+        }
+
+        [[nodiscard]] bool operator>=(const ExpireTime &other) const {
+            return _steadyTime >= other._steadyTime;
+        }
+
+        [[nodiscard]] bool operator==(const ExpireTime &other) const {
+            return _steadyTime == other._steadyTime;
+        }
+
+        [[nodiscard]] bool operator!=(const ExpireTime &other) const {
+            return _steadyTime != other._steadyTime;
+        }
+    };
+} // namespace tasks

--- a/nucleus/tests/lifecycle/kernel_tests.cpp
+++ b/nucleus/tests/lifecycle/kernel_tests.cpp
@@ -1,0 +1,28 @@
+#include "catch2/catch_all.hpp"
+#include "data/globals.hpp"
+#include "lifecycle/kernel.hpp"
+#include "test_ggroot.hpp"
+
+namespace fs = std::filesystem;
+
+// NOLINTBEGIN
+
+SCENARIO("Basic Kernel lifecycle", "[kernel]") {
+    // Incomplete tests, just getting started
+    test::GGRoot ggRoot;
+    GIVEN("A very basic startup") {
+        ggRoot.args.push_back("--root");
+        ggRoot.args.push_back(ggRoot.getDir().generic_string());
+        ggRoot.preLaunch();
+        ggRoot.launchAsync();
+        ggRoot.kernel.softShutdown(std::chrono::seconds(1));
+        ggRoot.join();
+        THEN("Config files were created") {
+            REQUIRE(fs::exists(ggRoot.getDir() / "config"));
+            REQUIRE(fs::exists(ggRoot.getDir() / "config" / "config.tlog"));
+            REQUIRE(fs::exists(ggRoot.getDir() / "config" / "effectiveConfig.yaml"));
+        }
+    }
+}
+
+// NOLINTEND

--- a/nucleus/tests/tasks/task_tests.cpp
+++ b/nucleus/tests/tasks/task_tests.cpp
@@ -1,0 +1,249 @@
+#include "catch2/catch_all.hpp"
+#include "data/shared_struct.hpp"
+#include "tasks/task.hpp"
+
+// NOLINTBEGIN
+
+class SubTaskStub : public tasks::SubTask {
+    std::string _flagName;
+    std::shared_ptr<data::StructModelBase> _returnData;
+
+public:
+    SubTaskStub(
+        const std::string_view &flagName, const std::shared_ptr<data::StructModelBase> &returnData
+    )
+        : _flagName(flagName), _returnData{returnData} {
+    }
+
+    SubTaskStub(const std::string_view &flagName) : _flagName(flagName) {
+    }
+
+    std::shared_ptr<data::StructModelBase> runInThread(
+        const std::shared_ptr<tasks::Task> &task,
+        const std::shared_ptr<data::StructModelBase> &dataIn
+    ) override {
+        if(dataIn) {
+            dataIn->put(_flagName, data::StructElement{true});
+        }
+        if(_returnData) {
+            _returnData->put(
+                "_" + _flagName,
+                data::StructElement{std::static_pointer_cast<data::ContainerModelBase>(dataIn)}
+            );
+        }
+        return _returnData;
+    }
+};
+
+SCENARIO("Task management", "[tasks]") {
+    data::Environment environment;
+    std::shared_ptr<tasks::TaskManager> taskManager{
+        std::make_shared<tasks::TaskManager>(environment)};
+    tasks::FixedTaskThreadScope threadScope{
+        std::make_shared<tasks::FixedTaskThread>(environment, taskManager)};
+
+    GIVEN("An empty task") {
+        auto taskAnchor{taskManager->createTask()};
+        auto task{taskAnchor.getObject<tasks::Task>()};
+        auto taskInitData{std::make_shared<data::SharedStruct>(environment)};
+        task->setData(taskInitData);
+        taskManager->queueTask(task);
+        // note, for this test, no worker allocated
+
+        WHEN("Polling once for completion") {
+            tasks::ExpireTime expireTime = tasks::ExpireTime::now();
+            bool didComplete = task->waitForCompletion(expireTime);
+            auto data = task->getData();
+            THEN("Task returns completed") {
+                REQUIRE(didComplete);
+            }
+            THEN("Task returns no data") {
+                REQUIRE(data == nullptr);
+            }
+        }
+    }
+
+    GIVEN("An empty task with completion function") {
+
+        auto taskAnchor{taskManager->createTask()};
+        auto task{taskAnchor.getObject<tasks::Task>()};
+        auto taskInitData{std::make_shared<data::SharedStruct>(environment)};
+        auto taskCompData{std::make_shared<data::SharedStruct>(environment)};
+        auto finalize{std::make_unique<SubTaskStub>("comp", taskCompData)};
+        task->setData(taskInitData);
+        task->setCompletion(std::move(finalize));
+        taskManager->queueTask(task);
+        // note, for this test, no worker allocated
+
+        WHEN("Polling once for completion") {
+            tasks::ExpireTime expireTime = tasks::ExpireTime::now();
+            bool didComplete = task->waitForCompletion(expireTime);
+            auto data = task->getData();
+            THEN("Task returns completed") {
+                REQUIRE(didComplete);
+            }
+            THEN("Task completion received no data") {
+                REQUIRE(taskCompData->hasKey("_comp"));
+                auto compStruct = taskCompData->get("_comp").castObject<data::SharedStruct>();
+                REQUIRE(compStruct == nullptr);
+            }
+            THEN("Task returned no data") {
+                REQUIRE(data == nullptr);
+            }
+        }
+    }
+
+    GIVEN("A single non-return sub-task with completion function") {
+        auto taskAnchor{taskManager->createTask()};
+        auto task{taskAnchor.getObject<tasks::Task>()};
+        auto taskInitData{std::make_shared<data::SharedStruct>(environment)};
+        auto taskCompData{std::make_shared<data::SharedStruct>(environment)};
+        auto subTask1{std::make_unique<SubTaskStub>("subTask1")};
+        auto finalize{std::make_unique<SubTaskStub>("comp", taskCompData)};
+        task->setData(taskInitData);
+        task->addSubtask(std::move(subTask1));
+        task->setCompletion(std::move(finalize));
+        taskManager->queueTask(task);
+        // note, for this test, no worker allocated
+
+        WHEN("Polling once for completion") {
+            tasks::ExpireTime expireTime = tasks::ExpireTime::now();
+            bool didComplete = task->waitForCompletion(expireTime);
+            auto data = task->getData();
+            THEN("Task returns completed") {
+                REQUIRE(didComplete);
+            }
+            THEN("Subtask1 was visited") {
+                REQUIRE(taskInitData->hasKey("subTask1"));
+            }
+            THEN("Task completion received no data") {
+                REQUIRE(taskCompData->hasKey("_comp"));
+                auto compStruct = taskCompData->get("_comp").castObject<data::SharedStruct>();
+                REQUIRE(compStruct == nullptr);
+            }
+            THEN("Task returned no data") {
+                REQUIRE(data == nullptr);
+            }
+        }
+    }
+
+    GIVEN("Three sub-tasks with completion function") {
+        auto taskAnchor{taskManager->createTask()};
+        auto task{taskAnchor.getObject<tasks::Task>()};
+        auto taskInitData{std::make_shared<data::SharedStruct>(environment)};
+        auto taskRetData{std::make_shared<data::SharedStruct>(environment)};
+        auto taskCompData{std::make_shared<data::SharedStruct>(environment)};
+        auto subTask1{std::make_unique<SubTaskStub>("subTask1")};
+        auto subTask2{std::make_unique<SubTaskStub>("subTask2")};
+        auto subTask3{std::make_unique<SubTaskStub>("subTask3", taskRetData)};
+        auto finalize{std::make_unique<SubTaskStub>("comp", taskCompData)};
+        task->setData(taskInitData);
+        task->addSubtask(std::move(subTask1));
+        task->addSubtask(std::move(subTask2));
+        task->addSubtask(std::move(subTask3));
+        task->setCompletion(std::move(finalize));
+        taskManager->queueTask(task);
+        // note, for this test, no worker allocated
+
+        WHEN("Polling once for completion") {
+            tasks::ExpireTime expireTime = tasks::ExpireTime::now();
+            bool didComplete = task->waitForCompletion(expireTime);
+            auto data = task->getData();
+            THEN("Task returns completed") {
+                REQUIRE(didComplete);
+            }
+            THEN("Subtask1 was visited") {
+                REQUIRE(taskInitData->hasKey("subTask1"));
+            }
+            THEN("Subtask2 was visited") {
+                REQUIRE(taskInitData->hasKey("subTask2"));
+            }
+            THEN("Subtask3 was visited") {
+                REQUIRE(taskInitData->hasKey("subTask3"));
+            }
+            THEN("Task completion received data") {
+                REQUIRE(taskCompData->hasKey("_comp"));
+                auto compStruct = taskCompData->get("_comp").castObject<data::SharedStruct>();
+                REQUIRE(compStruct == taskRetData);
+            }
+            THEN("Task returned data") {
+                REQUIRE(data == taskRetData);
+            }
+        }
+    }
+
+    GIVEN("Three sub-tasks returning early with completion function") {
+        auto taskAnchor{taskManager->createTask()};
+        auto task{taskAnchor.getObject<tasks::Task>()};
+        auto taskInitData{std::make_shared<data::SharedStruct>(environment)};
+        auto taskRetData2{std::make_shared<data::SharedStruct>(environment)};
+        auto taskRetData3{std::make_shared<data::SharedStruct>(environment)};
+        auto taskCompData{std::make_shared<data::SharedStruct>(environment)};
+        auto subTask1{std::make_unique<SubTaskStub>("subTask1")};
+        auto subTask2{std::make_unique<SubTaskStub>("subTask2", taskRetData2)};
+        auto subTask3{std::make_unique<SubTaskStub>("subTask3", taskRetData3)};
+        auto finalize{std::make_unique<SubTaskStub>("comp", taskCompData)};
+        task->setData(taskInitData);
+        task->addSubtask(std::move(subTask1));
+        task->addSubtask(std::move(subTask2));
+        task->addSubtask(std::move(subTask3));
+        task->setCompletion(std::move(finalize));
+        taskManager->queueTask(task);
+        // note, for this test, no worker allocated
+
+        WHEN("Polling once for completion") {
+            tasks::ExpireTime expireTime = tasks::ExpireTime::now();
+            bool didComplete = task->waitForCompletion(expireTime);
+            auto data = task->getData();
+            THEN("Task returns completed") {
+                REQUIRE(didComplete);
+            }
+            THEN("Subtask1 was visited") {
+                REQUIRE(taskInitData->hasKey("subTask1"));
+            }
+            THEN("Subtask2 was visited") {
+                REQUIRE(taskInitData->hasKey("subTask2"));
+            }
+            THEN("Subtask3 was not visited") {
+                REQUIRE_FALSE(taskInitData->hasKey("subTask3"));
+            }
+            THEN("Task completion received Subtask2 data") {
+                REQUIRE(taskCompData->hasKey("_comp"));
+                auto compStruct = taskCompData->get("_comp").castObject<data::SharedStruct>();
+                REQUIRE(compStruct == taskRetData2);
+            }
+            THEN("Task returned Subtask2 data") {
+                REQUIRE(data == taskRetData2);
+            }
+        }
+    }
+
+    GIVEN("An unqueued task") {
+        auto taskAnchor{taskManager->createTask()};
+        auto task{taskAnchor.getObject<tasks::Task>()};
+        auto taskInitData{std::make_shared<data::SharedStruct>(environment)};
+        task->setData(taskInitData);
+        // note, for this test, do not queue
+        // note, for this test, no worker allocated
+
+        WHEN("Waiting for cancelled task") {
+            task->cancelTask();
+            auto t1 = std::chrono::system_clock::now();
+            tasks::ExpireTime expireTime = tasks::ExpireTime::fromNowSecs(10);
+            bool didComplete = task->waitForCompletion(expireTime);
+            auto data = task->getData();
+            auto tDelta = std::chrono::duration_cast<std::chrono::seconds>(
+                              std::chrono::system_clock::now() - t1
+            )
+                              .count();
+            THEN("Task did not block") {
+                REQUIRE(tDelta < 9);
+            }
+            AND_THEN("Task returns not complete") {
+                REQUIRE_FALSE(didComplete);
+            }
+        }
+    }
+}
+
+// NOLINTEND

--- a/nucleus/tests/test_ggroot.hpp
+++ b/nucleus/tests/test_ggroot.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#include "lifecycle/command_line.hpp"
+#include "lifecycle/kernel.hpp"
+#include "test_tools.hpp"
+#include <atomic>
+#include <thread>
+
+namespace test {
+
+    class GGRoot : public TempDir {
+    protected:
+        void threadRunner() {
+            int res = kernel.launch();
+            result.store(res);
+            finished.store(true);
+        }
+
+    public:
+        data::Global global;
+        data::SysProperties sysProps;
+        std::vector<std::string> args;
+        lifecycle::Kernel kernel;
+        std::thread kernelThread;
+        std::atomic_int result;
+        std::atomic_bool finished;
+
+        GGRoot() : kernel(global) {
+        }
+
+        void preLaunch() {
+            lifecycle::CommandLine commandLine{global, kernel};
+            commandLine.parseArgs(args);
+            kernel.preLaunch(commandLine);
+        }
+
+        void launchAsync() {
+            kernelThread = std::thread(&GGRoot::threadRunner, this);
+        }
+
+        void join() {
+            kernelThread.join();
+        }
+    };
+} // namespace test

--- a/nucleus/tests/test_tools.hpp
+++ b/nucleus/tests/test_tools.hpp
@@ -1,0 +1,61 @@
+#pragma once
+#include <filesystem>
+#include <iostream>
+#include <random>
+
+namespace test {
+    //
+    // Generate temporary directory for testing
+    //
+    class TempDir {
+        std::filesystem::path _tempDir;
+
+    private:
+        std::filesystem::path genPath() {
+            auto tempdir = std::filesystem::temp_directory_path();
+            std::string prefix = "gg-lite-test-";
+            std::random_device rd;
+            std::mt19937 gen(rd());
+
+            for(int i = 0; i < 1000; ++i) {
+                auto num = gen();
+                std::string tail = prefix + std::to_string(num);
+                auto path = tempdir / tail;
+                if(std::filesystem::create_directory(path)) {
+                    return path;
+                }
+            }
+            throw std::runtime_error("Tried too many times creating temporary directory");
+        }
+
+    public:
+        TempDir() : _tempDir(genPath()) {
+        }
+
+        std::filesystem::path getDir() {
+            return _tempDir;
+        }
+
+        void reset() {
+            remove();
+            _tempDir = genPath();
+        }
+
+        void remove() {
+            if(_tempDir.empty()) {
+                return;
+            }
+
+            std::error_code ec;
+            std::filesystem::remove_all(_tempDir, ec);
+            if(ec) {
+                std::cerr << "Failed to clean up temporary directory" << std::endl;
+            }
+            _tempDir.clear();
+        }
+
+        ~TempDir() {
+            remove();
+        }
+    };
+} // namespace test

--- a/plugin_api/include/c_api.h
+++ b/plugin_api/include/c_api.h
@@ -118,6 +118,7 @@ IMPEXP uint32_t ggapiSendToListenerAsync(
 ) NOEXCEPT;
 IMPEXP uint32_t ggapiCallNext(uint32_t dataStruct) NOEXCEPT;
 IMPEXP uint32_t ggapiWaitForTaskCompleted(uint32_t asyncTask, int32_t timeout) NOEXCEPT;
+IMPEXP bool ggapiCancelTask(uint32_t asyncTask) NOEXCEPT;
 IMPEXP uint32_t ggapiRegisterPlugin(
     uint32_t moduleHandle,
     uint32_t componentName,

--- a/plugin_api/include/cpp_api.hpp
+++ b/plugin_api/include/cpp_api.hpp
@@ -248,6 +248,7 @@ namespace ggapi {
             Subscription listener, Struct message, int32_t timeout = -1
         );
         [[nodiscard]] Struct waitForTaskCompleted(int32_t timeout = -1);
+        void cancelTask();
         [[nodiscard]] Scope registerPlugin(StringOrd componentName, lifecycleCallback_t callback);
         [[nodiscard]] static Scope thisTask();
 
@@ -1022,6 +1023,10 @@ namespace ggapi {
         return callApiReturnHandle<Struct>([*this, timeout]() {
             return ::ggapiWaitForTaskCompleted(getHandleId(), timeout);
         });
+    }
+
+    inline void Scope::cancelTask() {
+        callApi([*this]() { return ::ggapiCancelTask(getHandleId()); });
     }
 
     inline Scope Scope::thisTask() {


### PR DESCRIPTION
Working on code path to allow Nucleus to be shutdown. This is used in GG for unit tests.
As part of this, added new capability in Task to cancel.
Added unit tests for Task to test various scenarios including cancel.
Refactored structures a little to reduce code repetition discovered while writing unit tests
Bug fixes from testing

