### PR TITLE
Misc Plugin Fixes

### DIFF
--- a/nucleus/src/deployment/device_configuration.cpp
+++ b/nucleus/src/deployment/device_configuration.cpp
@@ -41,6 +41,7 @@ namespace deployment {
 
     std::string DeviceConfiguration::initNucleusComponentName() {
         // TODO: missing code
+        return {};
     }
 
     void DeviceConfiguration::initializeNucleusComponentConfig(std::string nucleusComponentName) {
@@ -99,9 +100,8 @@ namespace deployment {
         // TODO: missing code
     }
 
-    void DeviceConfiguration::handleLoggingConfigurationChanges(
-        config::WhatHappened, config::ConfigNode
-    ) {
+    void DeviceConfiguration::
+        handleLoggingConfigurationChanges(config::WhatHappened, const std::shared_ptr<config::ConfigNode> &) {
         // TODO: missing code
     }
 
@@ -316,9 +316,10 @@ namespace deployment {
     }
 
     bool DeviceConfiguration::provisionInfoNodeChanged(
-        config::ConfigNode node, bool checkThingNameOnly
+        const std::shared_ptr<config::ConfigNode> &node, bool checkThingNameOnly
     ) {
         // TODO: missing code
+        return false;
     }
 
     config::Topic DeviceConfiguration::getTopic(data::StringOrdInit parameterName) {
@@ -350,6 +351,7 @@ namespace deployment {
 
     std::string DeviceConfiguration::getVersionFromBuildRecipeFile() {
         // TODO: missing code
+        return {};
     }
 
     void DeviceConfiguration::validateDeviceConfiguration(

--- a/nucleus/src/deployment/device_configuration.hpp
+++ b/nucleus/src/deployment/device_configuration.hpp
@@ -174,7 +174,8 @@ namespace deployment {
         void
         copyUnpackedNucleusArtifacts(const std::filesystem::path &, const std::filesystem::path &);
         void handleLoggingConfig();
-        void handleLoggingConfigurationChanges(config::WhatHappened, config::ConfigNode);
+        void
+        handleLoggingConfigurationChanges(config::WhatHappened, const std::shared_ptr<config::ConfigNode> &);
         //        void reconfigureLogging(LogConfigUpdate);
         std::string getComponentType(std::string);
         //        std::shared_ptr<config::Validator> &getDeTildeValidator(lifecycle::CommandLine
@@ -216,7 +217,7 @@ namespace deployment {
         void validate();
         void validate(bool);
         bool isDeviceConfiguredToTalkToCloud();
-        bool provisionInfoNodeChanged(config::ConfigNode, bool);
+        bool provisionInfoNodeChanged(const std::shared_ptr<config::ConfigNode> &node, bool);
         config::Topic getTopic(data::StringOrdInit);
         std::shared_ptr<config::Topics> getTopics(data::StringOrdInit);
         std::string getNucleusVersion();

--- a/nucleus/src/lifecycle/kernel.cpp
+++ b/nucleus/src/lifecycle/kernel.cpp
@@ -272,7 +272,7 @@ namespace lifecycle {
         //
         // TODO: This is stub/sample code
         //
-        _global.loader->discoverPlugins(); // TODO: replace with looking in plugin directory
+        _global.loader->discoverPlugins(getPaths()->pluginPath());
         std::shared_ptr<data::SharedStruct> configStruct{
             std::make_shared<data::SharedStruct>(_global.environment)};
         std::shared_ptr<data::ContainerModelBase> rootStruct = getConfig().root();

--- a/nucleus/src/plugins/plugin_loader.cpp
+++ b/nucleus/src/plugins/plugin_loader.cpp
@@ -119,10 +119,10 @@ bool plugins::DelegatePlugin::lifecycle(
     return true;
 }
 
-void plugins::PluginLoader::discoverPlugins() {
-    // two-layer iterator just to make testing easier
-    fs::path root = fs::absolute(".");
-    for(const auto &top : fs::directory_iterator(root)) {
+void plugins::PluginLoader::discoverPlugins(const std::filesystem::path &pluginDir) {
+    // The only plugins used are those in the plugin directory, or subdirectory of
+    // plugin directory
+    for(const auto &top : fs::directory_iterator(pluginDir)) {
         if(top.is_regular_file()) {
             discoverPlugin(top);
         } else if(top.is_directory()) {

--- a/nucleus/src/plugins/plugin_loader.hpp
+++ b/nucleus/src/plugins/plugin_loader.hpp
@@ -113,7 +113,7 @@ namespace plugins {
         explicit PluginLoader(data::Environment &environment) : TrackingScope(environment) {
         }
 
-        void discoverPlugins();
+        void discoverPlugins(const std::filesystem::path &pluginDir);
         void discoverPlugin(const std::filesystem::directory_entry &entry);
 
         void loadNativePlugin(const std::string &name);

--- a/plugin_api/include/cpp_api.hpp
+++ b/plugin_api/include/cpp_api.hpp
@@ -923,7 +923,6 @@ namespace ggapi {
 
     public:
         explicit BufferInStream(const Buffer buffer) : _stream(buffer), std::istream(&_stream) {
-            init(&_stream);
         }
     };
 
@@ -931,8 +930,7 @@ namespace ggapi {
         BufferStream _stream;
 
     public:
-        explicit BufferOutStream(const Buffer buffer) : _stream(buffer) {
-            init(&_stream);
+        explicit BufferOutStream(const Buffer buffer) : _stream(buffer), std::ostream(&_stream) {
             _stream.pubseekoff(0, std::ios_base::end, std::ios_base::out);
         }
     };

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(PLUGIN_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
 add_subdirectory(example_layered_plugin)
 add_subdirectory(example_mqtt_sender)
 add_subdirectory(example_plugin1)

--- a/plugins/example_layered_plugin/CMakeLists.txt
+++ b/plugins/example_layered_plugin/CMakeLists.txt
@@ -3,3 +3,7 @@ project(example_layered_plugin)
 
 add_library(example_layered_plugin MODULE main.cpp)
 target_link_libraries(example_layered_plugin PRIVATE nucleus-core)
+add_custom_command(TARGET example_layered_plugin
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:example_layered_plugin>" "${PLUGIN_BINARY_DIR}"
+        )

--- a/plugins/example_mqtt_sender/CMakeLists.txt
+++ b/plugins/example_mqtt_sender/CMakeLists.txt
@@ -3,3 +3,7 @@ project(example_mqtt_sender)
 
 add_library(example_mqtt_sender MODULE main.cpp)
 target_link_libraries(example_mqtt_sender PRIVATE nucleus-core)
+add_custom_command(TARGET example_mqtt_sender
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:example_mqtt_sender>" "${PLUGIN_BINARY_DIR}"
+        )

--- a/plugins/example_plugin1/CMakeLists.txt
+++ b/plugins/example_plugin1/CMakeLists.txt
@@ -3,3 +3,7 @@ project(example_plugin1)
 
 add_library(example_plugin1 MODULE main.cpp)
 target_link_libraries(example_plugin1 PRIVATE nucleus-core)
+add_custom_command(TARGET example_plugin1
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:example_plugin1>" "${PLUGIN_BINARY_DIR}"
+        )

--- a/plugins/example_plugin2/CMakeLists.txt
+++ b/plugins/example_plugin2/CMakeLists.txt
@@ -3,3 +3,7 @@ project(example_plugin2)
 
 add_library(example_plugin2 MODULE main.cpp)
 target_link_libraries(example_plugin2 PRIVATE nucleus-core)
+add_custom_command(TARGET example_plugin2
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:example_plugin2>" "${PLUGIN_BINARY_DIR}"
+        )

--- a/plugins/iot_broker/CMakeLists.txt
+++ b/plugins/iot_broker/CMakeLists.txt
@@ -13,3 +13,7 @@ FetchContent_MakeAvailable(device-sdk-cpp)
 
 add_library(iot_broker MODULE main.cpp)
 target_link_libraries(iot_broker PRIVATE nucleus-core aws-crt-cpp)
+add_custom_command(TARGET iot_broker
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:iot_broker>" "${PLUGIN_BINARY_DIR}"
+        )


### PR DESCRIPTION
1/ Fix build errors for gcc after DeviceConfiguration check-in (not sure why clang let it build, we need to look into that)
2/ Modified CMakelists to copy plugins to top-level plugins directory
3/ Nucleus now requires plugins to be in the "plugins" sub-directory, using the root path previously determined

Note for (3) - this means plugins cannot just be copied into same directory as Nucleus While (2) makes it easier to copy/paste.
Tip from Joe is to symlink
