### PR TITLE
Refactor StringTable::getOrCreateOrd w/string_view

### DIFF
--- a/nucleus/src/api/data.cpp
+++ b/nucleus/src/api/data.cpp
@@ -10,7 +10,7 @@ using namespace data;
 uint32_t ggapiGetStringOrdinal(const char *bytes, size_t len) noexcept {
     try {
         Global &global = Global::self();
-        return global.environment.stringTable.getOrCreateOrd(std::string{bytes, len}).asInt();
+        return global.environment.stringTable.getOrCreateOrd(std::string_view{bytes, len}).asInt();
     } catch(...) {
         std::terminate(); // any string table put errors would be a critical
                           // error requiring termination

--- a/nucleus/src/config/config_manager.cpp
+++ b/nucleus/src/config/config_manager.cpp
@@ -256,9 +256,9 @@ namespace config {
     }
 
     std::shared_ptr<Topics> Topics::createInteriorChild(
-        std::string_view sv, const Timestamp &timestamp
+        std::string_view name, const Timestamp &timestamp
     ) {
-        data::StringOrd handle = _environment.stringTable.getOrCreateOrd(std::string(sv));
+        data::StringOrd handle = _environment.stringTable.getOrCreateOrd(name);
         return createInteriorChild(handle, timestamp);
     }
 
@@ -346,7 +346,7 @@ namespace config {
     }
 
     std::shared_ptr<Topics> Topics::findInteriorChild(std::string_view name) {
-        data::StringOrd handle = _environment.stringTable.getOrCreateOrd(std::string(name));
+        data::StringOrd handle = _environment.stringTable.getOrCreateOrd(name);
         return findInteriorChild(handle);
     }
 
@@ -381,7 +381,7 @@ namespace config {
     }
 
     Topic Topics::createTopic(std::string_view name, const Timestamp &timestamp) {
-        data::StringOrd handle = _environment.stringTable.getOrCreateOrd(std::string(name));
+        data::StringOrd handle = _environment.stringTable.getOrCreateOrd(name);
         return createTopic(handle, timestamp);
     }
 
@@ -397,7 +397,7 @@ namespace config {
     }
 
     Topic Topics::getTopic(std::string_view name) {
-        data::StringOrd handle = _environment.stringTable.getOrCreateOrd(std::string(name));
+        data::StringOrd handle = _environment.stringTable.getOrCreateOrd(name);
         return getTopic(handle);
     }
 
@@ -428,8 +428,8 @@ namespace config {
         }
     }
 
-    std::shared_ptr<ConfigNode> Topics::getNode(std::string_view sv) {
-        data::StringOrd handle = _environment.stringTable.getOrCreateOrd(std::string(sv));
+    std::shared_ptr<ConfigNode> Topics::getNode(std::string_view name) {
+        data::StringOrd handle = _environment.stringTable.getOrCreateOrd(name);
         return getNode(handle);
     }
 
@@ -438,7 +438,7 @@ namespace config {
             throw std::runtime_error("Empty path provided");
         }
         std::shared_ptr<ConfigNode> node{ref<Topics>()};
-        for(auto &it : path) {
+        for(const auto &it : path) {
             std::shared_ptr<Topics> t{std::dynamic_pointer_cast<Topics>(node)};
             if(!t) {
                 return {};

--- a/nucleus/src/data/struct_model.cpp
+++ b/nucleus/src/data/struct_model.cpp
@@ -28,7 +28,7 @@ namespace data {
     }
 
     void StructModelBase::put(std::string_view sv, const StructElement &element) {
-        Handle handle = _environment.stringTable.getOrCreateOrd(std::string(sv));
+        Handle handle = _environment.stringTable.getOrCreateOrd(sv);
         putImpl(handle, element);
     }
 
@@ -37,7 +37,7 @@ namespace data {
     }
 
     bool StructModelBase::hasKey(const std::string_view sv) const {
-        Handle handle = _environment.stringTable.getOrCreateOrd(std::string(sv));
+        Handle handle = _environment.stringTable.getOrCreateOrd(sv);
         return hasKeyImpl(handle);
     }
 
@@ -45,8 +45,8 @@ namespace data {
         return hasKeyImpl(handle);
     }
 
-    StructElement StructModelBase::get(const std::string_view sv) const {
-        Handle handle = _environment.stringTable.getOrCreateOrd(std::string(sv));
+    StructElement StructModelBase::get(std::string_view sv) const {
+        Handle handle = _environment.stringTable.getOrCreateOrd(sv);
         return getImpl(handle);
     }
 


### PR DESCRIPTION
## Reason for Change
Accepting string_view to the find function avoids copying strings in cases when the key is already in the StringTable.
Many usages of the method create a temporary string in order to call the method,
even if the method in question does not emplace a new InternedString, StringOrd pair

## Description of Changes
Change method signature of getOrCreateOrd to accept std::string_view
Change usages of getOrCreateOrd to not create instances of std::string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
