### PR TITLE
Fix another task race condition

### DIFF
--- a/nucleus/src/data/globals.hpp
+++ b/nucleus/src/data/globals.hpp
@@ -7,8 +7,7 @@
 namespace data {
     struct Global {
         Environment environment;
-        std::shared_ptr<tasks::TaskManager> taskManager{
-            std::make_shared<tasks::TaskManager>(environment)};
+        tasks::TaskManagerContainer taskManager{environment};
         std::shared_ptr<pubsub::PubSubManager> lpcTopics{
             std::make_shared<pubsub::PubSubManager>(environment)};
         std::shared_ptr<plugins::PluginLoader> loader{

--- a/nucleus/src/tasks/task_manager.cpp
+++ b/nucleus/src/tasks/task_manager.cpp
@@ -173,6 +173,10 @@ namespace tasks {
 
     TaskManager::~TaskManager() {
         // Clean shutdown of all workers and tasks that are accessible to task manager
+        assert(_shutdown);
+    }
+
+    void TaskManager::shutdownAndWait() {
         std::unique_lock guard{_mutex};
         _shutdown = true;
         guard.unlock();

--- a/nucleus/tests/tasks/task_tests.cpp
+++ b/nucleus/tests/tasks/task_tests.cpp
@@ -42,8 +42,7 @@ public:
 
 SCENARIO("Task management", "[tasks]") {
     data::Environment environment;
-    std::shared_ptr<tasks::TaskManager> taskManager{
-        std::make_shared<tasks::TaskManager>(environment)};
+    tasks::TaskManagerContainer taskManager{environment};
     tasks::FixedTaskThreadScope threadScope{
         std::make_shared<tasks::FixedTaskThread>(environment, taskManager)};
 
@@ -253,8 +252,7 @@ SCENARIO("Task management", "[tasks]") {
 
 SCENARIO("Deferred task management", "[tasks]") {
     data::Environment environment;
-    std::shared_ptr<tasks::TaskManager> taskManager{
-        std::make_shared<tasks::TaskManager>(environment)};
+    tasks::TaskManagerContainer taskManager{environment};
     tasks::FixedTaskThreadScope threadScope{
         std::make_shared<tasks::FixedTimerTaskThread>(environment, taskManager)};
 


### PR DESCRIPTION
Was doing too much in destructor that may conflict with threads using TaskManager - solution - create a container that uses RII approach for cleanup.
