### PR TITLE
Plugin service name and service config

### DIFF
--- a/nucleus/src/data/string_table.hpp
+++ b/nucleus/src/data/string_table.hpp
@@ -143,6 +143,7 @@ namespace data {
         Symbol applyUnchecked(Symbol::Partial h) const {
             return {_table, h};
         }
+
     public:
         SymbolTable();
         Symbol testAndGetSymbol(std::string_view str) const {

--- a/nucleus/src/deployment/device_configuration.hpp
+++ b/nucleus/src/deployment/device_configuration.hpp
@@ -2,6 +2,7 @@
 #include "config/config_manager.hpp"
 #include "config/validator.hpp"
 #include "data/string_table.hpp"
+#include "errors/error_base.hpp"
 #include "lifecycle/kernel.hpp"
 #include "util/nucleus_paths.hpp"
 #include <atomic>

--- a/nucleus/src/lifecycle/kernel.hpp
+++ b/nucleus/src/lifecycle/kernel.hpp
@@ -44,7 +44,7 @@ namespace lifecycle {
         tasks::FixedTaskThreadScope _mainThread;
         std::unique_ptr<config::TlogWriter> _tlog;
         deployment::DeploymentStage _deploymentStageAtLaunch{deployment::DeploymentStage::DEFAULT};
-        std::unique_ptr<deployment::DeviceConfiguration> _deviceConfiguration{nullptr};
+        std::shared_ptr<deployment::DeviceConfiguration> _deviceConfiguration{nullptr};
         std::unique_ptr<KernelAlternatives> _kernelAlts{nullptr};
         std::atomic_int _exitCode{0};
 

--- a/nucleus/src/plugins/plugin_loader.cpp
+++ b/nucleus/src/plugins/plugin_loader.cpp
@@ -1,4 +1,5 @@
 #include "plugin_loader.hpp"
+#include "deployment/device_configuration.hpp"
 #include "errors/error_base.hpp"
 #include "pubsub/local_topics.hpp"
 #include "scope/context_full.hpp"
@@ -11,172 +12,209 @@ namespace fs = std::filesystem;
 #define STRINGIFY2(x) STRINGIFY(x)
 #define NATIVE_SUFFIX STRINGIFY2(PLATFORM_SHLIB_SUFFIX)
 
-plugins::NativePlugin::~NativePlugin() {
-    nativeHandle_t h = _handle.load();
-    _handle.store(nullptr);
-    if(!h) {
-        return;
-    }
-#if defined(USE_DLFCN)
-    ::dlclose(_handle);
-#elif defined(USE_WINDLL)
-    ::FreeLibrary(_handle);
-#endif
-}
+namespace plugins {
 
-void plugins::NativePlugin::load(const std::string &filePath) {
+    NativePlugin::~NativePlugin() {
+        nativeHandle_t h = _handle.load();
+        _handle.store(nullptr);
+        if(!h) {
+            return;
+        }
 #if defined(USE_DLFCN)
-    nativeHandle_t handle = ::dlopen(filePath.c_str(), RTLD_NOW | RTLD_LOCAL);
-    _handle.store(handle);
-    if(handle == nullptr) {
-        // Note, dlerror() below will flag "concurrency-mt-unsafe"
-        // It is thread safe on Linux and Mac
-        // There is no safer alternative, so all we can do is suppress
-        // TODO: When implementing loader thread, make sure this is all in same thread
-        // NOLINTNEXTLINE(concurrency-mt-unsafe)
-        std::string error{dlerror()};
-        throw std::runtime_error(
-            std::string("Cannot load shared object: ") + filePath + std::string(" ") + error);
-    }
-    // NOLINTNEXTLINE(*-reinterpret-cast)
-    _lifecycleFn.store(reinterpret_cast<lifecycleFn_t>(::dlsym(_handle, NATIVE_ENTRY_NAME)));
+        ::dlclose(_handle);
 #elif defined(USE_WINDLL)
-    nativeHandle_t handle =
-        ::LoadLibraryEx(filePath.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
-    _handle.store(handle);
-    if(handle == nullptr) {
-        uint32_t lastError = ::GetLastError();
-        // TODO: use FormatMessage
-        throw std::runtime_error(
-            std::string("Cannot load DLL: ") + filePath + std::string(" ")
-            + std::to_string(lastError));
+        ::FreeLibrary(_handle);
+#endif
     }
-    _lifecycleFn.store(
+
+    void NativePlugin::load(const std::filesystem::path &path) {
+        std::string filePath = path.generic_string();
+#if defined(USE_DLFCN)
+        nativeHandle_t handle = ::dlopen(filePath.c_str(), RTLD_NOW | RTLD_LOCAL);
+        _handle.store(handle);
+        if(handle == nullptr) {
+            // Note, dlerror() below will flag "concurrency-mt-unsafe"
+            // It is thread safe on Linux and Mac
+            // There is no safer alternative, so all we can do is suppress
+            // TODO: When implementing loader thread, make sure this is all in same thread
+            // NOLINTNEXTLINE(concurrency-mt-unsafe)
+            std::string error{dlerror()};
+            throw std::runtime_error(
+                std::string("Cannot load shared object: ") + filePath + std::string(" ") + error);
+        }
         // NOLINTNEXTLINE(*-reinterpret-cast)
-        reinterpret_cast<lifecycleFn_t>(::GetProcAddress(_handle.load(), NATIVE_ENTRY_NAME)));
+        _lifecycleFn.store(reinterpret_cast<lifecycleFn_t>(::dlsym(_handle, NATIVE_ENTRY_NAME)));
+#elif defined(USE_WINDLL)
+        nativeHandle_t handle =
+            ::LoadLibraryEx(filePath.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
+        _handle.store(handle);
+        if(handle == nullptr) {
+            uint32_t lastError = ::GetLastError();
+            // TODO: use FormatMessage
+            throw std::runtime_error(
+                std::string("Cannot load DLL: ") + filePath + std::string(" ")
+                + std::to_string(lastError));
+        }
+        _lifecycleFn.store(
+            // NOLINTNEXTLINE(*-reinterpret-cast)
+            reinterpret_cast<lifecycleFn_t>(::GetProcAddress(_handle.load(), NATIVE_ENTRY_NAME)));
 #endif
-}
+    }
 
-bool plugins::NativePlugin::isActive() noexcept {
-    return _lifecycleFn.load() != nullptr;
-}
+    bool NativePlugin::isActive() noexcept {
+        return _lifecycleFn.load() != nullptr;
+    }
 
-void plugins::PluginLoader::lifecycle(
-    data::Symbol phase, const std::shared_ptr<data::StructModelBase> &data) {
-    // TODO: Run this inside of a task?
-    for(const auto &i : _root->getRoots()) {
-        std::shared_ptr<AbstractPlugin> plugin{i.getObject<AbstractPlugin>()};
-        if(plugin->isActive()) {
-            errors::ThreadErrorContainer::get().clear();
-            // TODO: convert to logging
-            std::cerr << "Plugin \"" << plugin->getName()
-                      << "\" lifecycle phase: " << phase.toString() << std::endl;
-            if(!plugin->lifecycle(i.getHandle(), phase, data)) {
-                std::optional<errors::Error> lastError{
-                    errors::ThreadErrorContainer::get().getError()};
-                if(lastError.has_value()) {
-                    std::cerr << "Plugin \"" << plugin->getName()
-                              << "\" lifecycle error during phase: " << phase.toString() << " - "
-                              << lastError.value().what() << std::endl;
-                } else {
-                    std::cerr << "Plugin \"" << plugin->getName()
-                              << "\" lifecycle unhandled phase: " << phase.toString() << std::endl;
+    bool NativePlugin::callNativeLifecycle(
+        const data::ObjHandle &pluginHandle,
+        const data::Symbol &phase,
+        const data::ObjHandle &dataHandle) {
+
+        lifecycleFn_t lifecycleFn = _lifecycleFn.load();
+        if(lifecycleFn != nullptr) {
+            return lifecycleFn(pluginHandle.asInt(), phase.asInt(), dataHandle.asInt());
+        }
+        return true; // no error
+    }
+
+    bool DelegatePlugin::callNativeLifecycle(
+        const data::ObjHandle &pluginHandle,
+        const data::Symbol &phase,
+        const data::ObjHandle &dataHandle) {
+
+        uintptr_t delegateContext;
+        ggapiLifecycleCallback delegateLifecycle;
+        {
+            std::shared_lock guard{_mutex};
+            delegateContext = _delegateContext;
+            delegateLifecycle = _delegateLifecycle;
+        }
+        if(delegateLifecycle != nullptr) {
+            return delegateLifecycle(
+                delegateContext, pluginHandle.asInt(), phase.asInt(), dataHandle.asInt());
+        }
+        return true;
+    }
+
+    void PluginLoader::discoverPlugins(const std::filesystem::path &pluginDir) {
+        // The only plugins used are those in the plugin directory, or subdirectory of
+        // plugin directory
+        for(const auto &top : fs::directory_iterator(pluginDir)) {
+            if(top.is_regular_file()) {
+                discoverPlugin(top);
+            } else if(top.is_directory()) {
+                for(const auto &fileEnt : fs::directory_iterator(top)) {
+                    if(fileEnt.is_regular_file()) {
+                        discoverPlugin(fileEnt);
+                    }
                 }
             }
         }
     }
-}
 
-bool plugins::NativePlugin::lifecycle(
-    data::ObjHandle pluginAnchor,
-    data::Symbol phase,
-    const std::shared_ptr<data::StructModelBase> &data) {
-    lifecycleFn_t lifecycleFn = _lifecycleFn.load();
-    if(lifecycleFn != nullptr) {
-        // Below scope ensures local resources - handles and thread local data - are cleaned up
-        // when plugin code returns
-        scope::StackScope scopeForHandles{};
-
-        std::shared_ptr<data::StructModelBase> copy = data->copy();
-        data::ObjectAnchor dataAnchor = scopeForHandles.getCallScope()->root()->anchor(copy);
-        return lifecycleFn(pluginAnchor.asInt(), phase.asInt(), dataAnchor.asIntHandle());
+    void PluginLoader::discoverPlugin(const fs::directory_entry &entry) {
+        if(entry.path().extension().compare(NATIVE_SUFFIX) == 0) {
+            loadNativePlugin(entry.path());
+            return;
+        }
     }
-    return true; // no error
-}
 
-bool plugins::DelegatePlugin::lifecycle(
-    data::ObjHandle pluginAnchor,
-    data::Symbol phase,
-    const std::shared_ptr<data::StructModelBase> &data) {
-    uintptr_t delegateContext;
-    ggapiLifecycleCallback delegateLifecycle;
-    {
-        std::shared_lock guard{_mutex};
-        delegateContext = _delegateContext;
-        delegateLifecycle = _delegateLifecycle;
+    void PluginLoader::loadNativePlugin(const std::filesystem::path &path) {
+        auto stem = path.stem().generic_string();
+        auto name = util::trimStart(stem, "lib");
+        std::string serviceName = std::string("local.plugins.discovered.") + std::string(name);
+        std::shared_ptr<NativePlugin> plugin{
+            std::make_shared<NativePlugin>(_context.lock(), serviceName)};
+        std::cout << "Loading native plugin from " << path << std::endl;
+        plugin->load(path);
+        // add the plugins to collection by "anchoring"
+        // which solves a number of interesting problems
+        auto anchor = _root->anchor(plugin);
+        plugin->setSelf(anchor.getHandle());
+        plugin->bootstrap(*this);
     }
-    if(delegateLifecycle != nullptr) {
-        // Below scope ensures local resources - handles and thread local data - are cleaned up
-        // when plugin code returns
-        scope::StackScope scopeForHandles{};
 
-        std::shared_ptr<data::StructModelBase> copy = data->copy();
-        data::ObjectAnchor dataAnchor = scopeForHandles.getCallScope()->root()->anchor(copy);
-        return delegateLifecycle(
-            delegateContext, pluginAnchor.asInt(), phase.asInt(), dataAnchor.getHandle().asInt());
+    void PluginLoader::forAllPlugins(
+        const std::function<void(AbstractPlugin &, const std::shared_ptr<data::StructModelBase> &)>
+            &fn) const {
+
+        for(const auto &i : _root->getRoots()) {
+            std::shared_ptr<AbstractPlugin> plugin{i.getObject<AbstractPlugin>()};
+            plugin->invoke(fn);
+        }
     }
-    return true;
-}
 
-void plugins::PluginLoader::discoverPlugins(const std::filesystem::path &pluginDir) {
-    // The only plugins used are those in the plugin directory, or subdirectory of
-    // plugin directory
-    for(const auto &top : fs::directory_iterator(pluginDir)) {
-        if(top.is_regular_file()) {
-            discoverPlugin(top);
-        } else if(top.is_directory()) {
-            for(const auto &fileEnt : fs::directory_iterator(top)) {
-                if(fileEnt.is_regular_file()) {
-                    discoverPlugin(fileEnt);
-                }
+    PluginLoader &AbstractPlugin::loader() {
+        return context().pluginLoader();
+    }
+
+    std::shared_ptr<data::StructModelBase> PluginLoader::buildParams(
+        AbstractPlugin &plugin, bool bootstrap) const {
+        std::string nucleusName = _deviceConfig->getNucleusComponentName();
+        auto data = std::make_shared<data::SharedStruct>(_context.lock());
+        data->put(CONFIG_ROOT, context().configManager().root());
+        data->put(SYSTEM, context().configManager().lookupTopics({SYSTEM}));
+        if(!bootstrap) {
+            data->put(
+                NUCLEUS_CONFIG, context().configManager().lookupTopics({SERVICES, nucleusName}));
+            data->put(CONFIG, context().configManager().lookupTopics({SERVICES, plugin.getName()}));
+        }
+        data->put(NAME, plugin.getName());
+        return data;
+    }
+
+    void AbstractPlugin::invoke(
+        const std::function<void(AbstractPlugin &, const std::shared_ptr<data::StructModelBase> &)>
+            &fn) {
+
+        if(!isActive()) {
+            return;
+        }
+        std::shared_ptr<data::StructModelBase> data = loader().buildParams(*this);
+        fn(*this, data);
+    }
+
+    void AbstractPlugin::lifecycle(
+        data::Symbol phase, const std::shared_ptr<data::StructModelBase> &data) {
+
+        errors::ThreadErrorContainer::get().clear();
+        // TODO: convert to logging
+        std::cerr << "Plugin \"" << getName() << "\" lifecycle phase: " << phase.toString()
+                  << std::endl;
+        scope::StackScope scope{};
+        data::ObjHandle dataHandle = scope.getCallScope()->root()->anchor(data).getHandle();
+        if(!callNativeLifecycle(getSelf(), phase, dataHandle)) {
+            std::optional<errors::Error> lastError{errors::ThreadErrorContainer::get().getError()};
+            if(lastError.has_value()) {
+                std::cerr << "Plugin \"" << getName()
+                          << "\" lifecycle error during phase: " << phase.toString() << " - "
+                          << lastError.value().what() << std::endl;
+            } else {
+                std::cerr << "Plugin \"" << getName()
+                          << "\" lifecycle unhandled phase: " << phase.toString() << std::endl;
             }
         }
     }
-}
 
-void plugins::PluginLoader::discoverPlugin(const fs::directory_entry &entry) {
-    std::string name{entry.path().generic_string()};
-    if(entry.path().extension().compare(NATIVE_SUFFIX) == 0) {
-        loadNativePlugin(name);
-        return;
+    void AbstractPlugin::bootstrap(PluginLoader &loader) {
+        if(!isActive()) {
+            return;
+        }
+        auto data = loader.buildParams(*this, true);
+        lifecycle(loader.BOOTSTRAP, data);
+        data::StructElement el = data->get(loader.NAME);
+        if(el.isScalar()) {
+            // Allow name to be changed
+            _moduleName = el.getString();
+        }
+        // Update data, module name is now known
+        // TODO: This path is only when recipe is unknown
+        data = loader.buildParams(*this, false);
+        auto config = data->get(loader.CONFIG).castObject<data::StructModelBase>();
+        config->put("version", std::string("0.0.0"));
+        config->put("dependencies", std::make_shared<data::SharedList>(_context.lock()));
+        // Now allow plugin to bind to service part of config tree
+        lifecycle(loader.BIND, data);
     }
-}
 
-void plugins::PluginLoader::loadNativePlugin(const std::string &name) {
-    std::shared_ptr<NativePlugin> plugin{std::make_shared<NativePlugin>(_context.lock(), name)};
-    std::cout << "Loading native plugin from " << name << std::endl;
-    plugin->load(name);
-    // add the plugins to collection by "anchoring"
-    // which solves a number of interesting problems
-    _root->anchor(plugin);
-}
-
-void plugins::PluginLoader::lifecycleBootstrap(const std::shared_ptr<data::StructModelBase> &data) {
-    lifecycle(_bootstrap, data);
-}
-
-void plugins::PluginLoader::lifecycleDiscover(const std::shared_ptr<data::StructModelBase> &data) {
-    lifecycle(_discover, data);
-}
-
-void plugins::PluginLoader::lifecycleStart(const std::shared_ptr<data::StructModelBase> &data) {
-    lifecycle(_start, data);
-}
-
-void plugins::PluginLoader::lifecycleRun(const std::shared_ptr<data::StructModelBase> &data) {
-    lifecycle(_run, data);
-}
-
-void plugins::PluginLoader::lifecycleTerminate(const std::shared_ptr<data::StructModelBase> &data) {
-    lifecycle(_terminate, data);
-}
+} // namespace plugins

--- a/plugin_api/include/cpp_api.hpp
+++ b/plugin_api/include/cpp_api.hpp
@@ -227,6 +227,8 @@ namespace ggapi {
         }
 
     public:
+        constexpr Task() noexcept = default;
+
         explicit Task(const ObjHandle &other) : ObjHandle{other} {
             check();
         }
@@ -276,6 +278,8 @@ namespace ggapi {
         }
 
     public:
+        constexpr Subscription() noexcept = default;
+
         explicit Subscription(const ObjHandle &other) : ObjHandle{other} {
             check();
         }
@@ -310,7 +314,7 @@ namespace ggapi {
         }
 
     public:
-        Scope() noexcept = default;
+        constexpr Scope() noexcept = default;
         Scope(const Scope &) noexcept = default;
         Scope(Scope &&) noexcept = default;
         Scope &operator=(const Scope &) noexcept = default;
@@ -343,7 +347,7 @@ namespace ggapi {
     //
     class ModuleScope : public Scope {
     public:
-        ModuleScope() noexcept = default;
+        constexpr ModuleScope() noexcept = default;
         ModuleScope(const ModuleScope &) noexcept = default;
         ModuleScope(ModuleScope &&) noexcept = default;
         ModuleScope &operator=(const ModuleScope &) noexcept = default;
@@ -483,6 +487,8 @@ namespace ggapi {
 
         using KeyValue = std::pair<Symbol, ArgValue>;
 
+        constexpr Container() noexcept = default;
+
         explicit Container(const ObjHandle &other) : ObjHandle{other} {
         }
 
@@ -528,6 +534,8 @@ namespace ggapi {
         }
 
     public:
+        constexpr Struct() noexcept = default;
+
         explicit Struct(const ObjHandle &other) : Container{other} {
             check();
         }
@@ -565,7 +573,7 @@ namespace ggapi {
         }
 
         template<typename T>
-        T get(Symbol key) const {
+        [[nodiscard]] T get(Symbol key) const {
             required();
             if constexpr(std::is_same_v<bool, T>) {
                 return callApiReturn<bool>(
@@ -654,6 +662,8 @@ namespace ggapi {
         }
 
     public:
+        constexpr List() noexcept = default;
+
         explicit List(const ObjHandle &other) : Container{other} {
             check();
         }
@@ -740,6 +750,8 @@ namespace ggapi {
         }
 
     public:
+        constexpr Buffer() noexcept = default;
+
         explicit Buffer(const ObjHandle &other) : Container{other} {
             check();
         }
@@ -1124,8 +1136,9 @@ namespace ggapi {
     inline T Scope::anchor(T otherHandle) const {
         required();
         static_assert(std::is_base_of_v<ObjHandle, T>);
-        return callApiReturnHandle<T>(
-            [this, otherHandle]() { return ::ggapiAnchorHandle(getHandleId(), otherHandle); });
+        return callApiReturnHandle<T>([this, otherHandle]() {
+            return ::ggapiAnchorHandle(getHandleId(), otherHandle.getHandleId());
+        });
     }
 
     inline Subscription Scope::subscribeToTopic(Symbol topic, topicCallback_t callback) {

--- a/plugin_api/include/plugin.hpp
+++ b/plugin_api/include/plugin.hpp
@@ -4,17 +4,24 @@
 
 namespace ggapi {
 
+    /**
+     * Base class for all plugins
+     */
     class Plugin {
     private:
         std::atomic<ModuleScope> _moduleScope{ModuleScope{}};
-        std::atomic<StringOrd> _phase{StringOrd{}};
+        std::atomic<Symbol> _phase{Symbol{}};
+        std::atomic<Struct> _config{};
 
-        //
-        // Generic lifecycle dispatch
-        //
-        bool lifecycleDispatch(StringOrd phase, Struct data) {
+        /**
+         * Generic lifecycle dispatch
+         */
+        bool lifecycleDispatch(Symbol phase, Struct data) {
             if(phase == BOOTSTRAP) {
                 return onBootstrap(data);
+            } else if(phase == BIND) {
+                internalBind(data);
+                return onBind(data);
             } else if(phase == DISCOVER) {
                 return onDiscover(data);
             } else if(phase == START) {
@@ -29,12 +36,24 @@ namespace ggapi {
             }
         }
 
+        void internalBind(Struct data) {
+            _config = getScope().anchor(data.get<ggapi::Struct>(CONFIG));
+        }
+
     public:
-        static const StringOrd BOOTSTRAP;
-        static const StringOrd DISCOVER;
-        static const StringOrd START;
-        static const StringOrd RUN;
-        static const StringOrd TERMINATE;
+        // Lifecycle constants
+        inline static const Symbol BOOTSTRAP{"bootstrap"};
+        inline static const Symbol BIND{"bind"};
+        inline static const Symbol DISCOVER{"discover"};
+        inline static const Symbol START{"start"};
+        inline static const Symbol RUN{"run"};
+        inline static const Symbol TERMINATE{"terminate"};
+
+        // Lifecycle parameter constants
+        inline static const Symbol CONFIG_ROOT{"configRoot"};
+        inline static const Symbol CONFIG{"config"};
+        inline static const Symbol NUCLEUS_CONFIG{"nucleus"};
+        inline static const Symbol NAME{"name"};
 
         Plugin() noexcept = default;
         Plugin(const Plugin &) = delete;
@@ -47,11 +66,11 @@ namespace ggapi {
             // No exceptions may cross API boundary
             // Return true if handled.
             return trapErrorReturn<bool>([this, moduleHandle, phase, data]() {
-                return lifecycle(ModuleScope{moduleHandle}, StringOrd{phase}, Struct{data});
+                return lifecycle(ModuleScope{moduleHandle}, Symbol{phase}, Struct{data});
             });
         }
 
-        bool lifecycle(ModuleScope moduleScope, StringOrd phase, Struct data) {
+        bool lifecycle(ModuleScope moduleScope, Symbol phase, Struct data) {
             _moduleScope = moduleScope;
             _phase = phase;
             beforeLifecycle(phase, data);
@@ -60,69 +79,86 @@ namespace ggapi {
             return handled;
         }
 
-        //
-        // Retrieve scope of plugin
-        //
-        ModuleScope getScope() {
+        /**
+         * Retrieve scope of plugin. Using getScope().anchor() will attach data to the module
+         * scope.
+         */
+        [[nodiscard]] ModuleScope getScope() const {
             return _moduleScope.load();
         }
 
-        //
-        // Current phase driven by lifecycle manager
-        //
-        StringOrd getCurrentPhase() {
+        /**
+         * Current phase driven by lifecycle manager
+         */
+        [[nodiscard]] Symbol getCurrentPhase() const {
             return _phase.load();
         }
 
-        virtual void beforeLifecycle(StringOrd phase, Struct data) {
+        /**
+         * Retrieve config space unique to the given plugin
+         */
+        [[nodiscard]] Struct getConfig() const {
+            return _config;
         }
 
-        virtual void afterLifecycle(StringOrd phase, Struct data) {
+        /**
+         * Hook to allow any pre-processing before lifecycle step
+         */
+        virtual void beforeLifecycle(Symbol phase, Struct data) {
         }
 
-        //
-        // For plugins discovered during bootstrap. Return true if handled.
-        // TODO: This may change
-        //
+        /**
+         * Hook to allow any post-processing after lifecycle step
+         */
+        virtual void afterLifecycle(Symbol phase, Struct data) {
+        }
+
+        /**
+         * For plugins discovered during bootstrap. Return true if handled. Typically a plugin
+         * will set the component name during this cycle.
+         * TODO: This may change
+         */
         virtual bool onBootstrap(Struct data) {
             return false;
         }
 
-        //
-        // For plugins discovered during bootstrap, permits discovering other
-        // plugins. Return true if handled.
-        // TODO: This may change
-        //
+        /**
+         * For plugins, after recipe has been read, but before any other
+         * lifecycle stages. Use this cycle for any data binding.
+         */
+        virtual bool onBind(Struct data) {
+            return false;
+        }
+
+        /**
+         * For plugins discovered during bootstrap, permits discovering other
+         * plugins. Return true if handled.
+         * TODO: This may change
+         */
         virtual bool onDiscover(Struct data) {
             return false;
         }
 
-        //
-        // Plugin is about to move into an active state. Return true if handled.
-        //
+        /**
+         * Plugin is about to move into an active state. Return true if handled.
+         */
         virtual bool onStart(Struct data) {
             return false;
         }
 
-        //
-        // Plugin has transitioned into an active state. Return true if handled.
-        //
+        /**
+         * Plugin has transitioned into an active state. Return true if handled.
+         */
         virtual bool onRun(Struct data) {
             return false;
         }
 
-        //
-        // Plugin is being terminated - use for cleanup. Return true if handled.
-        //
+        /**
+         * Plugin is being terminated - use for cleanup. Return true if handled.
+         */
         virtual bool onTerminate(Struct data) {
             return false;
         }
     };
-
-    inline const StringOrd Plugin::BOOTSTRAP{"bootstrap"};
-    inline const StringOrd Plugin::DISCOVER{"discover"};
-    inline const StringOrd Plugin::START{"start"};
-    inline const StringOrd Plugin::RUN{"run"};
-    inline const StringOrd Plugin::TERMINATE{"terminate"};
 
 } // namespace ggapi


### PR DESCRIPTION
This change allows plugins to specify their "service name", and standardizes how some useful config branches are passed to each plugin. The service-name is allowed to be changed in the "boostrap" cycle. In all other cycles, it is passed as one of the parameters.

This change also has some refactoring on how plugin lifecycles are called in preparation for more complex lifecycle management.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
