### PR TITLE
Fix! Zero length symbol fix

### DIFF
--- a/nucleus/tests/data/symbol_tests.cpp
+++ b/nucleus/tests/data/symbol_tests.cpp
@@ -60,6 +60,15 @@ SCENARIO("String ordinals are consistent", "[ordinal]") {
                 }
             }
         }
+        WHEN("Zero-length ordinal allocated") {
+            auto empty{symbols.intern("")};
+            THEN("The ordinals is non-null") {
+                REQUIRE(empty.asInt() != 0);
+            }
+            THEN("Ordinal value is empty") {
+                REQUIRE(empty.toString() == "");
+            }
+        }
     }
 }
 


### PR DESCRIPTION
With this update, Nucleus will again support zero-length symbols.

Prior to fix, when zero-length symbol is added, it would cause table find to break. Since we can assume there will always be a zero-length symbol (and it's practically free to add one), a zero-length symbol is added in a way that will prevent at(x) throwing an error when converting to a string-view.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
