### PR TITLE
Add MSVC version checks to root CMake list file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,10 @@ if(UNIX)
 endif()
 if(MSVC)
   if(MSVC_VERSION LESS 1910)
-    message(SEND_ERROR "Microsoft Visual Studio 2019 with support for C++17 std::variant is required")
+    message(
+      SEND_ERROR
+        "Microsoft Visual Studio 2019 with support for C++17 std::variant is required"
+    )
   endif()
   if(MSVC_TOOLSET_VERSION LESS 141)
     message(SEND_ERROR "MSVC Toolset v141 is required for std::variant support")


### PR DESCRIPTION
*Issue #, if available:*
Related to issue with building with MSVC in GitHub Actions
*Description of changes:*
Adds version checks against MSVC to query std::variant support, implemented by MSVC 19.10.
Source: https://en.cppreference.com/w/cpp/compiler_support/17

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
