### PR TITLE
Add module awareness in local scope - required for logging scope

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -74,5 +74,5 @@ Please do **not** create a public github issue.
 
 ## Licensing
 
-See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to
-confirm the licensing of your contribution.
+See the [LICENSE](../LICENSE) file for our project's licensing. We will ask you
+to confirm the licensing of your contribution.

--- a/nucleus/src/api/data.cpp
+++ b/nucleus/src/api/data.cpp
@@ -452,22 +452,31 @@ bool ggapiStructHasKey(uint32_t structHandle, uint32_t keyInt) noexcept {
     });
 }
 
-uint32_t ggapiGetSize(uint32_t handle) noexcept {
-    return ggapi::trapErrorReturn<uint32_t>([handle]() {
+uint32_t ggapiGetSize(uint32_t containerHandle) noexcept {
+    return ggapi::trapErrorReturn<uint32_t>([containerHandle]() {
         auto &context = scope::context();
-        auto ss{context.objFromInt<ContainerModelBase>(handle)};
+        auto ss{context.objFromInt<ContainerModelBase>(containerHandle)};
         return ss->size();
     });
 }
 
-bool ggapiStructIsEmpty(uint32_t handle) noexcept {
-    return ggapi::trapErrorReturn<bool>([handle]() {
-        if(!handle) {
+bool ggapiIsEmpty(uint32_t containerHandle) noexcept {
+    return ggapi::trapErrorReturn<bool>([containerHandle]() {
+        if(!containerHandle) {
             return true;
         }
         auto &context = scope::context();
-        auto ss{context.objFromInt<ContainerModelBase>(handle)};
+        auto ss{context.objFromInt<ContainerModelBase>(containerHandle)};
         return ss->empty();
+    });
+}
+
+uint32_t ggapiStructClone(uint32_t structHandle) noexcept {
+    return ggapi::trapErrorReturn<uint32_t>([structHandle]() {
+        auto &context = scope::context();
+        auto ss{context.objFromInt<StructModelBase>(structHandle)};
+        auto copy = ss->copy();
+        return scope::NucleusCallScopeContext::intHandle(copy);
     });
 }
 

--- a/nucleus/src/api/tasks.cpp
+++ b/nucleus/src/api/tasks.cpp
@@ -82,7 +82,7 @@ uint32_t ggapiCallAsync(uint32_t callStruct, uint32_t callbackHandle, uint32_t d
     return ggapi::trapErrorReturn<uint32_t>([callStruct, callbackHandle, delay]() {
         auto &context = scope::context();
         if(!callbackHandle) {
-            throw errors::InvalidCallbackError();
+            throw errors::CallbackError("Invalid callback handle");
         }
         auto callback = context.objFromInt<tasks::Callback>(callbackHandle);
         auto callDataStruct = context.objFromInt<data::StructModelBase>(callStruct);
@@ -107,11 +107,12 @@ uint32_t ggapiRegisterCallback(
     uintptr_t callbackCtx,
     uint32_t callbackType) noexcept {
     return ggapi::trapErrorReturn<uint32_t>([callbackFunction, callbackCtx, callbackType]() {
-        auto &context = scope::Context::get();
+        auto &context = scope::context();
+        auto module = scope::thread().getEffectiveModule();
         auto typeSymbol = context.symbolFromInt(callbackType);
         std::shared_ptr<tasks::RegisteredCallback> callback =
             std::make_shared<tasks::RegisteredCallback>(
-                context.baseRef(), typeSymbol, callbackFunction, callbackCtx);
+                context.baseRef(), module, typeSymbol, callbackFunction, callbackCtx);
         return scope::NucleusCallScopeContext::anchor(callback).asIntHandle();
     });
 }

--- a/nucleus/src/data/string_table.hpp
+++ b/nucleus/src/data/string_table.hpp
@@ -216,7 +216,7 @@ namespace data {
         ~SymbolInit() = default;
 
         // NOLINTNEXTLINE(*-explicit-constructor)
-        SymbolInit(std::string_view constString) : _string(constString) {
+        SymbolInit(std::string_view constString) noexcept : _string(constString) {
         }
 
         std::string toString() const {

--- a/nucleus/src/errors/errors.hpp
+++ b/nucleus/src/errors/errors.hpp
@@ -99,11 +99,10 @@ namespace errors {
         }
     };
 
-    class InvalidCallbackError : public Error {
+    class CallbackError : public Error {
     public:
-        explicit InvalidCallbackError(
-            const std::string &what = "Invalid Callback specified") noexcept
-            : Error("InvalidCallbackError", what) {
+        explicit CallbackError(const std::string &what = "Callback error") noexcept
+            : Error("CallbackError", what) {
         }
     };
 
@@ -111,6 +110,25 @@ namespace errors {
     public:
         explicit JsonParseError(const std::string &what = "Unable to parse JSON") noexcept
             : Error("JsonParseError", what) {
+        }
+    };
+
+    class CommandLineArgumentError : public Error {
+    public:
+        explicit CommandLineArgumentError(const std::string &what) noexcept
+            : Error("CommandLineArgumentError", what) {
+        }
+    };
+
+    class BootError : public Error {
+    public:
+        explicit BootError(const std::string &what) noexcept : Error("BootError", what) {
+        }
+    };
+
+    class ModuleError : public Error {
+    public:
+        explicit ModuleError(const std::string &what) noexcept : Error("ModuleError", what) {
         }
     };
 

--- a/nucleus/src/lifecycle/kernel.cpp
+++ b/nucleus/src/lifecycle/kernel.cpp
@@ -10,8 +10,8 @@
 namespace lifecycle {
     //
     // GG-Interop:
-    // GG-Java tightly couples Kernel and KernelLifecycle, this class combines functionality from
-    // both. Also, some functionality from KernelCommandLine is moved here.
+    // GG-Java tightly couples Kernel and KernelLifecycle, this class combines functionality
+    // from both. Also, some functionality from KernelCommandLine is moved here.
     //
 
     Kernel::Kernel(const std::shared_ptr<scope::Context> &context) : _context(context) {

--- a/nucleus/src/lifecycle/sys_properties.hpp
+++ b/nucleus/src/lifecycle/sys_properties.hpp
@@ -3,6 +3,7 @@
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
+#include <string>
 
 namespace lifecycle {
     class SysProperties {

--- a/nucleus/src/scope/call_scope.hpp
+++ b/nucleus/src/scope/call_scope.hpp
@@ -7,7 +7,7 @@ namespace scope {
 
     /**
      * A scope that is intended to be stack based, is split into two, and should be used
-     * via the CallScope stack class.
+     * via the CallScope stack class. It provides a localized set of handle anchors
      */
     class CallScope : public data::TrackingScope {
         data::ObjHandle _self;

--- a/nucleus/src/tasks/task.hpp
+++ b/nucleus/src/tasks/task.hpp
@@ -161,6 +161,7 @@ namespace tasks {
         CurrentTaskScope &operator=(CurrentTaskScope &&) = delete;
         ~CurrentTaskScope();
     };
+
     class SubTask : public util::RefObject<SubTask> {
     protected:
         std::shared_ptr<TaskThread> _threadAffinity;

--- a/nucleus/src/tasks/task_callbacks.cpp
+++ b/nucleus/src/tasks/task_callbacks.cpp
@@ -1,12 +1,28 @@
 #include "task_callbacks.hpp"
 #include "data/struct_model.hpp"
+#include "errors/errors.hpp"
 #include "plugins/plugin_loader.hpp"
 #include "scope/context_full.hpp"
 #include "tasks/task.hpp"
 
 namespace tasks {
 
+    std::shared_ptr<plugins::AbstractPlugin> RegisteredCallback::getModule() const {
+        if(_module.has_value()) {
+            std::shared_ptr<plugins::AbstractPlugin> module{_module.value().lock()};
+            if(!module) {
+                throw errors::CallbackError("Target module unloaded");
+            }
+            return module;
+        } else {
+            return {};
+        }
+    }
+
     uint32_t RegisteredCallback::invoke(const CallbackPackedData &packed) {
+
+        auto module = getModule();
+        plugins::CurrentModuleScope moduleScope(module);
 
         // No mutex required as the member variables are immutable
         // Assume a scope was allocated prior to this call

--- a/plugin_api/include/c_api.h
+++ b/plugin_api/include/c_api.h
@@ -96,6 +96,7 @@ IMPEXP size_t ggapiStructGetStringLen(uint32_t structHandle, uint32_t keyInt) NO
 IMPEXP size_t
 ggapiStructGetString(uint32_t structHandle, uint32_t symInt, char *buffer, size_t buflen) NOEXCEPT;
 IMPEXP uint32_t ggapiStructGetHandle(uint32_t structHandle, uint32_t keyInt) NOEXCEPT;
+IMPEXP uint32_t ggapiStructClone(uint32_t structHandle) NOEXCEPT;
 IMPEXP bool ggapiListPutBool(uint32_t listHandle, int32_t idx, bool value) NOEXCEPT;
 IMPEXP bool ggapiListPutInt64(uint32_t listHandle, int32_t idx, uint64_t value) NOEXCEPT;
 IMPEXP bool ggapiListPutFloat64(uint32_t listHandle, int32_t idx, double value) NOEXCEPT;
@@ -124,8 +125,8 @@ IMPEXP bool ggapiBufferInsert(
 IMPEXP uint32_t
 ggapiBufferGet(uint32_t listHandle, int32_t idx, char *buffer, uint32_t buflen) NOEXCEPT;
 IMPEXP bool ggapiBufferResize(uint32_t structHandle, uint32_t newSize) NOEXCEPT;
-IMPEXP uint32_t ggapiGetSize(uint32_t structHandle) NOEXCEPT;
-IMPEXP bool ggapiStructIsEmpty(uint32_t structHandle) NOEXCEPT;
+IMPEXP bool ggapiIsEmpty(uint32_t containerHandle) NOEXCEPT;
+IMPEXP uint32_t ggapiGetSize(uint32_t containerHandle) NOEXCEPT;
 IMPEXP uint32_t ggapiAnchorHandle(uint32_t anchorHandle, uint32_t objectHandle) NOEXCEPT;
 IMPEXP bool ggapiReleaseHandle(uint32_t objectHandle) NOEXCEPT;
 IMPEXP uint32_t ggapiToJson(uint32_t containerHandle) NOEXCEPT;
@@ -134,6 +135,7 @@ IMPEXP uint32_t ggapiToYaml(uint32_t containerHandle) NOEXCEPT;
 IMPEXP uint32_t ggapiFromYaml(uint32_t bufferHandle) NOEXCEPT;
 IMPEXP uint32_t ggapiCreateCallScope() NOEXCEPT;
 IMPEXP uint32_t ggapiGetCurrentCallScope() NOEXCEPT;
+IMPEXP uint32_t ggapiGetCurrentModule() NOEXCEPT;
 IMPEXP uint32_t ggapiGetCurrentTask() NOEXCEPT;
 IMPEXP uint32_t
 ggapiSubscribeToTopic(uint32_t anchorHandle, uint32_t topic, uint32_t callbackHandle) NOEXCEPT;
@@ -155,6 +157,7 @@ IMPEXP bool ggapiSleep(uint32_t timeout) NOEXCEPT;
 IMPEXP bool ggapiCancelTask(uint32_t asyncTask) NOEXCEPT;
 IMPEXP uint32_t ggapiRegisterPlugin(
     uint32_t moduleHandle, uint32_t componentName, uint32_t callbackHandle) NOEXCEPT;
+IMPEXP uint32_t ggapiChangeModule(uint32_t moduleHandle) NOEXCEPT;
 IMPEXP uint32_t ggapiRegisterCallback(
     ggapiGenericCallback callbackFunction, uintptr_t callbackCtx, uint32_t callbackType) NOEXCEPT;
 

--- a/plugin_api/include/util.hpp
+++ b/plugin_api/include/util.hpp
@@ -56,10 +56,26 @@ namespace util {
         }
     }
 
+    inline int upperChar(int c) {
+        // important: ignore Locale to ensure portability
+        if(c >= 'a' && c <= 'z') {
+            return c - 'z' + 'A';
+        } else {
+            return c;
+        }
+    }
+
     inline std::string lower(std::string_view source) {
         std::string target;
         target.resize(source.size());
         std::transform(source.begin(), source.end(), target.begin(), lowerChar);
+        return target;
+    }
+
+    inline std::string upper(std::string_view source) {
+        std::string target;
+        target.resize(source.size());
+        std::transform(source.begin(), source.end(), target.begin(), upperChar);
         return target;
     }
 
@@ -223,12 +239,12 @@ namespace util {
     template<typename T>
     class RefObject : public std::enable_shared_from_this<T> {
     public:
-        ~RefObject() = default;
-        RefObject();
+        ~RefObject() noexcept = default;
+        RefObject() noexcept;
         RefObject(const RefObject &) = delete;
         RefObject(RefObject &&) noexcept = default;
         RefObject &operator=(const RefObject &) = delete;
-        RefObject &operator=(RefObject &&) noexcept = delete;
+        RefObject &operator=(RefObject &&) = delete;
 
         std::shared_ptr<const T> baseRef() const {
             return std::enable_shared_from_this<T>::shared_from_this();
@@ -249,7 +265,7 @@ namespace util {
     };
 
     template<typename T>
-    RefObject<T>::RefObject() {
+    RefObject<T>::RefObject() noexcept {
         static_assert(std::is_base_of_v<RefObject, T>);
     }
 


### PR DESCRIPTION
With this change, when Nucleus calls into a plugin, it maintains per-thread information of which module is called. This is used by logging to track logging configuration, but also used to prevent callbacks into unloaded plugins.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
