### PR TITLE
Fix command-line and SysProperties lints

### DIFF
--- a/nucleus/src/api/main.cpp
+++ b/nucleus/src/api/main.cpp
@@ -11,7 +11,11 @@ int ggapiMainThread(int argc, char *argv[], char *envp[]) noexcept {
     try {
         auto context = scope::context();
         if(envp != nullptr) {
-            context->sysProperties().parseEnv(envp);
+            auto end = envp;
+            while(*end != nullptr) {
+                ++end;
+            }
+            context->sysProperties().parseEnv({envp, static_cast<size_t>(end - envp)});
         }
         lifecycle::Kernel kernel{context};
         // limited scope
@@ -19,7 +23,7 @@ int ggapiMainThread(int argc, char *argv[], char *envp[]) noexcept {
             lifecycle::CommandLine commandLine{context, kernel};
             commandLine.parseEnv(context->sysProperties());
             if(argc > 0 && argv != nullptr) {
-                commandLine.parseArgs(argc, argv);
+                commandLine.parseRawProgramNameAndArgs({argv, static_cast<size_t>(argc)});
             }
             kernel.preLaunch(commandLine);
         }

--- a/nucleus/src/lifecycle/command_line.hpp
+++ b/nucleus/src/lifecycle/command_line.hpp
@@ -3,6 +3,7 @@
 #include "lifecycle/sys_properties.hpp"
 #include "scope/context.hpp"
 #include <optional>
+#include <util.hpp>
 
 namespace lifecycle {
 
@@ -27,9 +28,9 @@ namespace lifecycle {
             : scope::UsesContext(context), _kernel(kernel) {
         }
 
-        void parseEnv(SysProperties &sysProperties);
-        void parseHome(SysProperties &sysProperties);
-        void parseArgs(int argc, char *argv[]); // NOLINT(*-avoid-c-arrays)
+        void parseEnv(SysProperties &env);
+        void parseHome(SysProperties &env);
+        void parseRawProgramNameAndArgs(util::Span<char *>);
         void parseArgs(const std::vector<std::string> &args);
         void parseProgramName(std::string_view progName);
 

--- a/nucleus/src/lifecycle/sys_properties.cpp
+++ b/nucleus/src/lifecycle/sys_properties.cpp
@@ -1,30 +1,19 @@
 #include "sys_properties.hpp"
 
 namespace lifecycle {
-    void SysProperties::parseEnv(char *envp[]) { // NOLINT(*-avoid-c-arrays)
-        char **p = envp;
-        for(; *p != nullptr; ++p) { // NOLINT(*-pointer-arithmetic)
-            char *key = *p;
-            char *eq = key;
-            for(; *eq != 0; ++eq) { // NOLINT(*-pointer-arithmetic)
-                if(*eq == '=') {
-                    break;
-                }
-            }
-            if(*eq) {
-                put(std::string_view(key, eq - key),
-                    std::string_view(eq + 1)); // NOLINT(*-pointer-arithmetic)
+    void SysProperties::parseEnv(util::Span<char *> envs) {
+        for(std::string_view env : envs) {
+            if(auto pos = env.find('='); pos != std::string_view::npos) {
+                put(env.substr(0, pos), env.substr(pos + 1));
             } else {
-                put(std::string_view(key, eq - key), "");
+                put(env, {});
             }
         }
     }
 
     std::optional<std::string> SysProperties::get(std::string_view name) const {
         std::shared_lock guard{_mutex};
-        std::string key{name};
-        const auto &i = _cache.find(key);
-        if(i == _cache.end()) {
+        if(auto i = _cache.find(name); i == _cache.end()) {
             return {};
         } else {
             return i->second;
@@ -33,20 +22,19 @@ namespace lifecycle {
 
     bool SysProperties::exists(std::string_view name) const {
         std::shared_lock guard{_mutex};
-        std::string key{name};
-        const auto &i = _cache.find(key);
-        return i != _cache.end();
+        return _cache.find(name) != _cache.cend();
     }
 
-    void SysProperties::put(const std::string &name, const std::string &value) {
+    void SysProperties::put(std::string name, std::string value) {
         std::unique_lock guard{_mutex};
-        _cache.insert_or_assign(name, value);
+        _cache.insert_or_assign(std::move(name), std::move(value));
     }
 
     void SysProperties::remove(std::string_view name) {
         std::unique_lock guard{_mutex};
-        std::string key{name};
-        _cache.erase(key);
+        if(auto it = _cache.find(name); it != _cache.end()) {
+            _cache.erase(it);
+        }
     }
 
 } // namespace lifecycle

--- a/nucleus/src/lifecycle/sys_properties.hpp
+++ b/nucleus/src/lifecycle/sys_properties.hpp
@@ -4,25 +4,28 @@
 #include <optional>
 #include <shared_mutex>
 #include <string>
+#include <string_view>
+#include <util.hpp>
 
 namespace lifecycle {
+    using namespace std::string_view_literals;
     class SysProperties {
     private:
         mutable std::shared_mutex _mutex;
-        std::map<std::string, std::string> _cache;
+        std::map<std::string, std::string, std::less<>> _cache;
 
     public:
-        static constexpr auto HOME = {"HOME"};
+        static constexpr auto HOME = {"HOME"sv};
 
         SysProperties() = default;
 
-        void parseEnv(char *envp[]); // NOLINT(*-avoid-c-arrays)
+        void parseEnv(util::Span<char *> envs);
 
         std::optional<std::string> get(std::string_view name) const;
 
-        void put(const std::string &name, const std::string &value);
+        void put(std::string name, std::string value);
 
-        void put(std::string_view name, std::string_view value) {
+        inline void put(std::string_view name, std::string_view value) {
             put(std::string(name), std::string(value));
         }
 

--- a/nucleus/src/util/nucleus_paths.hpp
+++ b/nucleus/src/util/nucleus_paths.hpp
@@ -4,8 +4,10 @@
 #include <filesystem>
 #include <mutex>
 #include <shared_mutex>
+#include <string_view>
 
 namespace util {
+    using namespace std::string_view_literals;
     //
     // GG-Java has these in Util, but probably should be somewhere else
     //
@@ -21,31 +23,31 @@ namespace util {
         std::filesystem::path _kernelAltsPath;
         std::filesystem::path _cliIpcInfoPath;
         std::filesystem::path _binPath;
-        static constexpr auto HOME_DIR_PREFIX{"~/"};
-        static constexpr auto ROOT_DIR_PREFIX{"~root/"};
-        static constexpr auto CONFIG_DIR_PREFIX{"~config/"};
-        static constexpr auto PACKAGE_DIR_PREFIX{"~packages/"};
+        static constexpr auto HOME_DIR_PREFIX{"~/"sv};
+        static constexpr auto ROOT_DIR_PREFIX{"~root/"sv};
+        static constexpr auto CONFIG_DIR_PREFIX{"~config/"sv};
+        static constexpr auto PACKAGE_DIR_PREFIX{"~packages/"sv};
 
     public:
-        static constexpr auto PLUGINS_DIRECTORY{"plugins"};
-        static constexpr auto ARTIFACT_DIRECTORY{"artifacts"};
-        static constexpr auto RECIPE_DIRECTORY{"recipes"};
-        static constexpr auto DEFAULT_LOGS_DIRECTORY{"logs"};
-        static constexpr auto ARTIFACTS_DECOMPRESSED_DIRECTORY{"artifacts-unarchived"};
-        static constexpr auto CONFIG_PATH_NAME{"config"};
-        static constexpr auto WORK_PATH_NAME{"work"};
-        static constexpr auto PACKAGES_PATH_NAME{"packages"};
-        static constexpr auto ALTS_PATH_NAME{"alts"};
-        static constexpr auto DEPLOYMENTS_PATH_NAME{"deployments"};
-        static constexpr auto CLI_IPC_INFO_PATH_NAME{"cli_ipc_info"};
-        static constexpr auto BIN_PATH_NAME{"bin"};
-        static constexpr auto CURRENT_DIR{"current"};
-        static constexpr auto OLD_DIR{"old"};
-        static constexpr auto NEW_DIR{"new"};
-        static constexpr auto BROKEN_DIR{"broken"};
-        static constexpr auto INITIAL_SETUP_DIR{"init"};
-        static constexpr auto KERNEL_LIB_DIR{"lib"};
-        static constexpr auto LOADER_PID_FILE{"loader.pid"};
+        static constexpr auto PLUGINS_DIRECTORY{"plugins"sv};
+        static constexpr auto ARTIFACT_DIRECTORY{"artifacts"sv};
+        static constexpr auto RECIPE_DIRECTORY{"recipes"sv};
+        static constexpr auto DEFAULT_LOGS_DIRECTORY{"logs"sv};
+        static constexpr auto ARTIFACTS_DECOMPRESSED_DIRECTORY{"artifacts-unarchived"sv};
+        static constexpr auto CONFIG_PATH_NAME{"config"sv};
+        static constexpr auto WORK_PATH_NAME{"work"sv};
+        static constexpr auto PACKAGES_PATH_NAME{"packages"sv};
+        static constexpr auto ALTS_PATH_NAME{"alts"sv};
+        static constexpr auto DEPLOYMENTS_PATH_NAME{"deployments"sv};
+        static constexpr auto CLI_IPC_INFO_PATH_NAME{"cli_ipc_info"sv};
+        static constexpr auto BIN_PATH_NAME{"bin"sv};
+        static constexpr auto CURRENT_DIR{"current"sv};
+        static constexpr auto OLD_DIR{"old"sv};
+        static constexpr auto NEW_DIR{"new"sv};
+        static constexpr auto BROKEN_DIR{"broken"sv};
+        static constexpr auto INITIAL_SETUP_DIR{"init"sv};
+        static constexpr auto KERNEL_LIB_DIR{"lib"sv};
+        static constexpr auto LOADER_PID_FILE{"loader.pid"sv};
 
         static void createPath(const std::filesystem::path &path);
 

--- a/plugin_api/include/util.hpp
+++ b/plugin_api/include/util.hpp
@@ -221,6 +221,14 @@ namespace util {
             return bounded_copy(s_first, s_last, begin(), end());
         }
 
+        inline constexpr reference front() const noexcept {
+            return *data();
+        }
+
+        inline constexpr reference back() const noexcept {
+            return *std::prev(end());
+        }
+
         constexpr Span first(size_type n) const noexcept {
             return {data(), n};
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix lints in command_line.cpp/hpp and sys_properties.cpp/hpp
also changes char * constants to string_view constants to avoid type erasure (char * discards length of a string literal, which is char[N]);

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
