### PR TITLE
Fix calling convention of callback parameter

### DIFF
--- a/plugins/ipc_server/src/HeaderValue.hpp
+++ b/plugins/ipc_server/src/HeaderValue.hpp
@@ -265,9 +265,11 @@ static int sendMessage(
     return fn(&args);
 }
 
+extern "C" {
 static void onMessageFlush(int error_code, void *user_data) noexcept {
     std::ignore = user_data;
     std::ignore = error_code;
+}
 }
 
 namespace Headers {

--- a/plugins/ipc_server/src/server_continuation.cpp
+++ b/plugins/ipc_server/src/server_continuation.cpp
@@ -59,7 +59,7 @@ ggapi::Struct ServerContinuation::onTopicResponse(
     return ggapi::Struct::create();
 }
 
-void ServerContinuation::onContinuation(
+extern "C" void ServerContinuationCCallbacks::onContinuation(
     aws_event_stream_rpc_server_continuation_token *token,
     const aws_event_stream_rpc_message_args *message_args,
     void *user_data) noexcept {
@@ -113,7 +113,7 @@ void ServerContinuation::onContinuation(
     }
 }
 
-void ServerContinuation::onContinuationClose(
+extern "C" void ServerContinuationCCallbacks::onContinuationClose(
     aws_event_stream_rpc_server_continuation_token *token, void *user_data) noexcept {
     // NOLINTNEXTLINE
     auto continuation = static_cast<ContinutationHandle>(user_data);

--- a/plugins/ipc_server/src/server_continuation.hpp
+++ b/plugins/ipc_server/src/server_continuation.hpp
@@ -4,7 +4,11 @@
 
 #include "HeaderValue.hpp"
 
+class ServerContinuationCCallbacks;
+
 class ServerContinuation {
+    friend ServerContinuationCCallbacks;
+
 public:
     using Token = aws_event_stream_rpc_server_continuation_token;
 
@@ -12,7 +16,6 @@ private:
     Token *_token;
     std::string _operation;
     ggapi::Channel _channel{};
-    using ContinutationHandle = std::shared_ptr<ServerContinuation> *;
 
 public:
     explicit ServerContinuation(Token *token, std::string operation)
@@ -40,7 +43,12 @@ public:
 
     static ggapi::Struct onTopicResponse(
         const std::weak_ptr<ServerContinuation> &weakSelf, ggapi::Struct response);
+};
 
+extern "C" class ServerContinuationCCallbacks {
+    using ContinutationHandle = std::shared_ptr<ServerContinuation> *;
+
+public:
     static void onContinuation(
         aws_event_stream_rpc_server_continuation_token *token,
         const aws_event_stream_rpc_message_args *message_args,

--- a/plugins/ipc_server/src/server_listener.hpp
+++ b/plugins/ipc_server/src/server_listener.hpp
@@ -8,11 +8,17 @@
 #include "server_bootstrap.hpp"
 #include "server_continuation.hpp"
 
+extern "C" {
 static void onListenerDestroy(
     aws_event_stream_rpc_server_listener *server, void *user_data) noexcept {
 }
+}
+
+class ServerListenerCCallbacks;
 
 class ServerListener {
+    friend ServerListenerCCallbacks;
+
 public:
     using Connection = aws_event_stream_rpc_server_connection;
 
@@ -60,7 +66,10 @@ public:
         std::string_view message,
         aws_event_stream_rpc_message_type error_type,
         uint32_t flags);
+};
 
+class ServerListenerCCallbacks {
+public:
     static int onNewServerConnection(
         aws_event_stream_rpc_server_connection *connection,
         int error_code,


### PR DESCRIPTION
Functions with C linkage are different types from functions with C++
linkage. Calling a C++ linkage function from a C translation unit is
undefined behavior. Parameters that take a function pointer with C
linkage should only be passed function pointers with C linkage. GCC and
Clang do not warn about this.