### PR TITLE
Fix race in example onRun and onTerminate

### DIFF
--- a/plugins/example_mqtt_sender/tests/test_mqtt_pub_sub.cpp
+++ b/plugins/example_mqtt_sender/tests/test_mqtt_pub_sub.cpp
@@ -69,6 +69,7 @@ SCENARIO("Example Mqtt Sender pub/sub", "[pubsub]") {
                 expected.put(keys.topicName, "hello");
                 expected.put(keys.qos, 1);
                 expected.put(keys.payload, "Hello world!");
+
                 THEN("The listener's publish handler is called") {
                     REQUIRE_CALL(
                         mockListener, publishHandler(mock::_, mock::_, pubStructMatcher(expected)))
@@ -77,9 +78,6 @@ SCENARIO("Example Mqtt Sender pub/sub", "[pubsub]") {
 
                     // start the lifecycle
                     CHECK(sender.startLifecycle());
-
-                    // wait for the lifecycle to start
-                    sender.wait();
                 }
             }
 
@@ -124,9 +122,6 @@ SCENARIO("Example Mqtt Sender pub/sub", "[pubsub]") {
 
                     // start the lifecycle
                     CHECK(sender.startLifecycle());
-
-                    // wait for the lifecycle to start
-                    sender.wait();
                 }
             }
 

--- a/plugins/example_mqtt_sender/tests/test_util.hpp
+++ b/plugins/example_mqtt_sender/tests/test_util.hpp
@@ -34,17 +34,15 @@ public:
     bool stopLifecycle() {
         return executePhase("terminate");
     }
-
-    void wait() {
-        std::unique_lock<std::mutex> lock(_mtx);
-        _cv.wait(lock, [this] { return _running.load(); });
-        using namespace std::chrono_literals;
-        std::this_thread::sleep_for(0.5s);
-    }
 };
 
 class PubSubCallback {
 public:
+    constexpr PubSubCallback() noexcept = default;
+    constexpr PubSubCallback(const PubSubCallback &) noexcept = default;
+    PubSubCallback(PubSubCallback &&) = delete;
+    PubSubCallback &operator=(const PubSubCallback &) noexcept = default;
+    PubSubCallback &operator=(PubSubCallback &&) = delete;
     virtual ~PubSubCallback() = default;
     virtual ggapi::Struct publishHandler(ggapi::Task, ggapi::Symbol, ggapi::Struct) = 0;
     virtual ggapi::Struct subscribeHandler(ggapi::Task, ggapi::Symbol, ggapi::Struct) = 0;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Move the usage of a condition variable into the base plugin class' OnRun.
Move the notification of the condition variable after completing the first publish.
Remove sleeps which apparently pass the pub/sub tests despite race conditions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
