### PR TITLE
Start of making std::shared_ptr safe

### DIFF
--- a/nucleus/src/plugins/plugin_loader.hpp
+++ b/nucleus/src/plugins/plugin_loader.hpp
@@ -100,8 +100,8 @@ namespace plugins {
         //
     private:
         mutable std::shared_mutex _mutex;
-        std::weak_ptr<AbstractPlugin> _parent;
-        std::shared_ptr<tasks::Callback> _callback;
+        const std::weak_ptr<AbstractPlugin> _parent;
+        const std::shared_ptr<tasks::Callback> _callback;
 
     public:
         explicit DelegatePlugin(

--- a/nucleus/src/pubsub/local_topics.hpp
+++ b/nucleus/src/pubsub/local_topics.hpp
@@ -28,8 +28,8 @@ namespace pubsub {
 
     class TopicSubTask : public tasks::SubTask {
     private:
-        data::Symbol _topic;
-        std::shared_ptr<tasks::Callback> _callback;
+        const data::Symbol _topic;
+        const std::shared_ptr<tasks::Callback> _callback;
 
     public:
         explicit TopicSubTask(
@@ -47,9 +47,9 @@ namespace pubsub {
     //
     class Listener : public data::TrackedObject {
     private:
-        data::Symbol _topic;
-        std::weak_ptr<Listeners> _parent;
-        std::shared_ptr<tasks::Callback> _callback;
+        const data::Symbol _topic;
+        const std::weak_ptr<Listeners> _parent;
+        const std::shared_ptr<tasks::Callback> _callback;
 
     public:
         using BadCastError = errors::InvalidSubscriberError;
@@ -77,7 +77,7 @@ namespace pubsub {
     class Listeners : public util::RefObject<Listeners>, protected scope::UsesContext {
     private:
         data::Symbol _topic;
-        std::vector<std::weak_ptr<Listener>> _listeners;
+        std::vector<std::weak_ptr<Listener>> _listeners; // Protected by mutex
         PubSubManager &manager() const {
             return context()->lpcTopics();
         }

--- a/nucleus/src/scope/call_scope.cpp
+++ b/nucleus/src/scope/call_scope.cpp
@@ -10,6 +10,8 @@ namespace scope {
         const std::shared_ptr<scope::CallScope> &priorScope) {
         auto newScope{std::make_shared<CallScope>(context, owningContext, priorScope)};
         auto selfAnchor = root->anchor(newScope);
+        // TODO: Once set, 'self' doesn't change until destruction
+        // Need to have a way of enforcing this
         newScope->setSelf(selfAnchor.getHandle());
         return newScope;
     }

--- a/nucleus/src/scope/call_scope.hpp
+++ b/nucleus/src/scope/call_scope.hpp
@@ -11,8 +11,8 @@ namespace scope {
      */
     class CallScope : public data::TrackingScope {
         data::ObjHandle _self;
-        std::weak_ptr<scope::NucleusCallScopeContext> _owningContext;
-        std::weak_ptr<scope::CallScope> _priorScope;
+        const std::weak_ptr<scope::NucleusCallScopeContext> _owningContext;
+        const std::weak_ptr<scope::CallScope> _priorScope;
         mutable std::shared_mutex _mutex;
 
         void setSelf(const data::ObjHandle &handle) {

--- a/nucleus/src/scope/context.cpp
+++ b/nucleus/src/scope/context.cpp
@@ -130,7 +130,9 @@ namespace scope {
         return lazy()._loader;
     }
     logging::LogManager &Context::logManager() {
-        return *lazy()._logManager;
+        // TODO: normally this would not be safe, however we know logManager() will survive until
+        // context is destroyed. Even so, clean this up at some point
+        return *lazy()._logManager.load();
     }
     Context::~Context() {
         terminate();
@@ -360,7 +362,7 @@ namespace scope {
     void LazyContext::terminate() {
         _taskManager.shutdownAndWait();
         _configManager.publishQueue().stop();
-        _logManager->publishQueue()->stop();
+        _logManager.load()->publishQueue()->stop();
     }
 
     UsingContext::UsingContext() noexcept : _context(context()) {

--- a/nucleus/src/scope/context.hpp
+++ b/nucleus/src/scope/context.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "errors/errors.hpp"
+#include <atomic_shared.hpp>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -10,7 +11,6 @@ namespace scope {
     class ThreadContextContainer;
     class PerThreadContext;
     class NucleusCallScopeContext;
-    class CallScope;
 
     using ContextRef = std::shared_ptr<Context>;
     using WeakContext = std::weak_ptr<Context>;

--- a/nucleus/src/scope/context_glob.hpp
+++ b/nucleus/src/scope/context_glob.hpp
@@ -29,7 +29,7 @@ namespace scope {
         tasks::TaskManager _taskManager;
         pubsub::PubSubManager _lpcTopics;
         plugins::PluginLoader _loader;
-        std::shared_ptr<logging::LogManager> _logManager;
+        util::SafeSharedPtr<logging::LogManager> _logManager;
     };
 
 } // namespace scope

--- a/nucleus/src/scope/context_impl.hpp
+++ b/nucleus/src/scope/context_impl.hpp
@@ -75,9 +75,9 @@ namespace scope {
         }
 
     private:
-        std::weak_ptr<PerThreadContext> _threadContext;
-        std::shared_ptr<CallScope> _callScope;
-        std::shared_ptr<data::TrackingRoot> _scopeRoot;
+        const std::weak_ptr<PerThreadContext> _threadContext;
+        util::SafeSharedPtr<CallScope> _callScope;
+        util::SafeSharedPtr<data::TrackingRoot> _scopeRoot;
     };
 
     /**

--- a/plugin_api/CMakeLists.txt
+++ b/plugin_api/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
   include/scopes.hpp
   include/tasks_subscriptions.hpp
   include/util.hpp
-  include/error_tmpl.hpp)
+  include/error_tmpl.hpp
+  include/atomic_shared.hpp)
 
 target_include_directories(gg_plugin_api INTERFACE include)

--- a/plugin_api/include/atomic_shared.hpp
+++ b/plugin_api/include/atomic_shared.hpp
@@ -1,0 +1,77 @@
+#pragma once
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <type_traits>
+
+namespace util {
+
+    /**
+     * C++17 does not support std::atomic<std::shared_ptr<>>
+     */
+    template<typename T>
+    class SafeSharedPtr {
+        std::shared_ptr<T> _ptr;
+
+    public:
+        SafeSharedPtr() noexcept = default;
+        SafeSharedPtr(const SafeSharedPtr &other) noexcept {
+            store(other.load());
+        }
+        SafeSharedPtr(SafeSharedPtr &&other) noexcept {
+            store(std::move(other));
+        }
+        SafeSharedPtr &operator=(const SafeSharedPtr &other) noexcept {
+            store(other.load());
+            return *this;
+        }
+        SafeSharedPtr &operator=(SafeSharedPtr &&other) noexcept {
+            store(std::move(other));
+            return *this;
+        }
+        void reset() noexcept {
+            store({});
+        }
+        ~SafeSharedPtr() noexcept {
+            reset();
+        }
+        // NOLINTNEXTLINE(*-explicit-constructor)
+        SafeSharedPtr(const std::shared_ptr<T> &value) noexcept {
+            store(value);
+        }
+        // NOLINTNEXTLINE(*-explicit-constructor)
+        SafeSharedPtr &operator=(const std::shared_ptr<T> &value) noexcept {
+            store(value);
+            return *this;
+        }
+        // NOLINTNEXTLINE(*-explicit-constructor)
+        operator std::shared_ptr<T>() const noexcept {
+            return load();
+        }
+        std::shared_ptr<T> store(const std::shared_ptr<T> &value) {
+            std::atomic_store(&_ptr, value);
+            return value;
+        }
+        std::shared_ptr<T> load() const {
+            return std::atomic_load(&_ptr);
+        }
+
+        [[nodiscard]] bool operator==(const SafeSharedPtr<T> &other) const {
+            return load() == other.load();
+        }
+
+        [[nodiscard]] bool operator!=(const SafeSharedPtr<T> &other) const {
+            return load() != other.load();
+        }
+
+        [[nodiscard]] explicit operator bool() const {
+            return static_cast<bool>(load());
+        }
+
+        [[nodiscard]] bool operator!() const {
+            return !load();
+        }
+    };
+
+} // namespace util


### PR DESCRIPTION
std::atomic<std::shared_ptr<T>> is not added until C++20
However std::atomic_load and std::atomic_store are allowed.
This implementation is the start of fixing uses of std::shared_ptr. It is not complete, just setting the pattern.

Some pattern notes:
std::shared_ptr / std::weak_ptr is ok passed as a call/return value
util::SafeSharedPtr or "const std::shared_ptr" should be used for storage in objects that are used across multiple threads when otherwise not protected (e.g. std::vector<> may be protected with a mutex and therefore protects contained std::xxx)
Some objects shared across threads maintain weak back-references, these should be replaced with "const std::weak_ptr" to enforce they are read-only.

I.e. if std::shared_ptr / std::weak_ptr are only initialized in constuctor, use "const" to enforce it
If std::shared_ptr can be mutated and used cross-thread, use util::SafeSharedPtr
If neither apply, document single-threadedness