### PR TITLE
Clarify successful IPC close logs

### DIFF
--- a/plugins/ipc_server/src/server_listener.cpp
+++ b/plugins/ipc_server/src/server_listener.cpp
@@ -107,8 +107,14 @@ void ServerListenerCCallbacks::onServerConnectionShutdown(
     const std::scoped_lock<std::recursive_mutex> lock{thisConnection->stateMutex};
 
     thisConnection->underlyingConnection.remove(connection);
-    std::cerr << "[IPC] connection closed with " << connection << " with error code " << error_code
-              << '\n';
+
+    if(error_code == 1051) {
+        std::cerr << "[IPC] connection closed with " << connection << " successfully ("
+                  << error_code << ")" << std::endl;
+    } else {
+        std::cerr << "[IPC] connection closed with " << connection << " with error code "
+                  << error_code << std::endl;
+    }
 }
 
 void ServerListenerCCallbacks::onProtocolMessage(


### PR DESCRIPTION
Currently, on success, the log will print that it closed with error
1051. This is interpreted by readers of the log as an IPC failure.