### PR TITLE
Enable sanitize only on debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 
 # Safety
 if(NOT WIN32 AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -fsanitize=null")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=null")
 endif()
 
 # Uncomment to enable sanitizers - thread & address cannot be combined


### PR DESCRIPTION
Sanitize options are only intended on debug builds - they are intended for testing passes, and not production
We have to figure out how to improve this in future
Also the required library (ubsan) is not available on Windows, so added "NOT WIN32"
