### PR TITLE
Fix running tests out of IDE on Windows

### DIFF
--- a/nucleus/src/config/yaml_recipe.hpp
+++ b/nucleus/src/config/yaml_recipe.hpp
@@ -270,10 +270,10 @@ namespace config {
 
         void read(const std::filesystem::path &path) {
             std::ifstream stream{path};
-            stream.exceptions(std::ios::failbit | std::ios::badbit);
             if(!stream.is_open()) {
                 throw std::runtime_error("Unable to read config file");
             }
+            stream.exceptions(std::ios::failbit | std::ios::badbit);
             read(stream);
         }
 

--- a/nucleus/tests/deployment/recipe_tests.cpp
+++ b/nucleus/tests/deployment/recipe_tests.cpp
@@ -1,14 +1,15 @@
 #include "deployment/recipe_loader.hpp"
-#include "scope/context_full.hpp"
+#include "test_tools.hpp"
 #include <catch2/catch_all.hpp>
 
 using Catch::Matchers::Equals;
 
 SCENARIO("Recipe Reader", "[deployment]") {
+    auto samples = test::samples();
     GIVEN("An instance of recipe reader") {
         auto yaml_reader = deployment::RecipeLoader();
         WHEN("Reading a hello world recipe") {
-            auto recipe = yaml_reader.read("samples/hello_recipe.yml");
+            auto recipe = yaml_reader.read(samples / "hello_recipe.yml");
             THEN("The recipe is read") {
                 REQUIRE_THAT(recipe.formatVersion, Equals("2020-01-25"));
                 REQUIRE_THAT(recipe.componentName, Equals("com.example.HelloWorld"));
@@ -60,7 +61,7 @@ SCENARIO("Recipe Reader", "[deployment]") {
             }
         }
         WHEN("Reading a recipe with dependencies") {
-            auto recipe = yaml_reader.read("samples/sample1.yaml");
+            auto recipe = yaml_reader.read(samples / "sample1.yaml");
             THEN("The recipe is read") {
                 REQUIRE_THAT(recipe.formatVersion, Equals("2020-01-25"));
                 REQUIRE_THAT(recipe.componentName, Equals("com.example.HelloWorld"));
@@ -119,7 +120,7 @@ SCENARIO("Recipe Reader", "[deployment]") {
             }
         }
         WHEN("Reading a recipe with artifacts") {
-            auto recipe = yaml_reader.read("samples/plugin_recipe.yaml");
+            auto recipe = yaml_reader.read(samples / "plugin_recipe.yaml");
             THEN("The recipe is read") {
                 REQUIRE_THAT(recipe.getFormatVersion(), Equals("2020-01-25"));
                 REQUIRE_THAT(recipe.getComponentName(), Equals("aws.greengrass.some-plugin"));
@@ -165,7 +166,7 @@ SCENARIO("Recipe Reader", "[deployment]") {
         }
 
         WHEN("Reading a recipe with selections") {
-            auto recipe = yaml_reader.read("samples/selection_recipe.yml");
+            auto recipe = yaml_reader.read(samples / "selection_recipe.yml");
             THEN("The recipe is read") {
                 REQUIRE_THAT(recipe.formatVersion, Equals("2020-01-25"));
                 REQUIRE_THAT(recipe.componentName, Equals("com.example.HelloWorld"));

--- a/nucleus/tests/test_tools.hpp
+++ b/nucleus/tests/test_tools.hpp
@@ -4,6 +4,20 @@
 #include <random>
 
 namespace test {
+
+    //
+    // Access samples directory
+    //
+    inline std::filesystem::path samples() {
+        std::array<std::filesystem::path, 2> alts = {"samples", "../samples"};
+        for(const auto &alt : alts) {
+            if(std::filesystem::exists(alt)) {
+                return std::filesystem::absolute(alt);
+            }
+        }
+        throw std::runtime_error("Cannot find samples directory");
+    }
+
     //
     // Generate temporary directory for testing
     //
@@ -58,4 +72,5 @@ namespace test {
             remove();
         }
     };
+
 } // namespace test


### PR DESCRIPTION
When running Nucleus unit tests out of IDE on Windows, samples directory is not found. Added a simple helper to resolve this in a generic way. The test exposed that exception was thrown before path check, so fixed code path too.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
