### PR TITLE
making the plugin lifecycle functions protected to prevent direct cal…

### DIFF
--- a/plugin_api/include/plugin.hpp
+++ b/plugin_api/include/plugin.hpp
@@ -145,6 +145,8 @@ namespace ggapi {
             return _config;
         }
 
+    protected:
+        /** the lifecycle override interface should never be directly called so it is protected */
         /**
          * (Deprecated) Hook to allow any pre-processing before lifecycle step
          */


### PR DESCRIPTION
minor change to protect the plugin lifecycle worker functions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
