### PR TITLE
Add apiHandel back for cloud downloader's local scope

### DIFF
--- a/plugins/cloud_downloader/src/cloud_downloader.cpp
+++ b/plugins/cloud_downloader/src/cloud_downloader.cpp
@@ -10,7 +10,8 @@ constexpr static int TIME_OUT_MS = 5000;
 constexpr static int PORT_NUM = 443;
 const char* const THING_NAME_HEADER = "x-amzn-iot-thingname";
 
-// TODO: apiHandle is being pulled from iot_broker as a shared global. Fix in future.
+// TODO: apiHandle needs to be declared only once, version.script prevents it in linux
+// but does not work on mac
 static Aws::Crt::ApiHandle apiHandle{};
 
 /*


### PR DESCRIPTION
*Issue #, if available:*
Fixes the following error:

```
Fatal error condition occurred in /home/ubuntu/gglite_testing/aws-greengrass-lite/build/_deps/device-sdk-cpp-src/crt/aws-crt-cpp/crt/aws-c-http/source/http.c:549: s_library_initialized
Exiting Application
######
./bin/greengrass-lite(+0x7b0) [0xaaaac12507b0]
/lib/aarch64-linux-gnu/libc.so.6(__libc_start_main+0xe8) [0xffff89d93e10]
./bin/greengrass-lite(+0x6b4) [0xaaaac12506b4]
Aborted (core dumped)
```

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
