### PR TITLE
Disable plugin tests for Windows

### DIFF
--- a/plugins/cloud_downloader/CMakeLists.txt
+++ b/plugins/cloud_downloader/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 
 # Tests
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT WIN32)
   include(CTest)
 
   fetchContentAddCmake(Catch2 trompeloeil)

--- a/plugins/example_mqtt_sender/CMakeLists.txt
+++ b/plugins/example_mqtt_sender/CMakeLists.txt
@@ -31,7 +31,7 @@ install(TARGETS example_mqtt_sender DESTINATION plugins)
 
 # Tests
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT WIN32)
   include(CTest)
 
   fetchContentAddCmake(Catch2 trompeloeil)


### PR DESCRIPTION
Windows has a unique way of building static vs dynamic libraries. Some work is required to enable static linking for use by plugin tests - which is relatively low priority as long as tests get run at least on Linux. Disabling Windows plugin tests for now.
