### PR TITLE
fix: set request timestamp in deployment doc

### DIFF
--- a/nucleus/src/deployment/deployment_manager.cpp
+++ b/nucleus/src/deployment/deployment_manager.cpp
@@ -442,6 +442,8 @@ namespace deployment {
             deployment.deploymentType =
                 DeploymentTypeMap.lookup(deploymentStruct.get<std::string>("deploymentType"))
                     .value();
+            deployment.deploymentDocument.requestTimestamp = deploymentStruct.get<std::string>("requestTimestamp");
+
         } catch(std::exception &e) {
             LOG.atError("deployment")
                 .kv(DEPLOYMENT_ID_LOG_KEY, deployment.id)

--- a/plugins/cli_server/src/cli_server.cpp
+++ b/plugins/cli_server/src/cli_server.cpp
@@ -113,6 +113,7 @@ ggapi::Struct CliServer::createLocalDeploymentHandler(
     deployment.put(deploymentKeys.stageDetails, 0);
     deployment.put(deploymentKeys.errorStack, 0);
     deployment.put(deploymentKeys.errorTypes, 0);
+    deployment.put(deploymentKeys.requestTimestamp, static_cast<long>(std::time(0)));
 
     auto channel = getScope().anchor(ggapi::Channel::create());
     _subscriptions.emplace_back(requestId, channel, [](ggapi::Struct req) { return req; });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix using uninitialized value "deployment.deploymentDocument.timestamp".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
