### PR TITLE
fix(startable): properly get uid/gid from configuration

### DIFF
--- a/nucleus/src/platform_abstraction/linux/startable.cpp
+++ b/nucleus/src/platform_abstraction/linux/startable.cpp
@@ -27,13 +27,15 @@ namespace ipc {
         UserInfo user{};
         // uid setting only works as root or with root-like permissions
         // TODO: investigate. Probably need a root setuid daemon...
-        // or just ignore this step
+        // TODO: Remove restriction of getting user info to only root, when can alter as Non-root
+        // When Nucleus is not root, we skip gathering uid/gid for child process. Defaults to 0/0
+        // When child uid/gid is 0/0 (default), setUserInfo skips setting.
         if(getgid() == 0 && getuid() == 0) {
             if(_user.has_value()) {
                 if(_group.has_value()) {
-                    getUserInfo(*_user, *_group);
+                    user = getUserInfo(*_user, *_group);
                 } else {
-                    getUserInfo(*_user);
+                    user = getUserInfo(*_user);
                 }
             }
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 - properly set user var with returned uid/gid from getUserInfo function.
   - bug was that uid/gid was not being updated. UID/GID was always 0/0, meaning setUserInfo was always being skipped, which forked the child as same user and group as parent. (not being changing)
 - update TODO comment with proper information of why current implementation is the way it is by skipping as non-root

*Testing* 
 - confirmed in test component that effective user and group running component python script was the ```defaultRunWith posixUser``` in nucleus configuration
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
