### PR TITLE
chore: remove limitation of uid/gid setting to only root

### DIFF
--- a/nucleus/src/platform_abstraction/linux/permissions.cpp
+++ b/nucleus/src/platform_abstraction/linux/permissions.cpp
@@ -76,10 +76,10 @@ namespace ipc {
         // if either fail, aborting is safest to avoid creating
         // a privileged process
         if(setgid(user.gid) == -1) {
-            perror("setgid");
+            perror("setgid: Failed to set to the configured group");
             std::abort();
         } else if(setuid(user.uid) == -1) {
-            perror("setuid");
+            perror("setuid: Failed to set to the configured user");
             std::abort();
         }
     }

--- a/nucleus/src/platform_abstraction/linux/startable.cpp
+++ b/nucleus/src/platform_abstraction/linux/startable.cpp
@@ -25,18 +25,11 @@ namespace ipc {
 
         // Prepare to alter user permissions
         UserInfo user{};
-        // uid setting only works as root or with root-like permissions
-        // TODO: investigate. Probably need a root setuid daemon...
-        // TODO: Remove restriction of getting user info to only root, when can alter as Non-root
-        // When Nucleus is not root, we skip gathering uid/gid for child process. Defaults to 0/0
-        // When child uid/gid is 0/0 (default), setUserInfo skips setting.
-        if(getgid() == 0 && getuid() == 0) {
-            if(_user.has_value()) {
-                if(_group.has_value()) {
-                    user = getUserInfo(*_user, *_group);
-                } else {
-                    user = getUserInfo(*_user);
-                }
+        if(_user.has_value()) {
+            if(_group.has_value()) {
+                user = getUserInfo(*_user, *_group);
+            } else {
+                user = getUserInfo(*_user);
             }
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 - Remove the check for root when grabbing user info. *Before* if not root, then uid/gid default to 0, avoiding setting
  - we now always get user uid/gid, so we will always try and set
 - Update error throw from component / child process when setting fails
 
 
 When running as ```ubuntu``` with ```runAsDefault: posixUser: ggc_user:ggc_group```
 ```
{"loggerName":"com.aws.greengrass.lifecycle.Kernel","level":"WARN","timestamp":1709854728214,"event":"stderr","contexts":{"message":"setgid: Failed to set to the configured group: Operation not permitted\n","note":"testComponent"}}
 ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
