### PR TITLE
feat: add additional env variables for parity with Java

### DIFF
--- a/nucleus/src/lifecycle/kernel.cpp
+++ b/nucleus/src/lifecycle/kernel.cpp
@@ -422,6 +422,18 @@ namespace lifecycle {
             return _deviceConfiguration->getThingName().getString();
         };
 
+        auto getAWSRegion = [this]() -> std::string {
+            return _deviceConfiguration->getAWSRegion().getString();
+        };
+
+        auto getRootCAPath = [this]() -> std::string {
+            return _deviceConfiguration->getRootCAFilePath().getString();
+        };
+
+        auto getNucleusVersion = [this]() -> std::string {
+            return _deviceConfiguration->getNucleusVersion();
+        };
+
         // TODO: query TES plugin
         std::string container_uri = "http://localhost:8090/2016-11-01/credentialprovider/";
 
@@ -457,6 +469,10 @@ namespace lifecycle {
                 .addEnvironment("AWS_CONTAINER_CREDENTIALS_FULL_URI"s, std::move(container_uri))
                 .addEnvironment("AWS_CONTAINER_AUTHORIZATION_TOKEN"s, std::move(authToken))
                 .addEnvironment("AWS_IOT_THING_NAME"s, getThingName())
+                .addEnvironment("GG_ROOT_CA_PATH"s, getRootCAPath())
+                .addEnvironment("AWS_REGION"s, getAWSRegion())
+                .addEnvironment("AWS_DEFAULT_REGION"s, getAWSRegion())
+                .addEnvironment("GGC_VERSION"s, getNucleusVersion())
                 // TODO: Windows "run raw script" switch
                 .withArguments({"-c", std::move(script)})
                 // TODO: allow output to pass back to caller if subscription is specified


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Achieve parity with the environment variables set for component child processes in Java. This includes AWS_REGION, AWS_DEFAULT_REGION, GG_ROOT_CA_PATH, GGC_VERSION. These are set to their respective values from the device configuration.

*Testing*
Created a custom component that prints these env variables. They all print their respective expected values as per the provided config.

```
{"timestamp":1710461416646,"event":"stdout","contexts":{"message":"AWS_REGION is: us-west-2\nGG_ROOT_CA_PATH is: /home/ubuntu/repo/lite-dev/AmazonRootCA1.pem\nAWS_DEFAULT_REGION is: us-west-2\nGGC_VERSION is: 0.0.0\n","note":"com.example.SampleComponent"},"loggerName":"com.aws.greengrass.lifecycle.Kernel","level":"INFO"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
