### PR TITLE
Cross platform build of library

### DIFF
--- a/nucleus/CMakeLists.txt
+++ b/nucleus/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(Threads REQUIRED)
 fetchContentAddCmake(yaml-cpp)
 fetchContentAdd(rapidjson)
 
-add_compile_definitions(EXPORT_API)
+add_compile_definitions(EXPORT_NUCLEUS_API)
 
 if(UNIX)
   add_compile_definitions(USE_DLFCN)

--- a/plugin_api/include/c_api.h
+++ b/plugin_api/include/c_api.h
@@ -10,17 +10,18 @@
 #define NOEXCEPT
 #endif
 
+#pragma push_macro("IMPEXP")
+#define IMPORT_NUCLEUS_DECL
 #if defined(_WIN32)
-#define IMPORT __declspec(dllimport)
-#define EXPORT __declspec(dllexport)
+#define EXPORT_NUCLEUS_DECL __declspec(dllexport)
 #else
-#define IMPORT
-#define EXPORT __attribute__((visibility("default")))
+#define EXPORT_NUCLEUS_DECL __attribute__((visibility("default")))
 #endif
-#if defined(EXPORT_API)
-#define IMPEXP EXPORT
+// TODO: replace IMPEXP?
+#if defined(EXPORT_NUCLEUS_API)
+#define IMPEXP EXPORT_NUCLEUS_DECL
 #else
-#define IMPEXP IMPORT
+#define IMPEXP IMPORT_NUCLEUS_DECL
 #endif
 
 typedef uint32_t ggapiErrorKind; // Symbol representing kind of error, 0 = success
@@ -84,7 +85,7 @@ typedef ggapiErrorKind GgapiLifecycleFn(
     ggapiObjHandle data,
     bool *pWasHandled) NOEXCEPT;
 
-[[maybe_unused]] EXPORT GgapiLifecycleFn greengrass_lifecycle;
+[[maybe_unused]] EXPORT_NUCLEUS_DECL GgapiLifecycleFn greengrass_lifecycle;
 
 IMPEXP ggapiErrorKind
 ggapiSetError(ggapiErrorKind kind, ggapiCountedString what, ggapiDataLen len) NOEXCEPT;
@@ -232,4 +233,5 @@ IMPEXP uint32_t ggapiGetLogLevel(uint64_t *counter, uint32_t cachedLevel) NOEXCE
 IMPEXP bool ggapiSetLogLevel(uint32_t level) NOEXCEPT;
 IMPEXP bool ggapiLogEvent(uint32_t dataHandle) NOEXCEPT;
 
+#pragma pop_macro("IMPEXP")
 #endif // GG_PLUGIN_API

--- a/plugins/device-sdk/shared_obj/include/shared_device_sdk.hpp
+++ b/plugins/device-sdk/shared_obj/include/shared_device_sdk.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <aws/common/byte_order.h>
 #include <aws/common/logging.h>
 #include <aws/common/uuid.h>
@@ -29,20 +30,18 @@
 #include <aws/io/stream.h>
 #include <aws/iot/Mqtt5Client.h>
 
+#ifdef EXPORT_DEVICESDK_API
 #if defined(_WIN32)
-#define IMPORT __declspec(dllimport)
-#define EXPORT __declspec(dllexport)
+// Apparently defining this ends up breaking desired behavior (cause not understood)
+#define IMPEXP_DEVICE_SDK_API
 #else
-#define IMPORT
-#define EXPORT __attribute__((visibility("default")))
+#define IMPEXP_DEVICE_SDK_API __attribute__((visibility("default")))
 #endif
-
-#if defined(EXPORT_DEVICESDK_API)
-#define IMPEXP EXPORT
 #else
-#define IMPEXP IMPORT
+// Nothing needed for import
+#define IMPEXP_DEVICE_SDK_API
 #endif
 
 namespace util {
-    IMPEXP Aws::Crt::ApiHandle &getDeviceSdkApiHandle();
+    IMPEXP_DEVICE_SDK_API Aws::Crt::ApiHandle &getDeviceSdkApiHandle();
 } // namespace util


### PR DESCRIPTION
**Issue #, if available:**
With this change, Windows builds are working again, and also can build per-plugin tests

**Description of changes:**
Changed device_sdk macros in windows
refactored export macros in general
removed dllimport declspec - this is slightly slower, but enables linking

**Why is this change necessary:**
Keep development open

**How was this change tested:**
Ran through standard tests

**Any additional information or context required to review the change:**

**Checklist:**

- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [X] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
