### PR TITLE
Add -fno-semantic-interposition

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -71,6 +71,10 @@ endmacro()
 
 add_compile_options(-fno-common)
 
+if(LINUX)
+  add_compile_options(-fno-semantic-interposition)
+endif()
+
 # For all built shared-objects, request that exports are explicitly defined
 # Note, this isn't necessarily enough - see also version-script option
 if(UNIX)


### PR DESCRIPTION
With PIC enabled, clang defaults to somewhere between semantic
interposition fully enabled and disabled. GCC has it enabled. Since we
do not need interposition, we can disable it for consistency and for
improved optimization opportunities.
