### PR TITLE
Fix for actually executing the lambda provided by future.andThen()

### DIFF
--- a/nucleus/src/pubsub/promise.cpp
+++ b/nucleus/src/pubsub/promise.cpp
@@ -40,7 +40,7 @@ namespace pubsub {
     Promise::Promise(const scope::UsingContext &context) : FutureBase(context) {
     }
 
-    std::shared_ptr<Future> Promise::getFuture() {
+    std::shared_ptr<FutureBase> Promise::getFuture() {
         std::unique_lock guard{_mutex};
         auto f = _future.lock();
         if(f) {
@@ -79,6 +79,13 @@ namespace pubsub {
         callback->invokeFutureCallback(getFuture());
     }
 
+    void ErrorFuture::addCallback(const std::shared_ptr<tasks::Callback> &callback) {
+        callback->invokeFutureCallback(getFuture());
+    }
+    void ValueFuture::addCallback(const std::shared_ptr<tasks::Callback> &callback) {
+        callback->invokeFutureCallback(getFuture());
+    }
+
     bool Promise::isValid() const {
         std::shared_lock guard{_mutex};
         return _value.index() != 0;
@@ -113,8 +120,8 @@ namespace pubsub {
         return _promise->waitUntil(when);
     }
 
-    std::shared_ptr<Future> Future::getFuture() {
-        return ref<Future>();
+    std::shared_ptr<FutureBase> Future::getFuture() {
+        return ref<FutureBase>();
     }
 
 } // namespace pubsub

--- a/nucleus/src/pubsub/promise.hpp
+++ b/nucleus/src/pubsub/promise.hpp
@@ -26,7 +26,7 @@ namespace pubsub {
         virtual std::shared_ptr<data::ContainerModelBase> getValue() const = 0;
         virtual bool isValid() const = 0;
         virtual bool waitUntil(const tasks::ExpireTime &when) const = 0;
-        virtual std::shared_ptr<Future> getFuture() = 0;
+        virtual std::shared_ptr<FutureBase> getFuture() = 0;
         virtual void addCallback(const std::shared_ptr<tasks::Callback> &callback) = 0;
     };
 
@@ -50,11 +50,10 @@ namespace pubsub {
         bool waitUntil(const tasks::ExpireTime &) const override {
             return true;
         }
-        std::shared_ptr<Future> getFuture() override {
-            return ref<Future>();
+        std::shared_ptr<FutureBase> getFuture() override {
+            return ref<FutureBase>();
         }
-        void addCallback(const std::shared_ptr<tasks::Callback> &callback) override {
-        }
+        void addCallback(const std::shared_ptr<tasks::Callback> &callback) override;
     };
 
     /**
@@ -78,11 +77,10 @@ namespace pubsub {
         bool waitUntil(const tasks::ExpireTime &) const override {
             return true;
         }
-        std::shared_ptr<Future> getFuture() override {
-            return ref<Future>();
+        std::shared_ptr<FutureBase> getFuture() override {
+            return ref<FutureBase>();
         }
-        void addCallback(const std::shared_ptr<tasks::Callback> &callback) override {
-        }
+        void addCallback(const std::shared_ptr<tasks::Callback> &callback) override;
     };
 
     class Future : public FutureBase {
@@ -96,7 +94,7 @@ namespace pubsub {
         std::shared_ptr<data::ContainerModelBase> getValue() const override;
         bool isValid() const override;
         bool waitUntil(const tasks::ExpireTime &when) const override;
-        std::shared_ptr<Future> getFuture() override;
+        std::shared_ptr<FutureBase> getFuture() override;
         void addCallback(const std::shared_ptr<tasks::Callback> &callback) override;
     };
 
@@ -120,7 +118,7 @@ namespace pubsub {
     public:
         using BadCastError = errors::InvalidPromiseError;
         explicit Promise(const scope::UsingContext &context);
-        std::shared_ptr<Future> getFuture() override;
+        std::shared_ptr<FutureBase> getFuture() override;
         std::shared_ptr<data::ContainerModelBase> getValue() const override;
         void addCallback(const std::shared_ptr<tasks::Callback> &callback) override;
         bool isValid() const override;


### PR DESCRIPTION
**Issue #, if available:**
The cli server was not receiving ack on the deployment as it was wrapped on the .andThen's lambda.

**Description of changes:**

**Why is this change necessary:**
Provides deployment acknowledgement to the cli server

**How was this change tested:**
Manually deploying a component

**Any additional information or context required to review the change:**

**Checklist:**

- [x] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
