### PR TITLE
Remove reference cycle between Promise and Future

### DIFF
--- a/nucleus/src/api/pubsub.cpp
+++ b/nucleus/src/api/pubsub.cpp
@@ -5,6 +5,7 @@
 #include "tasks/task.hpp"
 #include "tasks/task_callbacks.hpp"
 #include <cpp_api.hpp>
+#include <exception>
 
 ggapiErrorKind ggapiIsSubscription(ggapiObjHandle handle, ggapiBool *pBool) noexcept {
     return apiImpl::catchErrorToKind([handle, pBool]() {
@@ -35,9 +36,7 @@ ggapiErrorKind ggapiCreatePromise(ggapiObjHandle *pHandle) noexcept {
 }
 
 ggapiErrorKind ggapiSubscribeToTopic(
-    ggapiSymbol topic,
-    ggapiObjHandle callbackHandle,
-    ggapiObjHandle *outListener) noexcept {
+    ggapiSymbol topic, ggapiObjHandle callbackHandle, ggapiObjHandle *outListener) noexcept {
 
     return apiImpl::catchErrorToKind([topic, callbackHandle, outListener]() {
         auto context = scope::context();
@@ -109,7 +108,7 @@ ggapiErrorKind ggapiPromiseSetError(
         auto kindSymbol = context->symbolFromInt(errorKind);
         std::string msg(str, strlen);
         auto promiseObj = context->objFromInt<pubsub::Promise>(promiseHandle);
-        promiseObj->setError(errors::Error(kindSymbol, msg));
+        promiseObj->setError(std::make_exception_ptr(errors::Error(kindSymbol, msg)));
     });
 }
 

--- a/nucleus/src/data/tracked_object.hpp
+++ b/nucleus/src/data/tracked_object.hpp
@@ -3,16 +3,8 @@
 #include "data/safe_handle.hpp"
 #include "errors/errors.hpp"
 #include "scope/context.hpp"
-#include <cstddef>
-#include <cstdint>
-#include <functional>
-#include <map>
 #include <memory>
-#include <mutex>
 #include <ref_object.hpp>
-#include <shared_mutex>
-#include <unordered_map>
-#include <vector>
 
 namespace data {
 

--- a/nucleus/src/pubsub/local_topics.cpp
+++ b/nucleus/src/pubsub/local_topics.cpp
@@ -1,5 +1,5 @@
 #include "local_topics.hpp"
-#include "scope/context_full.hpp"
+#include "scope/context_impl.hpp"
 #include "tasks/task.hpp"
 #include "tasks/task_callbacks.hpp"
 #include <shared_mutex>

--- a/nucleus/src/pubsub/promise.hpp
+++ b/nucleus/src/pubsub/promise.hpp
@@ -1,130 +1,92 @@
 #pragma once
-#include "data/handle_table.hpp"
-#include "data/safe_handle.hpp"
-#include "data/shared_struct.hpp"
-#include "data/string_table.hpp"
-#include "data/symbol_value_map.hpp"
-#include "errors/error_base.hpp"
-#include "scope/context.hpp"
-#include "tasks/task.hpp"
-#include <condition_variable>
-#include <functional>
-#include <map>
-#include <string>
-#include <variant>
-#include <vector>
+#include "data/tracked_object.hpp"
+#include <exception>
+#include <future>
+
+namespace tasks {
+    class ExpireTime;
+    class Callback;
+} // namespace tasks
+
+namespace data {
+    class ContainerModelBase;
+}
 
 namespace pubsub {
     class Future;
     class Promise;
 
+    struct PromiseCallbacks;
+
     class FutureBase : public data::TrackedObject {
 
     public:
         using BadCastError = errors::InvalidFutureError;
+
         explicit FutureBase(const scope::UsingContext &context);
+        virtual ~FutureBase() noexcept = default;
+        FutureBase(const FutureBase &) = delete;
+        FutureBase(FutureBase &&) = delete;
+        FutureBase &operator=(const FutureBase &) = delete;
+        FutureBase &operator=(FutureBase &&) = delete;
+
         virtual std::shared_ptr<data::ContainerModelBase> getValue() const = 0;
         virtual bool isValid() const = 0;
         virtual bool waitUntil(const tasks::ExpireTime &when) const = 0;
-        virtual std::shared_ptr<FutureBase> getFuture() = 0;
+        virtual std::shared_ptr<Future> getFuture() = 0;
         virtual void addCallback(const std::shared_ptr<tasks::Callback> &callback) = 0;
     };
 
-    /**
-     * Completed Future that wraps an error
-     */
-    class ErrorFuture : public FutureBase {
-        const errors::Error _error;
-
-    public:
-        explicit ErrorFuture(const scope::UsingContext &context, errors::Error error)
-            : FutureBase(context), _error(std::move(error)) {
-        }
-
-        std::shared_ptr<data::ContainerModelBase> getValue() const override {
-            throw _error;
-        }
-        bool isValid() const override {
-            return true;
-        }
-        bool waitUntil(const tasks::ExpireTime &) const override {
-            return true;
-        }
-        std::shared_ptr<FutureBase> getFuture() override {
-            return ref<FutureBase>();
-        }
-        void addCallback(const std::shared_ptr<tasks::Callback> &callback) override;
-    };
-
-    /**
-     * Completed Future that wraps a value
-     */
-    class ValueFuture : public FutureBase {
-        const std::shared_ptr<data::ContainerModelBase> _value;
-
-    public:
-        explicit ValueFuture(
-            const scope::UsingContext &context, std::shared_ptr<data::ContainerModelBase> value)
-            : FutureBase(context), _value(std::move(value)) {
-        }
-
-        std::shared_ptr<data::ContainerModelBase> getValue() const override {
-            return _value;
-        }
-        bool isValid() const override {
-            return true;
-        }
-        bool waitUntil(const tasks::ExpireTime &) const override {
-            return true;
-        }
-        std::shared_ptr<FutureBase> getFuture() override {
-            return ref<FutureBase>();
-        }
-        void addCallback(const std::shared_ptr<tasks::Callback> &callback) override;
-    };
-
     class Future : public FutureBase {
-        const std::shared_ptr<Promise> _promise;
-        friend class Promise;
+        std::shared_ptr<PromiseCallbacks> _callbacks;
+        std::shared_future<std::shared_ptr<data::ContainerModelBase>> _future;
 
     public:
         using BadCastError = errors::InvalidFutureError;
-        explicit Future(
-            const scope::UsingContext &context, const std::shared_ptr<Promise> &promise);
+
+        Future(
+            const scope::UsingContext &context,
+            std::shared_ptr<PromiseCallbacks> callbacks,
+            std::shared_future<std::shared_ptr<data::ContainerModelBase>> future);
+        std::shared_ptr<Future> getFuture() override;
+        ~Future() noexcept override;
+        Future(const Future &) = delete;
+        Future(Future &&) = delete;
+        Future &operator=(const Future &) = delete;
+        Future &operator=(Future &&) = delete;
+
         std::shared_ptr<data::ContainerModelBase> getValue() const override;
         bool isValid() const override;
         bool waitUntil(const tasks::ExpireTime &when) const override;
-        std::shared_ptr<FutureBase> getFuture() override;
         void addCallback(const std::shared_ptr<tasks::Callback> &callback) override;
     };
 
     class Promise : public FutureBase {
-
-        std::variant<std::monostate, std::shared_ptr<data::ContainerModelBase>, errors::Error>
-            _value;
-        mutable std::shared_mutex _mutex;
-        mutable std::condition_variable_any _fire;
-        std::weak_ptr<Future> _future;
-        std::vector<std::shared_ptr<tasks::Callback>> _callbacks;
+        std::promise<std::shared_ptr<data::ContainerModelBase>> _promise;
+        std::shared_future<std::shared_ptr<data::ContainerModelBase>> _future{
+            _promise.get_future().share()};
+        std::shared_ptr<PromiseCallbacks> _callbacks;
 
         template<typename T>
         void setAndFire(const T &value);
 
-        static std::shared_ptr<data::ContainerModelBase> handleValue(const std::monostate &);
-        static std::shared_ptr<data::ContainerModelBase> handleValue(
-            const std::shared_ptr<data::ContainerModelBase> &);
-        static std::shared_ptr<data::ContainerModelBase> handleValue(const errors::Error &);
-
     public:
         using BadCastError = errors::InvalidPromiseError;
+
         explicit Promise(const scope::UsingContext &context);
-        std::shared_ptr<FutureBase> getFuture() override;
+        ~Promise() noexcept override;
+        Promise(const Promise &) = delete;
+        Promise(Promise &&) = delete;
+        Promise &operator=(const Promise &) = delete;
+        Promise &operator=(Promise &&) = delete;
+
+        std::shared_ptr<Future> getFuture() override;
         std::shared_ptr<data::ContainerModelBase> getValue() const override;
         void addCallback(const std::shared_ptr<tasks::Callback> &callback) override;
         bool isValid() const override;
         bool waitUntil(const tasks::ExpireTime &when) const override;
         void setValue(const std::shared_ptr<data::ContainerModelBase> &value);
-        void setError(const errors::Error &error);
+        void setError(const std::exception_ptr &ex);
         void cancel();
     };
 

--- a/nucleus/src/tasks/task_callbacks.hpp
+++ b/nucleus/src/tasks/task_callbacks.hpp
@@ -1,8 +1,7 @@
 #pragma once
-#include "data/handle_table.hpp"
 #include "data/string_table.hpp"
+#include "data/tracked_object.hpp"
 #include <c_api.hpp>
-#include <utility>
 
 namespace data {
     class ContainerModelBase;
@@ -14,7 +13,8 @@ namespace plugins {
 
 namespace pubsub {
     class FutureBase;
-}
+    class Future;
+} // namespace pubsub
 
 namespace tasks {
     class Task;
@@ -47,7 +47,7 @@ namespace tasks {
             const data::Symbol &topic, const std::shared_ptr<data::ContainerModelBase> &data);
         uint32_t size() const override;
         void *data() override;
-        std::shared_ptr<pubsub::FutureBase> retVal() const;
+        std::shared_ptr<pubsub::Future> retVal() const;
     };
 
     class AsyncCallbackData : public CallbackPackedData {


### PR DESCRIPTION


**Issue #, if available:**

**Description of changes:**
Use std::promise and std::future for passing values/exceptions
Pass exceptions by std::exception_ptr
Use shared pointer to callbacks and callback mutex
Use private implementation idiom


**Why is this change necessary:**
Removes type hierarchy around Future
Fixes circular reference between Future and Promise
Detects common Promise/Future error conditions

**How was this change tested:**
With existing testing
Added an exception-passing test

**Any additional information or context required to review the change:**
Understanding of the C++ Futures library and how it relates to ggapi Future
https://en.cppreference.com/w/cpp/thread#Futures

**Checklist:**

- [ ] Updated the README if applicable
- [X] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [X] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
