### PR TITLE
Fix fetchContentAdd

### DIFF
--- a/utils/cmake/FetchContentFromDeps.cmake
+++ b/utils/cmake/FetchContentFromDeps.cmake
@@ -26,6 +26,7 @@ function(fetchContentAdd)
 
     string(TOLOWER "${name}" lower_name)
 
+    FetchContent_GetProperties(${name})
     if(NOT ${lower_name}_POPULATED)
       FetchContent_Populate(${name})
     endif()


### PR DESCRIPTION
A FetchContent_GetProperties call was missing to ensure variables are
available in the current scope.
