### PR TITLE
API Standard errors

### DIFF
--- a/plugin_api/CMakeLists.txt
+++ b/plugin_api/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(
   include/api_errors.hpp
   include/api_forwards.hpp
   include/api_logging.hpp
+  include/api_standard_errors.hpp
   include/archive.hpp
   include/atomic_shared.hpp
   include/buffer_stream.hpp

--- a/plugin_api/include/api_standard_errors.hpp
+++ b/plugin_api/include/api_standard_errors.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "api_errors.hpp"
+
+namespace ggapi {
+
+    /**
+     * Validation Error - e.g. IPC parameter validation
+     */
+    class ValidationError : public GgApiError {
+    public:
+        inline static const auto KIND = ggapi::Symbol("ValidationError");
+
+        explicit ValidationError(const std::string &what = "ValidationError") noexcept
+            : GgApiError(KIND, what) {
+        }
+    };
+
+    /**
+     * Access Denied Error - e.g. IPC access is denied
+     */
+    class AccessDeniedError : public GgApiError {
+    public:
+        inline static const auto KIND = ggapi::Symbol("AccessDenied");
+
+        explicit AccessDeniedError(const std::string &what = "AccessDenied") noexcept
+            : GgApiError(KIND, what) {
+        }
+    };
+
+    /**
+     * Operation is unsupported (typically used for IPC)
+     */
+    class UnsupportedOperationError : public GgApiError {
+    public:
+        inline static const auto KIND = ggapi::Symbol("UnsupportedOperation");
+
+        explicit UnsupportedOperationError(
+            const std::string &what = "UnsupportedOperation") noexcept
+            : GgApiError(KIND, what) {
+        }
+    };
+
+    /**
+     * Internal server error (typically used for IPC)
+     */
+    class InternalServerException : public GgApiError {
+    public:
+        inline static const auto KIND = ggapi::Symbol("InternalServerException");
+
+        explicit InternalServerException(
+            const std::string &what = "InternalServerException") noexcept
+            : GgApiError(KIND, what) {
+        }
+    };
+
+} // namespace ggapi


### PR DESCRIPTION
Add some well defined errors
A well defined error has a constant Kind
(TODO, each of these needs a shadow in Nucleus)

**Checklist:**

- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
