### PR TITLE
Improve IPC token cryptographic generation

### DIFF
--- a/plugins/ipc_server/CMakeLists.txt
+++ b/plugins/ipc_server/CMakeLists.txt
@@ -18,12 +18,12 @@ enable_warnings()
 add_library(
   ipc_server MODULE
   src/authentication_handler.cpp
-  src/authentication_handler.cpp
-  src/authentication_handler.hpp
   src/authentication_handler.hpp
   src/ipc_server.cpp
   src/ipc_server.hpp
   src/main.cpp
+  src/random_device.cpp
+  src/random_device.hpp
   src/server_bootstrap.cpp
   src/server_continuation.cpp
   src/server_continuation.hpp

--- a/plugins/ipc_server/src/authentication_handler.cpp
+++ b/plugins/ipc_server/src/authentication_handler.cpp
@@ -1,28 +1,61 @@
 #include "authentication_handler.hpp"
+#include "random_device.hpp"
 #include <algorithm>
+#include <mutex>
+#include <random>
 
-static constexpr int SEED = 123;
-
-std::string AuthenticationHandler::generateAuthToken(const std::string &serviceName) {
-    // SECURITY-TODO: Make random generation secure
+Token AuthenticationHandler::generateAuthToken(std::string serviceName) {
     static constexpr size_t TOKEN_LENGTH = 16;
-    std::string_view chars = "0123456789"
-                             "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    thread_local std::mt19937 rng{SEED};
-    auto dist = std::uniform_int_distribution{{}, chars.size() - 1};
+    // Base64
+    static constexpr std::string_view chars = "0123456789"
+                                              "+/"
+                                              "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                              "abcdefghijklmnopqrstuvwxyz";
+    ggpal::random_device rng;
+    auto dist = std::uniform_int_distribution<std::string_view::size_type>{0, chars.size() - 1};
     auto token = std::string(TOKEN_LENGTH, '\0');
-    std::generate_n(token.begin(), TOKEN_LENGTH, [&]() { return chars[dist(rng)]; });
-    _tokenMap.insert({token, serviceName});
-    return token;
+    std::generate(token.begin(), token.end(), [&] { return chars.at(dist(rng)); });
+
+    std::unique_lock guard{_mutex};
+    auto [iter, emplaced] = _tokenMap.emplace(serviceName + ":" + token, serviceName);
+    if(emplaced) {
+        try {
+            _serviceMap.emplace(std::move(serviceName), iter->first);
+        } catch(...) {
+            _tokenMap.erase(iter);
+            throw;
+        }
+    }
+    return iter->first;
 }
 
-bool AuthenticationHandler::authenticateRequest(const std::string &authToken) const {
-    if(_tokenMap.find(authToken) == _tokenMap.cend()) {
+bool AuthenticationHandler::authenticateRequest(const Token &authToken) const {
+    std::shared_lock guard{_mutex};
+    auto found = _tokenMap.find(authToken);
+    if(found == _tokenMap.cend()) {
         return false;
     }
-    const auto &serviceName = _tokenMap.at(authToken);
+    const auto &serviceName = found->second;
     if(serviceName.rfind("aws.greengrass", 0) != 0) {
         return false;
     }
     return true;
+}
+
+void AuthenticationHandler::revokeService(std::string const &serviceName) {
+    std::unique_lock guard{_mutex};
+    auto found = _serviceMap.find(serviceName);
+    if(found != _serviceMap.cend()) {
+        _tokenMap.erase(found->second);
+        _serviceMap.erase(found);
+    }
+}
+
+void AuthenticationHandler::revokeToken(const Token &token) {
+    std::unique_lock guard{_mutex};
+    auto found = _tokenMap.find(token);
+    if(found != _tokenMap.cend()) {
+        _serviceMap.erase(found->second);
+        _tokenMap.erase(found);
+    }
 }

--- a/plugins/ipc_server/src/authentication_handler.hpp
+++ b/plugins/ipc_server/src/authentication_handler.hpp
@@ -1,11 +1,46 @@
-#include <random>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
-class AuthenticationHandler {
-    std::unordered_map<std::string, std::string> _tokenMap;
+class Token {
+private:
+    std::string token;
 
 public:
-    std::string generateAuthToken(const std::string &serviceName);
-    bool authenticateRequest(const std::string &authToken) const;
+    Token() noexcept = default;
+    explicit Token(std::string token) noexcept : token{std::move(token)} {
+    }
+
+    explicit operator std::string const &() const noexcept {
+        return value();
+    }
+
+    [[nodiscard]] const std::string &value() const noexcept {
+        return token;
+    }
+
+    [[nodiscard]] friend bool operator==(const Token &lhs, const Token &rhs) noexcept {
+        return lhs.value() == rhs.value();
+    };
+};
+
+template<>
+struct std::hash<Token> {
+    ::std::size_t operator()(const Token &token) const noexcept {
+        return ::std::hash<::std::string>{}(token.value());
+    }
+};
+
+// TODO: authorize service to perform action
+class AuthenticationHandler {
+    std::unordered_map<Token, std::string> _tokenMap;
+    std::unordered_map<std::string, Token> _serviceMap;
+    mutable std::shared_mutex _mutex;
+
+public:
+    Token generateAuthToken(std::string serviceName);
+    bool authenticateRequest(const Token &authToken) const;
+    void revokeService(const std::string &serviceName);
+    void revokeToken(const Token &token);
 };

--- a/plugins/ipc_server/src/ipc_server.cpp
+++ b/plugins/ipc_server/src/ipc_server.cpp
@@ -38,10 +38,10 @@ ggapi::ObjHandle IpcServer::cliHandler(ggapi::Symbol, const ggapi::Container &re
     ggapi::Struct req{reqBase};
     auto serviceName = req.getValue<std::string>({keys.serviceName});
 
-    std::shared_lock guard{_mutex};
+    std::unique_lock guard{_mutex};
     auto resp = ggapi::Struct::create();
     resp.put(keys.socketPath, _socketPath);
-    resp.put(keys.cliAuthToken, _authHandler->generateAuthToken(serviceName));
+    resp.put(keys.cliAuthToken, _authHandler->generateAuthToken(serviceName).value());
     return resp;
 }
 

--- a/plugins/ipc_server/src/random_device.cpp
+++ b/plugins/ipc_server/src/random_device.cpp
@@ -1,0 +1,117 @@
+#include "random_device.hpp"
+
+// TODO: move into separate implementations inside platform abstraction
+
+// C++17 standard __has_include preprocessor directive
+#if __has_include(<unistd.h>) // detect POSIX platform
+#include <unistd.h> // defines _POSIX_VERSION
+#endif
+
+#if defined(__MINGW32__)
+#include <_mingw.h> // defines __MINGW64_VERSION_MAJOR
+#endif
+
+#if defined(_POSIX_VERSION) || defined(__CYGWIN__)
+#define HAS_DEV_RANDOM 1
+
+#include <fstream>
+
+[[maybe_unused]] static std::streamsize devRandomBytes(char *data, std::streamsize size) {
+    std::ifstream file;
+    // disable input buffering https://en.cppreference.com/w/cpp/io/basic_filebuf/setbuf
+    file.rdbuf()->pubsetbuf(nullptr, 0);
+    file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+    file.open("/dev/random", std::ios::binary | std::ios::in);
+    file.read(data, size);
+    return file.gcount();
+}
+
+#endif
+
+#if __has_include(<sys/random.h>) // detect platform with getrandom() available
+
+#include <array>
+#include <atomic>
+#include <cstring>
+#include <iterator>
+#include <sys/random.h> // getrandom()
+#include <system_error>
+
+ggpal::random_device::result_type ggpal::random_device::operator()() const {
+    static std::atomic_bool getrandomAvailable = true;
+    std::array<char, sizeof(result_type)> buffer{};
+    auto first = buffer.data();
+    auto last = buffer.data() + buffer.size();
+
+    if(getrandomAvailable.load()) {
+        while(first != last) {
+#ifndef GRND_RANDOM // Darwin
+            auto bytesWritten = getentropy(first, std::distance(first, last));
+#else
+            auto bytesWritten = getrandom(first, std::distance(first, last), GRND_RANDOM);
+#endif
+            if(bytesWritten < 0) {
+                if(errno == EINTR) {
+                    // syscall interrupted by signal
+                    continue;
+                } else if(errno == ENOSYS) {
+                    // fall back to opening /dev/random
+                    getrandomAvailable.store(false);
+                    break;
+                } else {
+                    throw std::system_error{errno, std::generic_category()};
+                }
+            } else {
+                std::advance(first, bytesWritten);
+            }
+        }
+    }
+
+    if(first != last) {
+        auto bytesWritten = devRandomBytes(first, std::distance(first, last));
+        std::advance(first, bytesWritten);
+        if(first != last) {
+            throw std::system_error{std::make_error_code(std::errc::io_error)};
+        }
+    }
+
+    result_type value;
+    std::memcpy(&value, buffer.data(), sizeof(value));
+    return value;
+}
+
+// POSIX platform (includes Cygwin or any other platform which emulates /dev/random as a
+// cryptographic entropy source)
+#elif defined(HAS_DEV_RANDOM)
+
+#include <array>
+#include <cstring>
+#include <limits>
+
+ggpal::random_device::result_type ggpal::random_device::operator()() const {
+    result_type result;
+    static_assert(sizeof(result) <= std::numeric_limits<std::streamsize>::max());
+    std::array<char, sizeof(result)> buffer{};
+    devRandomBytes(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+    std::memcpy(&result, buffer.data(), buffer.size());
+    return result;
+}
+
+// Windows implementation (cl; Visual Studio, or MinGW-w64)
+#elif defined(_MSC_FULL_VER) || defined(__MINGW64_VERSION_MAJOR)
+
+#define _CRT_RAND_S 1
+#include <stdlib.h>
+#include <system_error>
+
+ggpal::random_device::result_type ggpal::random_device::operator()() const {
+    static_assert(std::is_same_v<result_type, unsigned int>);
+    result_type result;
+    auto err = rand_s(&result);
+    if(err != 0) {
+        throw std::system_error{errno, std::generic_category()};
+    }
+    return result;
+}
+
+#endif

--- a/plugins/ipc_server/src/random_device.hpp
+++ b/plugins/ipc_server/src/random_device.hpp
@@ -1,0 +1,40 @@
+
+
+// TODO: move into platform abstraction
+
+#include <limits>
+#include <string>
+
+namespace ggpal {
+    // implements a platform-specific, cryptographically-secure random_device
+    class random_device {
+    public:
+        using result_type = unsigned int;
+
+        random_device() noexcept = default;
+        // compatibility with random_device, token ignored
+        explicit random_device(const std::string &) noexcept : ggpal::random_device{} {
+        }
+        ~random_device() noexcept = default;
+        random_device(const random_device &) = delete;
+        random_device(random_device &&) = delete;
+        random_device &operator=(const random_device &) = delete;
+        random_device &operator=(random_device &&) = delete;
+
+        // note: signature matches random_device::operator()
+        result_type operator()() const;
+
+        // NOLINTNEXTLINE(*-static) non-static definition conforms to C++11 standard
+        [[nodiscard]] double entropy() const noexcept {
+            return std::numeric_limits<result_type>::digits;
+        }
+
+        [[nodiscard]] static constexpr result_type min() noexcept {
+            return std::numeric_limits<result_type>::min();
+        }
+
+        [[nodiscard]] static constexpr result_type max() noexcept {
+            return std::numeric_limits<result_type>::max();
+        }
+    };
+} // namespace ggpal

--- a/utils/dictionary.txt
+++ b/utils/dictionary.txt
@@ -34,11 +34,13 @@ gdbinit
 ggapi
 ggdb
 gglite
+ggpal
 ggroot
 glldb
 greengrass
 greengrasscoreipc
 greengrassv2
+GRND
 Hasnt
 inlines
 iot


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use std::random_device with a cryptographic entropy source
Increase token characters from 36 to 64
Reduce probability of token collision

**Why is this change necessary:**
Fixes a SECURITY-TODO
Improves uniformity of random distribution

**How was this change tested:**
Observing token generation during local deployment

**Any additional information or context required to review the change:**

**Checklist:**

- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
