### PR TITLE
Improvements ready for IPC refactoring

### DIFF
--- a/nucleus/src/logging/log_manager.cpp
+++ b/nucleus/src/logging/log_manager.cpp
@@ -226,7 +226,7 @@ namespace logging {
 
     bool LogState::applyConfig(const LogConfigUpdate &source) {
         std::unique_lock guard{_mutex};
-        _level = source.getLevel().value_or(Level::Info);
+        _level = source.getLevel().value_or(DEFAULT_LOG_LEVEL);
         _fileSizeKB = source.getFileSizeKB().value_or(DEFAULT_MAX_FILE_SIZE_KB);
         _totalLogsSizeKB = source.getTotalLogsSizeKB().value_or(DEFAULT_MAX_FILE_SIZE_ALL_KB);
         auto format = source.getFormat().value_or(Format::Text);

--- a/nucleus/src/logging/log_manager.hpp
+++ b/nucleus/src/logging/log_manager.hpp
@@ -76,13 +76,20 @@ namespace logging {
     };
 
     class LogState {
+
+#ifdef NDEBUG
+        constexpr static auto DEFAULT_LOG_LEVEL = Level::Info;
+#else
+        constexpr static auto DEFAULT_LOG_LEVEL = Level::Debug;
+#endif
+
         constexpr static std::string_view DEFAULT_LOG_BASE{"greengrass"};
         constexpr static std::string_view LOG_EXTENSION{".log"};
         constexpr static uint64_t DEFAULT_MAX_FILE_SIZE_KB{1024L};
         constexpr static uint64_t DEFAULT_MAX_FILE_SIZE_ALL_KB{DEFAULT_MAX_FILE_SIZE_KB * 10};
         mutable std::shared_mutex _mutex;
         std::string _contextName;
-        Level _level{Level::Info};
+        Level _level{DEFAULT_LOG_LEVEL};
         Format _format{Format::Text};
         OutputType _outputType{OutputType::Console}; // until file specified
         uint64_t _fileSizeKB{DEFAULT_MAX_FILE_SIZE_KB};

--- a/plugin_api/include/logging.hpp
+++ b/plugin_api/include/logging.hpp
@@ -512,7 +512,7 @@ namespace logging {
         /**
          * Version of logLazy that allows stream operations.
          */
-        void logStream(const std::function<void(std::stringstream &)> &fn) {
+        void logStream(const std::function<void(std::ostream &)> &fn) {
             logLazy([&]() {
                 std::stringstream stream;
                 fn(stream);

--- a/utils/gdb-extensions/greengrass-lite.py
+++ b/utils/gdb-extensions/greengrass-lite.py
@@ -555,17 +555,15 @@ class ObjHandleIterator(object):
 
     def __next__(self):
         (index, self._index) = (self._index, self._index + 1)
-        match index:
-            case 0:
-                return 'handle', 'ObjHandle{%d}' % int(
-                    self._lazy_obj.handle_id())  # helps CLion
-            case 1:
-                return 'object', self._lazy_obj.object_ptr().dereference()
-            case 2:
-                return 'root', 'RootHandle{%d}' % int(
-                    self._lazy_obj.root().handle_id())
-            case _:
-                raise StopIteration
+        if index == 0:
+            return 'handle', 'ObjHandle{%d}' % int(
+                self._lazy_obj.handle_id())  # helps CLion
+        if index == 1:
+            return 'object', self._lazy_obj.object_ptr().dereference()
+        if index == 2:
+            return 'root', 'RootHandle{%d}' % int(
+                self._lazy_obj.root().handle_id())
+        raise StopIteration
 
 
 #
@@ -663,26 +661,24 @@ class DynamicStructPrinter:
             str_name = str(DataSymbolPrinter(name).to_simple_string())
             gdb.set_convenience_variable('arg', name)
             val_type = int(self._struct.eval('get($arg).getType()'))
-            match val_type:
-                case 0:  # NONE
-                    val = '[null]'
-                case 1:  # BOOL
-                    val = self._struct.eval('get($arg).getBool()')
-                case 2:  # INT
-                    val = self._struct.eval('get($arg).getInt()')
-                case 3:  # DOUBLE
-                    val = self._struct.eval('get($arg).getDouble()')
-                case 4:  # STRING, SYMBOL
-                    val = self._struct.eval('get($arg).rawGetString()')
-                case 5:  # STRING, SYMBOL
-                    val = self._struct.eval('get($arg).rawGetSymbol()')
-                case 6:  # OBJECT
-                    obj = self._struct.eval(
-                        'get($arg).getObject().get()').cast(
-                            gdb.lookup_type('data::TrackedObject*'))
-                    val = obj.cast(obj.dynamic_type).dereference()
-                case _:
-                    val = '[Unknown]'
+            if val_type == 0:
+                val = '[null]'
+            elif val_type == 1:
+                val = self._struct.eval('get($arg).getBool()')
+            elif val_type == 2:
+                val = self._struct.eval('get($arg).getInt()')
+            elif val_type == 3:
+                val = self._struct.eval('get($arg).getDouble()')
+            elif val_type == 4:
+                val = self._struct.eval('get($arg).rawGetString()')
+            elif val_type == 5:
+                val = self._struct.eval('get($arg).rawGetSymbol()')
+            elif val_type == 6:
+                obj = self._struct.eval('get($arg).getObject().get()').cast(
+                    gdb.lookup_type('data::TrackedObject*'))
+                val = obj.cast(obj.dynamic_type).dereference()
+            else:
+                val = '[Unknown]'
 
             return str(str_name), val
 


### PR DESCRIPTION
Misc fixes ready for IPC refactoring

Logging - default logging level is increased for debug builds
Logging - adjustment to how stream-based log printer callback works
Futures - minor additions/fixes
Subscriptions - allow specifying data type - e.g. Struct (follow pattern introduced for Channel)

GDB hooks - remove use of "match" to allow running in earlier versions of gdb/python.
