### PR TITLE
Improved exception bouncing between Nucleus and Plugin

### DIFF
--- a/nucleus/src/api/api_error_trap.hpp
+++ b/nucleus/src/api/api_error_trap.hpp
@@ -9,14 +9,8 @@ namespace apiImpl {
         try {
             std::invoke(f, std::forward<Args>(args)...);
             return 0;
-        } catch(errors::Error &err) {
-            return err.toThreadLastError();
-        } catch(ggapi::GgApiError &err) {
-            return errors::Error::of<ggapi::GgApiError>(err).toThreadLastError();
-        } catch(std::exception &err) {
-            return errors::Error::of<std::exception>(err).toThreadLastError();
         } catch(...) {
-            return errors::Error::unspecified().toThreadLastError();
+            return errors::Error::of(std::current_exception()).toThreadLastError();
         }
     }
 

--- a/nucleus/src/deployment/deployment_manager.cpp
+++ b/nucleus/src/deployment/deployment_manager.cpp
@@ -183,8 +183,10 @@ namespace deployment {
     Recipe DeploymentManager::loadRecipeFile(const std::filesystem::path &recipeFile) {
         try {
             return _recipeLoader.read(recipeFile);
-        } catch(std::exception &e) {
-            LOG.atWarn("deployment").kv("DeploymentType", "LOCAL").logAndThrow(e);
+        } catch(...) {
+            LOG.atWarn("deployment")
+                .kv("DeploymentType", "LOCAL")
+                .logAndThrow(std::current_exception());
         }
     }
 
@@ -192,8 +194,10 @@ namespace deployment {
         const std::filesystem::path &recipeFile) {
         try {
             return _recipeLoader.readAsStruct(recipeFile);
-        } catch(std::exception &e) {
-            LOG.atWarn("deployment").kv("DeploymentType", "LOCAL").logAndThrow(e);
+        } catch(...) {
+            LOG.atWarn("deployment")
+                .kv("DeploymentType", "LOCAL")
+                .logAndThrow(std::current_exception());
         }
     }
 

--- a/nucleus/src/errors/error_base.cpp
+++ b/nucleus/src/errors/error_base.cpp
@@ -46,15 +46,7 @@ namespace errors {
         return scope::context()->symbols().intern(strKind);
     }
     traits::ErrorTraits::SymbolType traits::ErrorTraits::translateKind(
-        traits::ErrorTraits::SymbolType symKind) noexcept {
-        return symKind;
-    }
-    traits::ErrorTraits::SymbolType traits::ErrorTraits::translateKind(
         ggapiErrorKind intKind) noexcept {
         return scope::context()->symbolFromInt(intKind);
-    }
-    traits::ErrorTraits::SymbolType traits::ErrorTraits::translateKind(
-        ggapi::Symbol symKind) noexcept {
-        return translateKind(symKind.asInt());
     }
 } // namespace errors

--- a/nucleus/src/errors/error_base.hpp
+++ b/nucleus/src/errors/error_base.hpp
@@ -14,10 +14,8 @@ namespace errors {
     namespace traits {
         struct ErrorTraits {
             using SymbolType = data::Symbol;
-            static SymbolType translateKind(std::string_view strKind) noexcept;
-            static SymbolType translateKind(SymbolType symKind) noexcept;
-            static SymbolType translateKind(ggapi::Symbol symKind) noexcept;
             static SymbolType translateKind(ggapiErrorKind intKind) noexcept;
+            static SymbolType translateKind(std::string_view strKind) noexcept;
         };
     } // namespace traits
 

--- a/nucleus/src/plugins/plugin_loader.cpp
+++ b/nucleus/src/plugins/plugin_loader.cpp
@@ -37,6 +37,7 @@ namespace plugins {
 
     static std::runtime_error makePluginError(
         std::string_view description, const std::filesystem::path &path, std::string_view message) {
+        // TODO, this should be returning a GG error
         const auto pathStr = path.string();
         std::string what;
         what.reserve(description.size() + pathStr.size() + message.size() + 2U);
@@ -318,10 +319,10 @@ namespace plugins {
             auto recipePath = it->second;
             try {
                 return deployment::RecipeLoader{}.read(recipePath);
-            } catch(std::runtime_error &e) {
+            } catch(...) {
                 // pass
                 LOG.atWarn("recipe-not-loaded")
-                    .cause(e)
+                    .cause(std::current_exception())
                     .kv("path", recipePath.string())
                     .log("Unable to load recipe file");
             }

--- a/nucleus/src/tasks/task_threads.cpp
+++ b/nucleus/src/tasks/task_threads.cpp
@@ -47,14 +47,10 @@ namespace tasks {
         if(task) {
             try {
                 task->invoke();
-            } catch(const errors::Error &err) {
-                LOG.atError("asyncTaskError").cause(err).log("errors::Error thrown by async task");
-            } catch(const std::exception &exp) {
-                LOG.atError("asyncStdError")
-                    .cause(exp)
-                    .log("c++ exception thrown executing async task");
             } catch(...) {
-                LOG.atError("asyncUnknownError").log("Unrecognized exception");
+                LOG.atError("asyncStdError")
+                    .cause(std::current_exception())
+                    .log("c++ exception thrown executing async task");
             }
         } else {
             stall(ExpireTime::infinite());

--- a/nucleus/tests/errors/errors_test.cpp
+++ b/nucleus/tests/errors/errors_test.cpp
@@ -5,7 +5,7 @@
 SCENARIO("Last error is invariant in thread", "[errors]") {
     GIVEN("Thread is in an error state") {
         std::runtime_error cpp_err{"Some error text"};
-        errors::Error err{errors::Error::of(cpp_err)};
+        errors::Error err{errors::Error::of(std::make_exception_ptr(cpp_err))};
         errors::ThreadErrorContainer::get().setError(err);
         WHEN("Error is retrieved") {
             auto gotErr = errors::ThreadErrorContainer::get().getError();
@@ -15,7 +15,7 @@ SCENARIO("Last error is invariant in thread", "[errors]") {
                 // The platform safe way is to use typeid
                 // When manually testing, this was string like "std13runtime_error"
                 std::string kindName = gotErr.value().kind().toString();
-                REQUIRE(kindName == typeid(std::runtime_error).name());
+                REQUIRE(kindName == "std::runtime_error");
                 REQUIRE(
                     std::string_view(gotErr.value().what()) == std::string_view("Some error text"));
             }

--- a/plugin_api/include/api_errors.hpp
+++ b/plugin_api/include/api_errors.hpp
@@ -11,13 +11,10 @@ namespace ggapi {
     namespace traits {
         struct ErrorTraits {
             using SymbolType = ggapi::Symbol;
-            static SymbolType translateKind(SymbolType symKind) noexcept {
-                return symKind;
-            }
             static SymbolType translateKind(ggapiErrorKind intKind) noexcept {
                 return SymbolType(intKind);
             }
-            static SymbolType translateKind(const std::string &strKind) noexcept {
+            static SymbolType translateKind(const std::string_view &strKind) noexcept {
                 return {strKind};
             }
         };
@@ -37,15 +34,13 @@ namespace ggapi {
             } else {
                 return fn();
             }
-        } catch(std::exception &e) {
-            std::ignore = GgApiError::of(e).toThreadLastError();
         } catch(...) {
-            std::ignore = GgApiError::unspecified().toThreadLastError();
-        }
-        if constexpr(std::is_void_v<T>) {
-            return;
-        } else {
-            return static_cast<T>(0);
+            std::ignore = GgApiError::of(std::current_exception()).toThreadLastError();
+            if constexpr(std::is_void_v<T>) {
+                return;
+            } else {
+                return static_cast<T>(0);
+            }
         }
     }
 
@@ -79,12 +74,8 @@ namespace ggapi {
         try {
             std::invoke(std::forward<Func>(f), std::forward<Args>(args)...);
             return 0;
-        } catch(GgApiError &err) {
-            return err.toThreadLastError();
-        } catch(std::exception &err) {
-            return GgApiError::of<std::exception>(err).toThreadLastError();
         } catch(...) {
-            return GgApiError::unspecified().toThreadLastError();
+            return GgApiError::of(std::current_exception()).toThreadLastError();
         }
     }
 

--- a/plugin_api/include/futures.hpp
+++ b/plugin_api/include/futures.hpp
@@ -462,12 +462,8 @@ namespace ggapi {
             static_assert(std::is_invocable_r_v<ggapi::Container, Func, Args...>);
             Container c = std::invoke(std::forward<Func>(f), std::forward<Args>(args)...);
             setValue(c);
-        } catch(const ggapi::GgApiError &err) {
-            setError(err); // Note, setError() can throw exception if Promise invalid
-        } catch(const std::exception &exp) {
-            setError(ggapi::GgApiError::of(exp));
         } catch(...) {
-            setError(ggapi::GgApiError("Unknown error"));
+            setError(ggapi::GgApiError::of(std::current_exception()));
         }
         return *this;
     }


### PR DESCRIPTION
Make use of std::exception_ptr to maintain as much exception information as possible. This degrades to a {Kind, message} Tuple when transitioning across Nucleus/Plugin boundary. Old code use to pattern match a few different exceptions over-and-over. New code puts that in one place. Sadly std::exception_ptr cannot itself transition across the boundary.

**Checklist:**

- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
