### PR TITLE
added ggapi:: prefix

### DIFF
--- a/plugin_api/include/api_standard_errors.hpp
+++ b/plugin_api/include/api_standard_errors.hpp
@@ -64,7 +64,7 @@ namespace ggapi {
         inline static const auto KIND = ggapi::Symbol("ggapi::UnhandledLifecycleEvent");
 
         explicit UnhandledLifecycleEvent(
-            const std::string &what = "ggapi::UnhandledLifecycleEvent") noexcept
+            const std::string &what = "Unhandled Lifecycle Event") noexcept
             : GgApiError(KIND, what) {
         }
     };


### PR DESCRIPTION
standard errors now have ggapi:: prefix.  Updated UnhandledLifecycleEvent to reflect this prefix.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
