### PR TITLE
changing the status of the getSecretValue IPC feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `plugin_api` directory has the interface plugins should build against.
 | SubscribeToConfigurationUpdate          |           |   soon   |                              |
 | SubscribeToValidateConfigurationUpdates |           |   soon   |                              |
 | SendConfigurationValidityReport         |           |   soon   |                              |
-| GetSecretValue                          |           |   soon   |                              |
+| GetSecretValue                          |           |  future  |                              |
 | PutComponentMetric                      |           |   soon   |                              |
 | GetComponentDetails                     |           |  future  |                              |
 | RestartComponent                        |           |  future  |                              |


### PR DESCRIPTION
Change the readme file to indicate GetSecretValue IPC call is a future feature.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
