### PR TITLE
Use Token type for AuthN handling

### DIFF
--- a/plugins/ipc_server/src/authentication_handler.hpp
+++ b/plugins/ipc_server/src/authentication_handler.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
@@ -46,9 +47,8 @@ namespace ipc_server {
 
     public:
         Token generateAuthToken(std::string serviceName);
-        bool authenticateRequest(const Token &authToken) const;
         void revokeService(const std::string &serviceName);
         void revokeToken(const Token &token);
-        std::string retrieveServiceName(const std::string &token);
+        std::optional<std::string> retrieveServiceName(const Token &token) const;
     };
 } // namespace ipc_server

--- a/plugins/ipc_server/src/ipc_server.cpp
+++ b/plugins/ipc_server/src/ipc_server.cpp
@@ -75,6 +75,7 @@ namespace ipc_server {
         {
             std::unique_lock guard{_mutex};
             outData.socketPath = _socketPath;
+            // TODO: handle empty service names
             outData.authToken = _authHandler->generateAuthToken(inData.serviceName).value();
         }
         return ggapi::serialize(outData);

--- a/plugins/ipc_server/src/server_connection.hpp
+++ b/plugins/ipc_server/src/server_connection.hpp
@@ -3,11 +3,10 @@
 #include <api_standard_errors.hpp>
 #include <auto_release.hpp>
 #include <cpp_api.hpp>
-#include <filesystem>
-#include <forward_list>
 #include <shared_device_sdk.hpp>
 
 namespace ipc_server {
+    class Token;
     class ServerListener;
     class ConnectionStream;
 
@@ -35,7 +34,7 @@ namespace ipc_server {
         std::atomic<bool> _authenticated{false};
 
     private:
-        std::string getServiceNameFromToken(const std::string &token);
+        [[nodiscard]] std::string getServiceNameFromToken(const Token &token) const;
 
     public:
         ServerConnection(const ServerConnection &) = delete;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use Token type for retrieving service name

**Why is this change necessary:**
Removes noisy type conversion during AuthN
Relaxes mutex locking (was unique, now shared)

**How was this change tested:**
Compilation and Linkage. Running nucleus

**Any additional information or context required to review the change:**

**Checklist:**

- [x] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
