### PR TITLE
fix: check if tes future is valid

### DIFF
--- a/plugins/log_manager/src/log_manager.cpp
+++ b/plugins/log_manager/src/log_manager.cpp
@@ -76,11 +76,14 @@ void LogManager::retrieveCredentialsFromTES() {
     LOG.atInfo().log("Calling topic to request credentials from TES");
     auto tesFuture = ggapi::Subscription::callTopicFirst(
             ggapi::Symbol{TES_REQUEST_TOPIC}, request);
-    if(tesFuture.isValid()) {
-        _credentials = ggapi::Struct(tesFuture.waitAndGetValue());
-    }
-    else {
-        _credentials = {};
+    _credentials = {};
+    if(tesFuture) {
+        // TODO: Review error behavior and change
+        try {
+            _credentials = ggapi::Struct(tesFuture.waitAndGetValue());
+        } catch (...) {
+            LOG.atInfo().log("There was an issue while getting TES future.");
+        }
     }
 }
 

--- a/plugins/tes_http_server_plugin/src/tes_http_server.cpp
+++ b/plugins/tes_http_server_plugin/src/tes_http_server.cpp
@@ -32,7 +32,13 @@ ggapi::Struct getTesCredentialsStruct() {
     auto tesFuture = ggapi::Subscription::callTopicFirst(
         ggapi::Symbol{requestTesCredentialsTopic}, tes_lpc_request);
     if(tesFuture) {
-        return ggapi::Struct(tesFuture.waitAndGetValue());
+        // TODO: Review error behavior and change
+        try {
+            return ggapi::Struct(tesFuture.waitAndGetValue());
+        } catch (...) {
+            LOG.atInfo().log("There was an issue while getting TES future.");
+            return {};
+        }
     } else {
         return {};
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Check that TES future is valid, otherwise an exception is thrown.

**Why is this change necessary:**
Fixes a bug where if TES is configured wrongly (policy does not have correct policies) then we get a runtime error.

**How was this change tested:**
Reverted policy to an incorrect version and checked that instead of breaking nucleus, it simply logs the error for log manager.

**Any additional information or context required to review the change:**

**Checklist:**

- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
