### PR TITLE
Fix key already exist seg fault when putting struct

### DIFF
--- a/nucleus/src/config/config_manager.cpp
+++ b/nucleus/src/config/config_manager.cpp
@@ -100,7 +100,7 @@ namespace config {
 
             // remove the existing child if its merge behavior is REPLACE
             if(std::dynamic_pointer_cast<ReplaceBehaviorTree>(childMergeBehavior)) {
-                removeChild(*getNode(childSym));
+                _children.erase(childSym);
             }
         }
     }
@@ -113,8 +113,14 @@ namespace config {
     void Topics::updateChild(const TopicElement &element) {
         data::Symbol key = element.getKey();
         if(element.isType<data::StructModelBase>()) {
-            auto newNode = createInteriorChild(key);
-            newNode->updateFromMap(element);
+            auto i = _children.find(key);
+            if(i != _children.end()) {
+                _children.erase(key);
+                auto newNode = createInteriorChild(key.toString());
+                newNode->updateFromMap(element);
+            } else {
+                createInteriorChild(key.toString())->updateFromMap(element);
+            }
             return;
         }
         checkedPut(element, [this, key, &element](auto &el) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
 - after change to `putImpl` method, the creating first key in structs was changed. The first key was created with a null value before we got to createInteriorChild, so that when createInteriorChild checked if the key exists, it did and returned the null value, causing the seg fault.
 - Mimic'ing the java version, unblocks since this behavior is now expected / is proper.
 https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/9b644d2fd37e9528e868be6cce5c5ee42757407a/src/main/java/com/aws/greengrass/config/Topics.java#L340-L348

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**

- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
