### PR TITLE
feat: add gg-fleet-statusd design

### DIFF
--- a/docs/design/gg-fleet-statusd.md
+++ b/docs/design/gg-fleet-statusd.md
@@ -1,41 +1,38 @@
 # GG Lite - Fleet Status Service Daemon Design
 
-See [gg-fleet-statusd spec](../spec/components/gg-fleet-statusd.md) for the 
+See [gg-fleet-statusd spec](../spec/components/gg-fleet-statusd.md) for the
 public interface for gg-fleet-statusd.
 
 ## Overview
 
-The fleet status service enables Greengrass to collect and report the health 
-status of deployed components to the cloud. This allows customers to track 
-their device status in the console. GG Lite will replicate GG Classic behavior,
-ensuring that customers can still see component statuses in the console just 
-as they do with Classic. This task will be handled by `gg-fleet-statusd`, an
+The fleet status service enables Greengrass to collect and report the health
+status of deployed components to the cloud. This allows customers to track their
+device status in the console. GG Lite will replicate GG Classic behavior,
+ensuring that customers can still see component statuses in the console just as
+they do with Classic. This task will be handled by `gg-fleet-statusd`, an
 individual process part of GG Lite.
-
 
 ## Requirements
 
 1. The daemon must use `iotcored` to send MQTT messages containing the device
- status to the cloud.
+   status to the cloud.
 2. The daemon must receive component health statuses from `gghealthd`.
 3. The daemon must send a fleet status update on startup.
 
-**Note:** These requirements only cover the current scope for the design and 
-will be expanded upon as we continue to add new features to gg-fleet-statusd. 
-
+**Note:** These requirements only cover the current scope for the design and
+will be expanded upon as we continue to add new features to gg-fleet-statusd.
 
 ## Startup
 
-1. On startup, `gg-fleet-statusd` will use `gghealthd` to retrieve the health 
-status of all components on the device.
+1. On startup, `gg-fleet-statusd` will use `gghealthd` to retrieve the health
+   status of all components on the device.
 2. The daemon will use `iotcored` to publish a fleet status update to IoT Core,
- containing the health statuses collected in the previous step.
-
+   containing the health statuses collected in the previous step.
 
 ## Offline Capabilities
 
-In this current stage of the design, fleet status service will not support any 
-offline capabilities. It will simply send a fleet status update on startup if 
-an MQTT connection is present. In the future, status updates will be sent on 
-any instances of MQTT reconnections as well, ensuring that the device status is
+In this current stage of the design, fleet status service will not support any
+offline capabilities. It will simply send a fleet status update on startup if an
+MQTT connection is present. In the future, status updates will be sent on any
+instances of MQTT reconnections as well, ensuring that the device status is
 visible in the cloud as soon as it has a network connection.


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adding a one pager for the gg-fleet-statusd design. This design currently covers sending a fleet status update on startup. The document will be expanded as more features are added in the future.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**

- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
