### PR TITLE
Simplify RPC client API

### DIFF
--- a/ggl-lib/include/ggl/client.h
+++ b/ggl-lib/include/ggl/client.h
@@ -9,22 +9,15 @@
 /*! Pluggable RPC client interface */
 
 #include "alloc.h"
-#include "ggl/error.h"
+#include "error.h"
 #include "object.h"
 
 typedef struct GglConn GglConn;
 
-/** Open a connection to server on `path`. */
-GglError ggl_connect(GglBuffer path, GglConn **conn)
-    __attribute__((warn_unused_result));
-
-/** Close a connection to a server. */
-void ggl_close(GglConn *conn);
-
 /** Make an RPC call.
  * `result` will use memory from `alloc` if needed. */
 GglError ggl_call(
-    GglConn *conn,
+    GglBuffer interface,
     GglBuffer method,
     GglMap params,
     GglAlloc *alloc,
@@ -32,6 +25,6 @@ GglError ggl_call(
 ) __attribute__((warn_unused_result));
 
 /** Make an RPC notification (no response). */
-GglError ggl_notify(GglConn *conn, GglBuffer method, GglMap params);
+GglError ggl_notify(GglBuffer interface, GglBuffer method, GglMap params);
 
 #endif

--- a/ggl-lib/include/ggl/server.h
+++ b/ggl-lib/include/ggl/server.h
@@ -6,7 +6,7 @@
 #ifndef GGL_COMMS_SERVER_H
 #define GGL_COMMS_SERVER_H
 
-#include "ggl/error.h"
+#include "error.h"
 #include "object.h"
 #include <stdnoreturn.h>
 

--- a/msgpack-rpc/src/server.c
+++ b/msgpack-rpc/src/server.c
@@ -3,22 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "ggl/server.h"
-#include "ggl/bump_alloc.h"
-#include "ggl/defer.h"
-#include "ggl/error.h"
-#include "ggl/log.h"
-#include "ggl/object.h"
-#include "ggl/utils.h"
 #include "msgpack.h"
 #include <assert.h>
 #include <errno.h>
+#include <ggl/bump_alloc.h>
+#include <ggl/defer.h>
+#include <ggl/error.h>
+#include <ggl/log.h>
+#include <ggl/object.h>
+#include <ggl/server.h>
+#include <ggl/utils.h>
 #include <pthread.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -286,7 +287,7 @@ noreturn void ggl_listen(GglBuffer path, void *ctx) {
                 }
 
                 if ((size_t) sys_ret == 0) {
-                    GGL_LOGI("msgpack-rpc", "Connection closed.");
+                    GGL_LOGD("msgpack-rpc", "Connection closed.");
                     break;
                 }
 

--- a/samples/example-client/src/main.c
+++ b/samples/example-client/src/main.c
@@ -17,15 +17,6 @@ int main(void) {
     GglBuffer server = GGL_STR("/aws/ggl/echo-server");
     static uint8_t buffer[10 * sizeof(GglObject)] = { 0 };
 
-    GglConn *conn;
-    GglError ret = ggl_connect(server, &conn);
-    if (ret != GGL_ERR_OK) {
-        GGL_LOGE(
-            "client", "Failed to connect to %.*s", (int) server.len, server.data
-        );
-        return EHOSTUNREACH;
-    }
-
     GglMap args = GGL_MAP({ GGL_STR("message"), GGL_OBJ_STR("hello world") });
 
     struct timespec before;
@@ -36,11 +27,12 @@ int main(void) {
         GglBumpAlloc alloc = ggl_bump_alloc_init(GGL_BUF(buffer));
         GglObject result;
 
-        ret = ggl_call(conn, GGL_STR("echo"), args, &alloc.alloc, &result);
+        GglError ret
+            = ggl_call(server, GGL_STR("echo"), args, &alloc.alloc, &result);
 
         if (ret != 0) {
             GGL_LOGE("client", "Failed to send echo: %d.", ret);
-            break;
+            return EPROTO;
         }
     }
 

--- a/samples/mqtt-client/src/main.c
+++ b/samples/mqtt-client/src/main.c
@@ -12,24 +12,21 @@
 int main(void) {
     GglBuffer iotcored = GGL_STR("/aws/ggl/iotcored");
 
-    GglConn *conn;
-    GglError ret = ggl_connect(iotcored, &conn);
-    if (ret != 0) {
-        GGL_LOGE(
-            "mqtt-client",
-            "Failed to connect to %.*s",
-            (int) iotcored.len,
-            iotcored.data
-        );
-        return EHOSTUNREACH;
-    }
-
     GglMap args = GGL_MAP(
         { GGL_STR("topic"), GGL_OBJ_STR("hello") },
         { GGL_STR("payload"), GGL_OBJ_STR("hello world") },
     );
 
-    ggl_notify(conn, GGL_STR("publish"), args);
+    GglError ret = ggl_notify(iotcored, GGL_STR("publish"), args);
+    if (ret != 0) {
+        GGL_LOGE(
+            "mqtt-client",
+            "Failed to send notify message to %.*s",
+            (int) iotcored.len,
+            iotcored.data
+        );
+        return EPROTO;
+    }
 
     GGL_LOGI("mqtt-client", "Sent MQTT publish.");
 }


### PR DESCRIPTION
This removes `ggl_connect` and `ggl_close`.

Now a new connection is used for every RPC transaction, and the
connection is immediately cleaned up.

This simplifies the client API, and removes the need for memory
management for tracking open connections.