### PR TITLE
removed alpha check for keypath validation

### DIFF
--- a/ggconfigd/src/config.c
+++ b/ggconfigd/src/config.c
@@ -379,11 +379,6 @@ static bool validate_key(GglBuffer *key) {
     if (!isalpha(key->data[0])) { // make sure the path starts with a character
         return false;
     }
-    for (size_t x = 0; x < key->len; x++) {
-        if (!isalpha(key->data[x]) && key->data[x] != '/') {
-            return false;
-        }
-    }
     return true;
 }
 


### PR DESCRIPTION
Removed the alpha character check for 100% of the keypath.  Now valid keypath must START with an alpha character.  This is to prevent keypath from starting with '/'.  This is a temporary requirement as the '/' path separator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
