### PR TITLE
Add gghealthd get_health

### DIFF
--- a/gghealthd/include/bus_client.h
+++ b/gghealthd/include/bus_client.h
@@ -9,6 +9,6 @@
 GglError verify_component_exists(GglBuffer component_name);
 
 // use ggconfigd to list root components
-GglError get_root_component_list(GglAlloc *alloc, GglList *component_list);
+GglError get_root_component_list(GglAlloc *alloc, GglMap *component_list);
 
 #endif

--- a/gghealthd/include/bus_client.h
+++ b/gghealthd/include/bus_client.h
@@ -9,6 +9,6 @@
 GglError verify_component_exists(GglBuffer component_name);
 
 // use ggconfigd to list root components
-GglError get_root_component_list(GglAlloc *alloc, GglMap *component_list);
+GglError get_root_component_list(GglAlloc *alloc, GglList *component_list);
 
 #endif

--- a/gghealthd/include/health.h
+++ b/gghealthd/include/health.h
@@ -11,6 +11,11 @@
 // https://docs.aws.amazon.com/greengrass/v2/APIReference/API_DescribeComponent.html
 #define COMPONENT_NAME_MAX_LEN 128
 
+// TODO: CMake configuration
+#ifndef GGHEALTHD_GET_HEALTH_BUFFER_SIZE
+#define GGHEALTHD_GET_HEALTH_BUFFER_SIZE 4096
+#endif
+
 GglError gghealthd_init(void);
 
 // get status from native orchestrator or local database

--- a/gghealthd/src/bus_client.c
+++ b/gghealthd/src/bus_client.c
@@ -61,22 +61,30 @@ GglError verify_component_exists(GglBuffer component_name) {
     );
 }
 
-GglError get_root_component_list(GglAlloc *alloc, GglMap *component_list) {
+GglError get_root_component_list(GglAlloc *alloc, GglList *component_list) {
     assert(
         (alloc != NULL) && (component_list != NULL)
-        && (component_list->pairs == NULL)
+        && (component_list->items == NULL)
     );
 
     GglObject result = { 0 };
-    GglError err = get_key(alloc, GGL_LIST(GGL_OBJ_STR("services")), &result);
+    GglError err = get_key(
+        alloc,
+        GGL_LIST(
+            GGL_OBJ_STR("services"),
+            GGL_OBJ_STR("main"),
+            GGL_OBJ_STR("dependencies")
+        ),
+        &result
+    );
     if (err != GGL_ERR_OK) {
         return err;
     }
-    if (result.type != GGL_TYPE_MAP) {
+    if (result.type != GGL_TYPE_LIST) {
         GGL_LOGE("ggconfigd protocol error expected Map");
         return GGL_ERR_FATAL;
     }
-    *component_list = result.map;
+    *component_list = result.list;
 
     return GGL_ERR_OK;
 }

--- a/gghealthd/src/health.c
+++ b/gghealthd/src/health.c
@@ -515,7 +515,7 @@ GglError gghealthd_get_health(GglBuffer *status) {
 
     static uint8_t bump_buffer[GGHEALTHD_GET_HEALTH_BUFFER_SIZE];
     GglBumpAlloc alloc = ggl_bump_alloc_init(GGL_BUF(bump_buffer));
-    GglList components = { 0 };
+    GglMap components = { 0 };
 
     err = get_root_component_list(&alloc.alloc, &components);
     if (err != GGL_ERR_OK) {
@@ -523,16 +523,9 @@ GglError gghealthd_get_health(GglBuffer *status) {
     }
 
     for (size_t i = 0; i < components.len; ++i) {
-        GglObject *component_name = &components.items[i];
-        if (component_name->type != GGL_TYPE_BUF) {
-            GGL_LOGE("gghealthd", "Component name was not of type Buffer");
-            return GGL_ERR_FATAL;
-        }
-
+        GglKV *component = &components.pairs[i];
         uint8_t qualified_name[SERVICE_NAME_MAX_LEN + 1] = { 0 };
-        err = get_service_name(
-            component_name->buf, &GGL_BYTE_VEC(qualified_name)
-        );
+        err = get_service_name(component->key, &GGL_BYTE_VEC(qualified_name));
         if (err != GGL_ERR_OK) {
             return err;
         }
@@ -549,8 +542,8 @@ GglError gghealthd_get_health(GglBuffer *status) {
             GGL_LOGW(
                 "gghealthd",
                 "%.*s is BROKEN",
-                (int) component_name->buf.len,
-                (const char *) component_name->buf.data
+                (int) component->key.len,
+                (const char *) component->key.data
             );
 
             *status = GGL_STR("UNHEALTHY");


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- gghealthd get_health core bus API.
  - Returns the device health of the core device based on the lifecycle states of all configured root components

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
