### PR TITLE
Return error on ggconfigd subscribe if key doesn't exist

### DIFF
--- a/ggconfigd/src/db_interface.c
+++ b/ggconfigd/src/db_interface.c
@@ -912,17 +912,13 @@ GglError ggconfig_get_key_notification(GglList *key_path, uint32_t handle) {
     // value
     key_id = get_key_id(key_path);
     if (key_id == 0) {
-        GglError err = create_key_path(key_path, &key_id);
-        if (err != GGL_ERR_OK) {
-            GGL_LOGE(
-                "ggconfig_get_key_notification",
-                "failed to create key path %s with error %d",
-                print_key_path(key_path),
-                (int) err
-            );
-            sqlite3_exec(config_database, "ROLLBACK", NULL, NULL, NULL);
-            return err;
-        }
+        GGL_LOGE(
+            "ggconfig_get_key_notification",
+            "key %s does not exist",
+            print_key_path(key_path)
+        );
+        sqlite3_exec(config_database, "ROLLBACK", NULL, NULL, NULL);
+        return GGL_ERR_FAILURE;
     }
     GGL_LOGI(
         "ggconfig_get_key_notification",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To replicate the behavior of GGv2 Classic: https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/main/src/main/java/com/aws/greengrass/builtin/services/configstore/ConfigStoreIPCEventStreamAgent.java#L391 , and also we don't want subscriptions to cause keys to be created in the database.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
