### PR TITLE
ggl-process: Add define for P_PIDFD

### DIFF
--- a/ggl-process/src/process.c
+++ b/ggl-process/src/process.c
@@ -21,6 +21,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+// Glibc 2.2.5 to 2.35 do not provide P_PIDFD
+// Yocto Kirkstone uses Glibc 2.35
+#define P_PIDFD 3
+
 static pid_t sys_clone3(struct clone_args *args) {
     return (pid_t) syscall(SYS_clone3, args, sizeof(struct clone_args));
 }

--- a/misc/dictionary.txt
+++ b/misc/dictionary.txt
@@ -86,3 +86,4 @@ WERROR
 Xiwyu
 xlink
 yapf
+Yocto


### PR DESCRIPTION
P_PIDFD is not defined in glibc 2.35 but acc. to docs it should work if defined.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
