### PR TITLE
Use CAINFO instead of CAPATH for setting RootCA

### DIFF
--- a/ggl-http/src/gghttp_util.c
+++ b/ggl-http/src/gghttp_util.c
@@ -93,7 +93,7 @@ void gghttplib_add_certificate_data(
         curl_data->curl, CURLOPT_SSLKEY, request_data.gghttplib_p_key_path
     );
     curl_easy_setopt(
-        curl_data->curl, CURLOPT_CAPATH, request_data.gghttplib_root_ca_path
+        curl_data->curl, CURLOPT_CAINFO, request_data.gghttplib_root_ca_path
     );
 }
 


### PR DESCRIPTION
CAPATH expects a directory, but rootCaPath is a file path

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
