### PR TITLE
Add tes credentials url to sample nucleus config

### DIFF
--- a/docs/examples/sample_nucleus_config.yml
+++ b/docs/examples/sample_nucleus_config.yml
@@ -32,6 +32,7 @@ services:
       runWithDefault:
         posixUser: "ggc_user:ggc_group"
       telemetry: {}
+      tesCredUrl: "http://127.0.0.1:8080/"
     dependencies: []
   aws.greengrass.fleet_provisioning:
     configuration:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add tesCredUrl to sample config since deployment daemon needs it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
