### PR TITLE
CMakeLists.txt: change CMAKE_CURRENT_SOURCE_DIR to CMAKE_CURRENT_LIST…

### DIFF
--- a/ggconfigd/CMakeLists.txt
+++ b/ggconfigd/CMakeLists.txt
@@ -5,4 +5,4 @@
 ggl_init_module(ggconfigd LIBS ggl-lib core-bus core-bus-gg-config ggl-json
                                PkgConfig::sqlite3)
 target_compile_definitions(ggconfigd
-                           PRIVATE GGL_COMP_DIR=${CMAKE_CURRENT_SOURCE_DIR})
+                           PRIVATE GGL_COMP_DIR=${CMAKE_CURRENT_LIST_DIR})


### PR DESCRIPTION
…_DIR

As this is causing issues with Yocto, path is not correct. See this discussion: https://stackoverflow.com/questions/15662497/difference-between-cmake-current-source-dir-and-cmake-current-list-dir

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
