### PR TITLE
ggconfigd/CMakeLists.txt: add a blank after GGL_COMP_DIR=${CMAKE_CURR…

### DIFF
--- a/ggconfigd/CMakeLists.txt
+++ b/ggconfigd/CMakeLists.txt
@@ -4,5 +4,6 @@
 
 ggl_init_module(ggconfigd LIBS ggl-lib core-bus core-bus-gg-config ggl-json
                                PkgConfig::sqlite3)
+# the blank after GGL_COMP_DIR=${CMAKE_CURRENT_LIST_DIR} is important!
 target_compile_definitions(ggconfigd
-                           PRIVATE GGL_COMP_DIR=${CMAKE_CURRENT_LIST_DIR})
+                           PRIVATE GGL_COMP_DIR=${CMAKE_CURRENT_LIST_DIR} )


### PR DESCRIPTION
…ENT_LIST_DIR}

As this was causing in Yocto issues with construction of the path. Instead of:
.../build/tmp/work/core2-64-poky-linux/greengrass-lite/git/git/ggconfigd/src it was:
.../build/tmp/work/core2-64-poky-1/greengrass-lite/git/git/ggconfigd/src

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
