### PR TITLE
Fix build when path contains linux

### DIFF
--- a/ggconfigd/CMakeLists.txt
+++ b/ggconfigd/CMakeLists.txt
@@ -5,4 +5,5 @@
 ggl_init_module(ggconfigd LIBS ggl-lib core-bus core-bus-gg-config ggl-json
                                PkgConfig::sqlite3)
 target_compile_definitions(ggconfigd
-                           PRIVATE GGL_COMP_DIR=${CMAKE_CURRENT_LIST_DIR})
+                           PRIVATE "GGL_COMP_DIR=${CMAKE_CURRENT_LIST_DIR}")
+target_compile_options(ggconfigd PRIVATE $<$<COMPILE_LANGUAGE:ASM>:-undef>)


### PR DESCRIPTION
Yocto builds were failing as the path contains `linux` which was defined as a macro by the preprocessor when processing `ggconfigd/src/embeds.S`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
