### PR TITLE
Remove Musl Nix check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
             check: packages-default
           - name: build with Clang
             check: packages-ggl-clang
-          - name: build with Musl
-            check: packages-ggl-musl
           - name: clang-tidy
             check: clang-tidy
           - name: header includes

--- a/nix/packages/ggl-musl.nix
+++ b/nix/packages/ggl-musl.nix
@@ -1,4 +1,0 @@
-{ pkgsMusl
-, moduleArgs
-}:
-pkgsMusl.${moduleArgs.config.pname}


### PR DESCRIPTION
The check currently is expensive; will need to be replaced with cross-compiling or such.