### PR TITLE
Use memmove in dependency resolution

### DIFF
--- a/ggdeploymentd/src/component_manager.c
+++ b/ggdeploymentd/src/component_manager.c
@@ -97,9 +97,7 @@ bool resolve_component_version(
     );
 
     assert(local_version.len <= NAME_MAX);
-    memmove(
-        resolved_version->data, local_version.data, local_version.len
-    );
+    memmove(resolved_version->data, local_version.data, local_version.len);
     resolved_version->len = local_version.len;
     return true;
 }

--- a/ggdeploymentd/src/component_store.c
+++ b/ggdeploymentd/src/component_store.c
@@ -137,11 +137,7 @@ GglError find_available_component(
         if (ggl_buffer_eq(component_name, recipe_component)
             && is_in_range(recipe_version, requirement)) {
             assert(recipe_version.len <= NAME_MAX);
-            memmove(
-                version->data,
-                recipe_version.data,
-                recipe_version.len
-            );
+            memmove(version->data, recipe_version.data, recipe_version.len);
             version->len = recipe_version.len;
             return GGL_ERR_OK;
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Incorrect parameters were being passed into `memcpy` in the dependency resolution code. Fixing the parameters used and using `memmove` instead to avoid bugs with the source and destination memories overlapping.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
