### PR TITLE
CMakeLists.txt: BIN -> bin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,7 +354,7 @@ endif()
 #
 # CPACK deb package generation
 #
-install(PROGRAMS "misc/run_nucleus" DESTINATION BIN)
+install(PROGRAMS "misc/run_nucleus" DESTINATION bin)
 
 set(CPACK_GENERATOR DEB)
 


### PR DESCRIPTION
BIN is not a variable it is the name under /usr/BIN -> so bin is correct

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
