### PR TITLE
Only create config db relationTable index when db is created

### DIFF
--- a/ggconfigd/src/db_interface.c
+++ b/ggconfigd/src/db_interface.c
@@ -81,16 +81,21 @@ GglError ggconfig_open(void) {
                 return_err = GGL_ERR_OK;
             } else {
                 return_err = create_database();
-            }
-            rc = sqlite3_exec(
-                config_database, GGL_SQL_CREATE_INDEX, NULL, NULL, &err_message
-            );
-            if (rc) {
-                GGL_LOGI(
-                    "Failed to add an index to the relationTable %s, expect an "
-                    "autoindex to be created",
-                    err_message
+                rc = sqlite3_exec(
+                    config_database,
+                    GGL_SQL_CREATE_INDEX,
+                    NULL,
+                    NULL,
+                    &err_message
                 );
+                if (rc) {
+                    GGL_LOGI(
+                        "Failed to add an index to the relationTable %s, "
+                        "expect an "
+                        "autoindex to be created",
+                        err_message
+                    );
+                }
             }
         }
         // create a temporary table for subscriber data


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently the index is attempted to be created every time configd starts up. But the index only needs be created once and is persisted in the db. So it shows an error on subsequent start-ups.

This makes it so the relationTable index is created only once- when the db is created

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
