### PR TITLE
Remove GGL_OBJ macro

### DIFF
--- a/core-bus-aws-iot-mqtt/src/aws_iot_mqtt.c
+++ b/core-bus-aws-iot-mqtt/src/aws_iot_mqtt.c
@@ -19,8 +19,8 @@ GglError ggl_aws_iot_mqtt_publish(
     GglBuffer topic, GglBuffer payload, uint8_t qos, bool wait_for_resp
 ) {
     GglMap args = GGL_MAP(
-        { GGL_STR("topic"), GGL_OBJ(topic) },
-        { GGL_STR("payload"), GGL_OBJ(payload) },
+        { GGL_STR("topic"), GGL_OBJ_BUF(topic) },
+        { GGL_STR("payload"), GGL_OBJ_BUF(payload) },
         { GGL_STR("qos"), GGL_OBJ_I64(qos) }
     );
 
@@ -48,12 +48,13 @@ GglError ggl_aws_iot_mqtt_subscribe(
 
     GglObject filters[GGL_MQTT_MAX_SUBSCRIBE_FILTERS] = { 0 };
     for (size_t i = 0; i < topic_filters.len; i++) {
-        filters[i] = GGL_OBJ(topic_filters.bufs[i]);
+        filters[i] = GGL_OBJ_BUF(topic_filters.bufs[i]);
     }
 
     GglMap args = GGL_MAP(
         { GGL_STR("topic_filter"),
-          GGL_OBJ((GglList) { .items = filters, .len = topic_filters.len }) },
+          GGL_OBJ_LIST((GglList) { .items = filters, .len = topic_filters.len }
+          ) },
         { GGL_STR("qos"), GGL_OBJ_I64(qos) }
     );
 

--- a/core-bus-gg-config/src/gg_config.c
+++ b/core-bus-gg-config/src/gg_config.c
@@ -24,12 +24,12 @@ GglError ggl_gg_config_read(
 
     GglObject path_obj[GGL_MAX_OBJECT_DEPTH] = { 0 };
     for (size_t i = 0; i < key_path.len; i++) {
-        path_obj[i] = GGL_OBJ(key_path.bufs[i]);
+        path_obj[i] = GGL_OBJ_BUF(key_path.bufs[i]);
     }
 
     GglMap args = GGL_MAP(
         { GGL_STR("key_path"),
-          GGL_OBJ((GglList) { .items = path_obj, .len = key_path.len }) },
+          GGL_OBJ_LIST((GglList) { .items = path_obj, .len = key_path.len }) },
     );
 
     GglError remote_err = GGL_ERR_OK;
@@ -77,12 +77,12 @@ GglError ggl_gg_config_write(
 
     GglObject path_obj[GGL_MAX_OBJECT_DEPTH] = { 0 };
     for (size_t i = 0; i < key_path.len; i++) {
-        path_obj[i] = GGL_OBJ(key_path.bufs[i]);
+        path_obj[i] = GGL_OBJ_BUF(key_path.bufs[i]);
     }
 
     GglMap args = GGL_MAP(
         { GGL_STR("key_path"),
-          GGL_OBJ((GglList) { .items = path_obj, .len = key_path.len }) },
+          GGL_OBJ_LIST((GglList) { .items = path_obj, .len = key_path.len }) },
         { GGL_STR("value"), value },
         { GGL_STR("timestamp"), GGL_OBJ_I64(timestamp) },
     );
@@ -113,12 +113,12 @@ GglError ggl_gg_config_subscribe(
 
     GglObject path_obj[GGL_MAX_OBJECT_DEPTH] = { 0 };
     for (size_t i = 0; i < key_path.len; i++) {
-        path_obj[i] = GGL_OBJ(key_path.bufs[i]);
+        path_obj[i] = GGL_OBJ_BUF(key_path.bufs[i]);
     }
 
     GglMap args = GGL_MAP(
         { GGL_STR("key_path"),
-          GGL_OBJ((GglList) { .items = path_obj, .len = key_path.len }) },
+          GGL_OBJ_LIST((GglList) { .items = path_obj, .len = key_path.len }) },
     );
 
     GglError remote_err = GGL_ERR_OK;

--- a/core-bus/src/client_common.c
+++ b/core-bus/src/client_common.c
@@ -51,7 +51,7 @@ static GglError payload_writer(GglBuffer *buf, void *payload) {
     assert(payload != NULL);
 
     GglMap *map = payload;
-    return ggl_serialize(GGL_OBJ(*map), buf);
+    return ggl_serialize(GGL_OBJ_MAP(*map), buf);
 }
 
 GglError ggl_client_send_message(

--- a/core-bus/src/object_serde.c
+++ b/core-bus/src/object_serde.c
@@ -194,7 +194,7 @@ static GglError read_buf(
     if (ret != GGL_ERR_OK) {
         return ret;
     }
-    *obj = GGL_OBJ(val);
+    *obj = GGL_OBJ_BUF(val);
     return GGL_ERR_OK;
 }
 
@@ -269,7 +269,7 @@ static GglError read_list(
         }
     }
 
-    *obj = GGL_OBJ(val);
+    *obj = GGL_OBJ_LIST(val);
     return GGL_ERR_OK;
 }
 
@@ -343,7 +343,7 @@ static GglError read_map(
         }
     }
 
-    *obj = GGL_OBJ(val);
+    *obj = GGL_OBJ_MAP(val);
     return GGL_ERR_OK;
 }
 

--- a/core-bus/src/server.c
+++ b/core-bus/src/server.c
@@ -186,7 +186,7 @@ static GglError client_ready(void *ctx, uint32_t handle) {
         return GGL_ERR_OK;
     }
 
-    GglMap params = GGL_MAP();
+    GglMap params = { 0 };
 
     if (msg.payload.len > 0) {
         static uint8_t payload_deserialize_mem

--- a/fleet-provisioning/src/entry.c
+++ b/fleet-provisioning/src/entry.c
@@ -133,7 +133,7 @@ static GglError fetch_from_db(FleetProvArgs *args) {
                 GGL_STR("configuration"),
                 GGL_STR("iotDataEndpoint")
             ),
-            GGL_OBJ(data_endpoint),
+            GGL_OBJ_BUF(data_endpoint),
             0
         );
         if (ret != GGL_ERR_OK) {
@@ -242,8 +242,8 @@ GglError run_fleet_prov(FleetProvArgs *args) {
 
     ret = ggl_gg_config_write(
         GGL_BUF_LIST(GGL_STR("system"), GGL_STR("privateKeyPath")),
-        GGL_OBJ((GglBuffer) { .data = (uint8_t *) private_file_path,
-                              .len = strlen(private_file_path) }),
+        GGL_OBJ_BUF((GglBuffer) { .data = (uint8_t *) private_file_path,
+                                  .len = strlen(private_file_path) }),
         0
     );
     if (ret != GGL_ERR_OK) {

--- a/fleet-provisioning/src/provisioner.c
+++ b/fleet-provisioning/src/provisioner.c
@@ -78,10 +78,10 @@ static int request_thing_name(GglObject *cert_owner_gg_obj) {
     //         ...
     //     }
     // }
-    GglObject thing_payload_obj = GGL_OBJ_MAP(
+    GglObject thing_payload_obj = GGL_OBJ_MAP(GGL_MAP(
         { GGL_STR("certificateOwnershipToken"), *cert_owner_gg_obj },
         { GGL_STR("parameters"), config_template_param_json_obj }
-    );
+    ));
     GglError ret_err_json
         = ggl_json_encode(thing_payload_obj, &thing_request_buf);
     if (ret_err_json != GGL_ERR_OK) {
@@ -91,10 +91,10 @@ static int request_thing_name(GglObject *cert_owner_gg_obj) {
     // Publish message builder for thing request
     GglMap thing_request_args = GGL_MAP(
         { GGL_STR("topic"),
-          GGL_OBJ((GglBuffer) { .len = strlen(global_register_thing_url),
-                                .data = (uint8_t *) global_register_thing_url }
-          ) },
-        { GGL_STR("payload"), GGL_OBJ(thing_request_buf) },
+          GGL_OBJ_BUF((GglBuffer
+          ) { .len = strlen(global_register_thing_url),
+              .data = (uint8_t *) global_register_thing_url }) },
+        { GGL_STR("payload"), GGL_OBJ_BUF(thing_request_buf) },
     );
 
     GglError ret_thing_req_publish
@@ -239,8 +239,9 @@ static GglError subscribe_callback(void *ctx, uint32_t handle, GglObject data) {
 
             ret = ggl_gg_config_write(
                 GGL_BUF_LIST(GGL_STR("system"), GGL_STR("certificateFilePath")),
-                GGL_OBJ((GglBuffer) { .data = (uint8_t *) global_cert_file_path,
-                                      .len = strlen(global_cert_file_path) }),
+                GGL_OBJ_BUF((GglBuffer
+                ) { .data = (uint8_t *) global_cert_file_path,
+                    .len = strlen(global_cert_file_path) }),
                 0
             );
             if (ret != GGL_ERR_OK) {
@@ -338,8 +339,9 @@ GglError make_request(
     // Subscribe to csr success topic
     GglMap subscribe_args = GGL_MAP(
         { GGL_STR("topic_filter"),
-          GGL_OBJ((GglBuffer) { .data = (uint8_t *) certificate_response_url,
-                                .len = strlen(certificate_response_url) }) },
+          GGL_OBJ_BUF((GglBuffer
+          ) { .data = (uint8_t *) certificate_response_url,
+              .len = strlen(certificate_response_url) }) },
     );
 
     ret = ggl_subscribe(
@@ -369,7 +371,7 @@ GglError make_request(
     // Subscribe to csr reject topic
     GglMap subscribe_reject_args = GGL_MAP(
         { GGL_STR("topic_filter"),
-          GGL_OBJ((GglBuffer
+          GGL_OBJ_BUF((GglBuffer
           ) { .data = (uint8_t *) certificate_response_reject_url,
               .len = strlen(certificate_response_reject_url) }) },
     );
@@ -401,7 +403,7 @@ GglError make_request(
     // Subscribe to register thing success topic
     GglMap subscribe_thing_args = GGL_MAP(
         { GGL_STR("topic_filter"),
-          GGL_OBJ((GglBuffer
+          GGL_OBJ_BUF((GglBuffer
           ) { .len = strlen(global_register_thing_accept_url),
               .data = (uint8_t *) global_register_thing_accept_url }) },
     );
@@ -431,11 +433,11 @@ GglError make_request(
     ggl_sleep(2);
 
     // Create a json payload object
-    GglObject csr_payload_obj
-        = GGL_OBJ_MAP({ GGL_STR("certificateSigningRequest"),
-                        GGL_OBJ((GglBuffer) { .data = (uint8_t *) csr_as_string,
-                                              .len = strlen(csr_as_string) }) }
-        );
+    GglObject csr_payload_obj = GGL_OBJ_MAP(
+        GGL_MAP({ GGL_STR("certificateSigningRequest"),
+                  GGL_OBJ_BUF((GglBuffer) { .data = (uint8_t *) csr_as_string,
+                                            .len = strlen(csr_as_string) }) })
+    );
     GglError ret_err_json = ggl_json_encode(csr_payload_obj, &csr_buf);
     if (ret_err_json != GGL_ERR_OK) {
         return GGL_ERR_PARSE;
@@ -447,9 +449,9 @@ GglError make_request(
     // Prepare publish packet for requesting certificate with csr
     GglMap args = GGL_MAP(
         { GGL_STR("topic"),
-          GGL_OBJ((GglBuffer) { .len = strlen(cert_request_url),
-                                .data = (uint8_t *) cert_request_url }) },
-        { GGL_STR("payload"), GGL_OBJ(csr_buf) },
+          GGL_OBJ_BUF((GglBuffer) { .len = strlen(cert_request_url),
+                                    .data = (uint8_t *) cert_request_url }) },
+        { GGL_STR("payload"), GGL_OBJ_BUF(csr_buf) },
     );
 
     // NOLINTNEXTLINE(concurrency-mt-unsafe)

--- a/gg-fleet-statusd/src/fleet_status_service.c
+++ b/gg-fleet-statusd/src/fleet_status_service.c
@@ -46,19 +46,19 @@ GglError publish_message(GglBuffer thing_name) {
         return ret;
     }
 
-    GglObject payload_obj = GGL_OBJ_MAP(
-        { GGL_STR("ggcVersion"), GGL_OBJ_STR("3.13.0") },
-        { GGL_STR("platform"), GGL_OBJ_STR("linux") },
-        { GGL_STR("architecture"), GGL_OBJ_STR("amd64") },
-        { GGL_STR("runtime"), GGL_OBJ_STR("NucleusLite") },
-        { GGL_STR("thing"), GGL_OBJ(thing_name) },
+    GglObject payload_obj = GGL_OBJ_MAP(GGL_MAP(
+        { GGL_STR("ggcVersion"), GGL_OBJ_BUF(GGL_STR("3.13.0")) },
+        { GGL_STR("platform"), GGL_OBJ_BUF(GGL_STR("linux")) },
+        { GGL_STR("architecture"), GGL_OBJ_BUF(GGL_STR("amd64")) },
+        { GGL_STR("runtime"), GGL_OBJ_BUF(GGL_STR("NucleusLite")) },
+        { GGL_STR("thing"), GGL_OBJ_BUF(thing_name) },
         { GGL_STR("sequenceNumber"), GGL_OBJ_I64(1) },
         { GGL_STR("timestamp"), GGL_OBJ_I64(10) },
-        { GGL_STR("messageType"), GGL_OBJ_STR("COMPLETE") },
-        { GGL_STR("trigger"), GGL_OBJ_STR("NUCLEUS_LAUNCH") },
-        { GGL_STR("overallDeviceStatus"), GGL_OBJ_STR("HEALTHY") },
-        { GGL_STR("components"), GGL_OBJ_LIST() }
-    );
+        { GGL_STR("messageType"), GGL_OBJ_BUF(GGL_STR("COMPLETE")) },
+        { GGL_STR("trigger"), GGL_OBJ_BUF(GGL_STR("NUCLEUS_LAUNCH")) },
+        { GGL_STR("overallDeviceStatus"), GGL_OBJ_BUF(GGL_STR("HEALTHY")) },
+        { GGL_STR("components"), GGL_OBJ_LIST({ 0 }) }
+    ));
 
     // build payload
     static uint8_t payload_buf[PAYLOAD_BUFFER_LEN];

--- a/ggconfigd-test/src/entry.c
+++ b/ggconfigd-test/src/entry.c
@@ -51,7 +51,8 @@ GglError run_ggconfigd_test(void) {
 
     ret = ggl_kv_vec_push(
         &args,
-        (GglKV) { GGL_STR("recipe_directory_path"), GGL_OBJ(recipe_dir.buf) }
+        (GglKV) { GGL_STR("recipe_directory_path"),
+                  GGL_OBJ_BUF(recipe_dir.buf) }
     );
     if (ret != GGL_ERR_OK) {
         assert(false);
@@ -60,13 +61,13 @@ GglError run_ggconfigd_test(void) {
 
     GglKV component;
     if (component_name != NULL) {
-        component
-            = (GglKV) { ggl_buffer_from_null_term(component_name),
-                        GGL_OBJ(ggl_buffer_from_null_term(component_version)) };
+        component = (GglKV
+        ) { ggl_buffer_from_null_term(component_name),
+            GGL_OBJ_BUF(ggl_buffer_from_null_term(component_version)) };
         ret = ggl_kv_vec_push(
             &args,
             (GglKV) { GGL_STR("root_component_versions_to_add"),
-                      GGL_OBJ((GglMap) { .pairs = &component, .len = 1 }) }
+                      GGL_OBJ_MAP((GglMap) { .pairs = &component, .len = 1 }) }
         );
         if (ret != GGL_ERR_OK) {
             assert(false);

--- a/ggconfigd/src/db_corebus.c
+++ b/ggconfigd/src/db_corebus.c
@@ -206,7 +206,7 @@ static GglError process_map(
         GglKV *kv = &the_map->pairs[x];
         GGL_LOGT("Preparing %zu, %.*s", x, (int) kv->key.len, kv->key.data);
 
-        ggl_obj_vec_push(key_path, GGL_OBJ(kv->key));
+        ggl_obj_vec_push(key_path, GGL_OBJ_BUF(kv->key));
         GGL_LOGT("pushed the key");
         if (kv->val.type == GGL_TYPE_MAP) {
             GGL_LOGT("value is a map");

--- a/ggconfigd/src/db_interface.c
+++ b/ggconfigd/src/db_interface.c
@@ -606,7 +606,7 @@ static GglError notify_single_key(
         case SQLITE_ROW: {
             uint32_t handle = (uint32_t) sqlite3_column_int64(stmt, 0);
             GGL_LOGD("Sending to %u", handle);
-            ggl_respond(handle, GGL_OBJ(*changed_key_path));
+            ggl_respond(handle, GGL_OBJ_LIST(*changed_key_path));
         } break;
         default:
             GGL_LOGE(

--- a/ggdeploymentd/src/bus_server.c
+++ b/ggdeploymentd/src/bus_server.c
@@ -26,7 +26,7 @@ static void create_local_deployment(void *ctx, GglMap params, uint32_t handle) {
         return;
     }
 
-    ggl_respond(handle, GGL_OBJ(id.buf));
+    ggl_respond(handle, GGL_OBJ_BUF(id.buf));
 }
 
 void ggdeploymentd_start_server(void) {

--- a/ggdeploymentd/src/deployment_handler.c
+++ b/ggdeploymentd/src/deployment_handler.c
@@ -200,13 +200,14 @@ static GglError get_posix_user(char **posix_user) {
 }
 
 static GglError get_data_endpoint(GglByteVec *endpoint) {
-    GglMap params = GGL_MAP({ GGL_STR("key_path"),
-                              GGL_OBJ_LIST(
-                                  GGL_OBJ_STR("services"),
-                                  GGL_OBJ_STR("aws.greengrass.Nucleus-Lite"),
-                                  GGL_OBJ_STR("configuration"),
-                                  GGL_OBJ_STR("iotDataEndpoint")
-                              ) });
+    GglMap params
+        = GGL_MAP({ GGL_STR("key_path"),
+                    GGL_OBJ_LIST(GGL_LIST(
+                        GGL_OBJ_BUF(GGL_STR("services")),
+                        GGL_OBJ_BUF(GGL_STR("aws.greengrass.Nucleus-Lite")),
+                        GGL_OBJ_BUF(GGL_STR("configuration")),
+                        GGL_OBJ_BUF(GGL_STR("iotDataEndpoint"))
+                    )) });
 
     static uint8_t resp_mem[128] = { 0 };
     GglBumpAlloc balloc
@@ -234,13 +235,14 @@ static GglError get_data_endpoint(GglByteVec *endpoint) {
 }
 
 static GglError get_data_port(GglByteVec *port) {
-    GglMap params = GGL_MAP({ GGL_STR("key_path"),
-                              GGL_OBJ_LIST(
-                                  GGL_OBJ_STR("services"),
-                                  GGL_OBJ_STR("aws.greengrass.Nucleus-Lite"),
-                                  GGL_OBJ_STR("configuration"),
-                                  GGL_OBJ_STR("greengrassDataPlanePort")
-                              ) });
+    GglMap params
+        = GGL_MAP({ GGL_STR("key_path"),
+                    GGL_OBJ_LIST(GGL_LIST(
+                        GGL_OBJ_BUF(GGL_STR("services")),
+                        GGL_OBJ_BUF(GGL_STR("aws.greengrass.Nucleus-Lite")),
+                        GGL_OBJ_BUF(GGL_STR("configuration")),
+                        GGL_OBJ_BUF(GGL_STR("greengrassDataPlanePort"))
+                    )) });
 
     static uint8_t resp_mem[128] = { 0 };
     GglBumpAlloc balloc
@@ -268,10 +270,11 @@ static GglError get_data_port(GglByteVec *port) {
 }
 
 static GglError get_private_key_path(GglByteVec *pkey_path) {
-    GglMap params = GGL_MAP(
-        { GGL_STR("key_path"),
-          GGL_OBJ_LIST(GGL_OBJ_STR("system"), GGL_OBJ_STR("privateKeyPath")) }
-    );
+    GglMap params = GGL_MAP({ GGL_STR("key_path"),
+                              GGL_OBJ_LIST(GGL_LIST(
+                                  GGL_OBJ_BUF(GGL_STR("system")),
+                                  GGL_OBJ_BUF(GGL_STR("privateKeyPath"))
+                              )) });
 
     uint8_t resp_mem[128] = { 0 };
     GglBumpAlloc balloc
@@ -302,10 +305,10 @@ static GglError get_private_key_path(GglByteVec *pkey_path) {
 
 static GglError get_cert_path(GglByteVec *cert_path) {
     GglMap params = GGL_MAP({ GGL_STR("key_path"),
-                              GGL_OBJ_LIST(
-                                  GGL_OBJ_STR("system"),
-                                  GGL_OBJ_STR("certificateFilePath")
-                              ) });
+                              GGL_OBJ_LIST(GGL_LIST(
+                                  GGL_OBJ_BUF(GGL_STR("system")),
+                                  GGL_OBJ_BUF(GGL_STR("certificateFilePath"))
+                              )) });
 
     static uint8_t resp_mem[128] = { 0 };
     GglBumpAlloc balloc
@@ -335,10 +338,11 @@ static GglError get_cert_path(GglByteVec *cert_path) {
 }
 
 static GglError get_rootca_path(GglByteVec *rootca_path) {
-    GglMap params = GGL_MAP(
-        { GGL_STR("key_path"),
-          GGL_OBJ_LIST(GGL_OBJ_STR("system"), GGL_OBJ_STR("rootCaPath")) }
-    );
+    GglMap params = GGL_MAP({ GGL_STR("key_path"),
+                              GGL_OBJ_LIST(GGL_LIST(
+                                  GGL_OBJ_BUF(GGL_STR("system")),
+                                  GGL_OBJ_BUF(GGL_STR("rootCaPath"))
+                              )) });
 
     static uint8_t resp_mem[128] = { 0 };
     GglBumpAlloc balloc
@@ -1128,7 +1132,7 @@ static GglError parse_dataplane_response_and_save_recipe(
 
         ret = ggl_gg_config_write(
             GGL_BUF_LIST(GGL_STR("services"), cloud_component_name->buf, ),
-            GGL_OBJ_MAP({ GGL_STR("arn"), *cloud_component_arn }),
+            GGL_OBJ_MAP(GGL_MAP({ GGL_STR("arn"), *cloud_component_arn })),
             1
         );
         if (ret != GGL_ERR_OK) {
@@ -1179,7 +1183,7 @@ static GglError resolve_dependencies(
 
         ret = ggl_kv_vec_push(
             &components_to_resolve,
-            (GglKV) { pair->key, GGL_OBJ(component_version) }
+            (GglKV) { pair->key, GGL_OBJ_BUF(component_version) }
         );
         if (ret != GGL_ERR_OK) {
             return ret;
@@ -1195,7 +1199,7 @@ static GglError resolve_dependencies(
             GGL_STR("thingGroupsToRootComponents"),
             thing_group_name
         ),
-        GGL_OBJ(components_to_resolve.map),
+        GGL_OBJ_MAP(components_to_resolve.map),
         0
     );
 
@@ -1368,7 +1372,7 @@ static GglError resolve_dependencies(
                     ret = ggl_kv_vec_push(
                         &components_to_resolve,
                         (GglKV) { root_component_name_buf,
-                                  GGL_OBJ(root_component_version_buf) }
+                                  GGL_OBJ_BUF(root_component_version_buf) }
                     );
                     GGL_LOGD(
                         "Added %.*s to the list of root components to resolve "
@@ -1436,7 +1440,8 @@ static GglError resolve_dependencies(
         }
 
         ret = ggl_kv_vec_push(
-            resolved_components_kv_vec, (GglKV) { pair->key, GGL_OBJ(val_buf) }
+            resolved_components_kv_vec,
+            (GglKV) { pair->key, GGL_OBJ_BUF(val_buf) }
         );
         if (ret != GGL_ERR_OK) {
             GGL_LOGE(
@@ -1566,7 +1571,7 @@ static GglError resolve_dependencies(
                             return ret;
                         }
 
-                        *existing_requirements = GGL_OBJ(new_req_vec.buf);
+                        *existing_requirements = GGL_OBJ_BUF(new_req_vec.buf);
                     }
 
                     // If we haven't resolved it yet, and it doesn't have an
@@ -1592,7 +1597,7 @@ static GglError resolve_dependencies(
 
                         ret = ggl_kv_vec_push(
                             &components_to_resolve,
-                            (GglKV) { name_key_buf, GGL_OBJ(vers_key_buf) }
+                            (GglKV) { name_key_buf, GGL_OBJ_BUF(vers_key_buf) }
                         );
                         if (ret != GGL_ERR_OK) {
                             return ret;

--- a/ggdeploymentd/src/deployment_queue.c
+++ b/ggdeploymentd/src/deployment_queue.c
@@ -71,7 +71,7 @@ static GglError deep_copy_deployment(
 ) {
     assert(deployment != NULL);
 
-    GglObject obj = GGL_OBJ(deployment->deployment_id);
+    GglObject obj = GGL_OBJ_BUF(deployment->deployment_id);
     GglError ret = ggl_obj_deep_copy(&obj, alloc);
     if (ret != GGL_ERR_OK) {
         return ret;
@@ -88,42 +88,42 @@ static GglError deep_copy_deployment(
         return ret;
     }
 
-    obj = GGL_OBJ(deployment->root_component_versions_to_add);
+    obj = GGL_OBJ_MAP(deployment->root_component_versions_to_add);
     ret = ggl_obj_deep_copy(&obj, alloc);
     if (ret != GGL_ERR_OK) {
         return ret;
     }
     deployment->root_component_versions_to_add = obj.map;
 
-    obj = GGL_OBJ(deployment->cloud_root_components_to_add);
+    obj = GGL_OBJ_MAP(deployment->cloud_root_components_to_add);
     ret = ggl_obj_deep_copy(&obj, alloc);
     if (ret != GGL_ERR_OK) {
         return ret;
     }
     deployment->cloud_root_components_to_add = obj.map;
 
-    obj = GGL_OBJ(deployment->root_components_to_remove);
+    obj = GGL_OBJ_LIST(deployment->root_components_to_remove);
     ret = ggl_obj_deep_copy(&obj, alloc);
     if (ret != GGL_ERR_OK) {
         return ret;
     }
     deployment->root_components_to_remove = obj.list;
 
-    obj = GGL_OBJ(deployment->component_to_configuration);
+    obj = GGL_OBJ_MAP(deployment->component_to_configuration);
     ret = ggl_obj_deep_copy(&obj, alloc);
     if (ret != GGL_ERR_OK) {
         return ret;
     }
     deployment->component_to_configuration = obj.map;
 
-    obj = GGL_OBJ(deployment->configuration_arn);
+    obj = GGL_OBJ_BUF(deployment->configuration_arn);
     ret = ggl_obj_deep_copy(&obj, alloc);
     if (ret != GGL_ERR_OK) {
         return ret;
     }
     deployment->configuration_arn = obj.buf;
 
-    obj = GGL_OBJ(deployment->thing_group);
+    obj = GGL_OBJ_BUF(deployment->thing_group);
     ret = ggl_obj_deep_copy(&obj, alloc);
     if (ret != GGL_ERR_OK) {
         return ret;

--- a/ggdeploymentd/src/iot_jobs_listener.c
+++ b/ggdeploymentd/src/iot_jobs_listener.c
@@ -193,12 +193,13 @@ static GglError update_job(
     }
 
     // https://docs.aws.amazon.com/iot/latest/developerguide/jobs-mqtt-api.html
-    GglObject payload_object = GGL_OBJ_MAP(
-        { GGL_STR("status"), GGL_OBJ(job_status) },
+    GglObject payload_object = GGL_OBJ_MAP(GGL_MAP(
+        { GGL_STR("status"), GGL_OBJ_BUF(job_status) },
         { GGL_STR("expectedVersion"),
-          GGL_OBJ((GglBuffer) { .data = version_buf, .len = (size_t) len }) },
-        { GGL_STR("clientToken"), GGL_OBJ_STR("jobs-nucleus-lite") }
-    );
+          GGL_OBJ_BUF((GglBuffer) { .data = version_buf, .len = (size_t) len }
+          ) },
+        { GGL_STR("clientToken"), GGL_OBJ_BUF(GGL_STR("jobs-nucleus-lite")) }
+    ));
 
     GglBumpAlloc call_alloc = ggl_bump_alloc_init(GGL_BUF(response_scratch));
     GglObject result = GGL_OBJ_NULL();
@@ -220,12 +221,12 @@ static GglError describe_next_job(void) {
     }
 
     // https://docs.aws.amazon.com/iot/latest/developerguide/jobs-mqtt-api.html
-    GglObject payload_object = GGL_OBJ_MAP(
-        { GGL_STR("jobId"), GGL_OBJ_STR(NEXT_JOB_LITERAL) },
-        { GGL_STR("thingName"), GGL_OBJ(thing_name_buf) },
+    GglObject payload_object = GGL_OBJ_MAP(GGL_MAP(
+        { GGL_STR("jobId"), GGL_OBJ_BUF(GGL_STR(NEXT_JOB_LITERAL)) },
+        { GGL_STR("thingName"), GGL_OBJ_BUF(thing_name_buf) },
         { GGL_STR("includeJobDocument"), GGL_OBJ_BOOL(true) },
-        { GGL_STR("clientToken"), GGL_OBJ_STR("jobs-nucleus-lite") }
-    );
+        { GGL_STR("clientToken"), GGL_OBJ_BUF(GGL_STR("jobs-nucleus-lite")) }
+    ));
 
     GglBumpAlloc call_alloc = ggl_bump_alloc_init(GGL_BUF(response_scratch));
     GglObject job_description = GGL_OBJ_NULL();

--- a/gghealthd/src/bus_server.c
+++ b/gghealthd/src/bus_server.c
@@ -39,10 +39,10 @@ static void get_status(void *ctx, GglMap params, uint32_t handle) {
         );
         ggl_respond(
             handle,
-            GGL_OBJ_MAP(
-                { GGL_STR("component_name"), GGL_OBJ(component_name->buf) },
-                { GGL_STR("lifecycle_state"), GGL_OBJ(status) },
-            )
+            GGL_OBJ_MAP(GGL_MAP(
+                { GGL_STR("component_name"), GGL_OBJ_BUF(component_name->buf) },
+                { GGL_STR("lifecycle_state"), GGL_OBJ_BUF(status) },
+            ))
         );
     } else {
         ggl_return_err(handle, error);
@@ -93,7 +93,7 @@ static void get_health(void *ctx, GglMap params, uint32_t handle) {
     GglError error = gghealthd_get_health(&status);
 
     if (error == GGL_ERR_OK) {
-        ggl_respond(handle, GGL_OBJ(status));
+        ggl_respond(handle, GGL_OBJ_BUF(status));
     } else {
         ggl_return_err(handle, error);
     }

--- a/gghealthd/src/health.c
+++ b/gghealthd/src/health.c
@@ -372,13 +372,13 @@ static GglError get_run_status(
         return err;
     }
     const GglMap STATUS_MAP = GGL_MAP(
-        { GGL_STR("activating"), GGL_OBJ_STR("STARTING") },
-        { GGL_STR("active"), GGL_OBJ_STR("RUNNING") },
+        { GGL_STR("activating"), GGL_OBJ_BUF(GGL_STR("STARTING")) },
+        { GGL_STR("active"), GGL_OBJ_BUF(GGL_STR("RUNNING")) },
         // `reloading` doesn't have any mapping to greengrass. It's an
         // active component whose systemd (not greengrass) configuration is
         // reloading
-        { GGL_STR("reloading"), GGL_OBJ_STR("RUNNING") },
-        { GGL_STR("deactivating"), GGL_OBJ_STR("STOPPING") },
+        { GGL_STR("reloading"), GGL_OBJ_BUF(GGL_STR("RUNNING")) },
+        { GGL_STR("deactivating"), GGL_OBJ_BUF(GGL_STR("STOPPING")) },
         // inactive and failed are ambiguous
         { GGL_STR("inactive"), GGL_OBJ_NULL() },
         { GGL_STR("failed"), GGL_OBJ_NULL() },
@@ -447,11 +447,11 @@ GglError gghealthd_update_status(GglBuffer component_name, GglBuffer status) {
     const GglMap STATUS_MAP = GGL_MAP(
         { GGL_STR("NEW"), GGL_OBJ_NULL() },
         { GGL_STR("INSTALLED"), GGL_OBJ_NULL() },
-        { GGL_STR("STARTING"), GGL_OBJ_STR("RELOADING=1") },
-        { GGL_STR("RUNNING"), GGL_OBJ_STR("READY=1") },
-        { GGL_STR("ERRORED"), GGL_OBJ_STR("ERRNO=71") },
-        { GGL_STR("BROKEN"), GGL_OBJ_STR("ERRNO=71") },
-        { GGL_STR("STOPPING"), GGL_OBJ_STR("STOPPING=1") },
+        { GGL_STR("STARTING"), GGL_OBJ_BUF(GGL_STR("RELOADING=1")) },
+        { GGL_STR("RUNNING"), GGL_OBJ_BUF(GGL_STR("READY=1")) },
+        { GGL_STR("ERRORED"), GGL_OBJ_BUF(GGL_STR("ERRNO=71")) },
+        { GGL_STR("BROKEN"), GGL_OBJ_BUF(GGL_STR("ERRNO=71")) },
+        { GGL_STR("STOPPING"), GGL_OBJ_BUF(GGL_STR("STOPPING=1")) },
         { GGL_STR("FINISHED"), GGL_OBJ_NULL() }
     );
 

--- a/ggipc-client/src/client.c
+++ b/ggipc-client/src/client.c
@@ -46,7 +46,7 @@ static GglError payload_writer(GglBuffer *buf, void *payload) {
     }
 
     GglMap *map = payload;
-    return ggl_json_encode(GGL_OBJ(*map), buf);
+    return ggl_json_encode(GGL_OBJ_MAP(*map), buf);
 }
 
 static GglError send_message(
@@ -271,7 +271,7 @@ GglError ggipc_private_get_system_config(
     GglError ret = ggipc_call(
         conn,
         GGL_STR("aws.greengrass.private#GetSystemConfig"),
-        GGL_MAP({ GGL_STR("key"), GGL_OBJ(key) }),
+        GGL_MAP({ GGL_STR("key"), GGL_OBJ_BUF(key) }),
         &balloc.alloc,
         &resp
     );
@@ -302,7 +302,7 @@ GglError ggipc_get_config_str(
     GglObjVec path_vec = GGL_OBJ_VEC((GglObject[GGL_MAX_OBJECT_DEPTH]) { 0 });
     GglError ret = GGL_ERR_OK;
     for (size_t i = 0; i < key_path.len; i++) {
-        ggl_obj_vec_chain_push(&ret, &path_vec, GGL_OBJ(key_path.bufs[i]));
+        ggl_obj_vec_chain_push(&ret, &path_vec, GGL_OBJ_BUF(key_path.bufs[i]));
     }
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("Key path too long.");
@@ -311,12 +311,12 @@ GglError ggipc_get_config_str(
 
     GglKVVec args = GGL_KV_VEC((GglKV[2]) { 0 });
     (void) ggl_kv_vec_push(
-        &args, (GglKV) { GGL_STR("keyPath"), GGL_OBJ(path_vec.list) }
+        &args, (GglKV) { GGL_STR("keyPath"), GGL_OBJ_LIST(path_vec.list) }
     );
     if (component_name != NULL) {
         (void) ggl_kv_vec_push(
             &args,
-            (GglKV) { GGL_STR("componentName"), GGL_OBJ(*component_name) }
+            (GglKV) { GGL_STR("componentName"), GGL_OBJ_BUF(*component_name) }
         );
     }
 
@@ -364,8 +364,8 @@ GglError ggipc_publish_to_iot_core(
     int conn, GglBuffer topic_name, GglBuffer payload, uint8_t qos
 ) {
     GglMap args = GGL_MAP(
-        { GGL_STR("topicName"), GGL_OBJ(topic_name) },
-        { GGL_STR("payload"), GGL_OBJ(payload) },
+        { GGL_STR("topicName"), GGL_OBJ_BUF(topic_name) },
+        { GGL_STR("payload"), GGL_OBJ_BUF(payload) },
         { GGL_STR("qos"), GGL_OBJ_I64(qos) }
     );
 

--- a/ggipcd/src/services/cli/create_local_deployment.c
+++ b/ggipcd/src/services/cli/create_local_deployment.c
@@ -80,6 +80,6 @@ GglError ggl_handle_create_local_deployment(
         handle,
         stream_id,
         GGL_STR("aws.greengrass#CreateLocalDeploymentResponse"),
-        GGL_OBJ_MAP({ GGL_STR("deploymentId"), result })
+        GGL_OBJ_MAP(GGL_MAP({ GGL_STR("deploymentId"), result }))
     );
 }

--- a/ggipcd/src/services/config/config_path_object.c
+++ b/ggipcd/src/services/config/config_path_object.c
@@ -48,11 +48,11 @@ GglError ggl_parse_config_path(
     component_key_path.list.len = 0;
 
     GglError ret = ggl_obj_vec_push(
-        &component_key_path, GGL_OBJ(config_path.items[3].buf)
+        &component_key_path, GGL_OBJ_BUF(config_path.items[3].buf)
     );
     for (size_t i = 4; i < config_path.len; i++) {
         ggl_obj_vec_chain_push(
-            &ret, &component_key_path, GGL_OBJ(config_path.items[i].buf)
+            &ret, &component_key_path, GGL_OBJ_BUF(config_path.items[i].buf)
         );
     }
     if (ret != GGL_ERR_OK) {

--- a/ggipcd/src/services/config/get_configuration.c
+++ b/ggipcd/src/services/config/get_configuration.c
@@ -80,9 +80,9 @@ GglError ggl_handle_get_configuration(
         handle,
         stream_id,
         GGL_STR("aws.greengrass#GetConfigurationResponse"),
-        GGL_OBJ_MAP(
-            { GGL_STR("componentName"), GGL_OBJ(component_name) },
+        GGL_OBJ_MAP(GGL_MAP(
+            { GGL_STR("componentName"), GGL_OBJ_BUF(component_name) },
             { GGL_STR("value"), read_value }
-        )
+        ))
     );
 }

--- a/ggipcd/src/services/config/subscribe_to_configuration_update.c
+++ b/ggipcd/src/services/config/subscribe_to_configuration_update.c
@@ -37,13 +37,13 @@ static GglError subscribe_to_configuration_update_callback(
         return err;
     }
 
-    GglObject ipc_response = GGL_OBJ_MAP(
+    GglObject ipc_response = GGL_OBJ_MAP(GGL_MAP(
         { GGL_STR("configurationUpdateEvent"),
-          GGL_OBJ_MAP(
-              { GGL_STR("componentName"), GGL_OBJ(component_name) },
-              { GGL_STR("keyPath"), GGL_OBJ(key_path) },
-          ) },
-    );
+          GGL_OBJ_MAP(GGL_MAP(
+              { GGL_STR("componentName"), GGL_OBJ_BUF(component_name) },
+              { GGL_STR("keyPath"), GGL_OBJ_LIST(key_path) },
+          )) },
+    ));
 
     err = ggl_ipc_response_send(
         resp_handle,
@@ -92,7 +92,7 @@ GglError ggl_handle_subscribe_to_configuration_update(
     // this component's configuration. Similarly, (although this doesn't appear
     // to be documented) no key path provided also implies we want to subscribe
     // to all keys under this component's configuration
-    GglObject *empty_list = (GglObject *) &GGL_OBJ_LIST();
+    GglObject *empty_list = (GglObject *) &GGL_OBJ_LIST({ 0 });
     if (key_path_obj == NULL) {
         key_path_obj = empty_list;
     } else {
@@ -123,13 +123,13 @@ GglError ggl_handle_subscribe_to_configuration_update(
 
     GglObject config_path_obj[GGL_MAX_OBJECT_DEPTH] = { 0 };
     for (size_t i = 0; i < full_key_path.len; i++) {
-        config_path_obj[i] = GGL_OBJ(full_key_path.bufs[i]);
+        config_path_obj[i] = GGL_OBJ_BUF(full_key_path.bufs[i]);
     }
 
     GglMap call_args = GGL_MAP(
         { GGL_STR("key_path"),
-          GGL_OBJ((GglList) { .items = config_path_obj,
-                              .len = full_key_path.len }) },
+          GGL_OBJ_LIST((GglList) { .items = config_path_obj,
+                                   .len = full_key_path.len }) },
     );
 
     // TODO: return IPC errors
@@ -152,6 +152,6 @@ GglError ggl_handle_subscribe_to_configuration_update(
         handle,
         stream_id,
         GGL_STR("aws.greengrass#SubscribeToConfigurationUpdateResponse"),
-        GGL_OBJ_MAP()
+        GGL_OBJ_MAP({ 0 })
     );
 }

--- a/ggipcd/src/services/config/update_configuration.c
+++ b/ggipcd/src/services/config/update_configuration.c
@@ -92,6 +92,6 @@ GglError ggl_handle_update_configuration(
         handle,
         stream_id,
         GGL_STR("aws.greengrass#UpdateConfigurationResponse"),
-        GGL_OBJ_MAP()
+        GGL_OBJ_MAP({ 0 })
     );
 }

--- a/ggipcd/src/services/mqttproxy/publish_to_iot_core.c
+++ b/ggipcd/src/services/mqttproxy/publish_to_iot_core.c
@@ -84,6 +84,6 @@ GglError ggl_handle_publish_to_iot_core(
         handle,
         stream_id,
         GGL_STR("aws.greengrass#PublishToIoTCoreResponse"),
-        GGL_OBJ_MAP()
+        GGL_OBJ_MAP({ 0 })
     );
 }

--- a/ggipcd/src/services/mqttproxy/subscribe_to_iot_core.c
+++ b/ggipcd/src/services/mqttproxy/subscribe_to_iot_core.c
@@ -38,12 +38,13 @@ static GglError subscribe_to_iot_core_callback(
         return GGL_ERR_OK;
     }
 
-    GglObject response
-        = GGL_OBJ_MAP({ GGL_STR("message"),
-                        GGL_OBJ_MAP(
-                            { GGL_STR("topicName"), GGL_OBJ(*topic) },
-                            { GGL_STR("payload"), GGL_OBJ(base64_payload) }
-                        ) });
+    GglObject response = GGL_OBJ_MAP(
+        GGL_MAP({ GGL_STR("message"),
+                  GGL_OBJ_MAP(GGL_MAP(
+                      { GGL_STR("topicName"), GGL_OBJ_BUF(*topic) },
+                      { GGL_STR("payload"), GGL_OBJ_BUF(base64_payload) }
+                  )) })
+    );
 
     ret = ggl_ipc_response_send(
         resp_handle,
@@ -125,6 +126,6 @@ GglError ggl_handle_subscribe_to_iot_core(
         handle,
         stream_id,
         GGL_STR("aws.greengrass#SubscribeToIoTCoreResponse"),
-        GGL_OBJ_MAP()
+        GGL_OBJ_MAP({ 0 })
     );
 }

--- a/ggipcd/src/services/pubsub/publish_to_topic.c
+++ b/ggipcd/src/services/pubsub/publish_to_topic.c
@@ -80,7 +80,8 @@ GglError ggl_handle_publish_to_topic(
     GglMap call_args = GGL_MAP(
         { GGL_STR("topic"), *topic },
         { GGL_STR("type"),
-          is_json ? GGL_OBJ_STR("json") : GGL_OBJ_STR("base64") },
+          is_json ? GGL_OBJ_BUF(GGL_STR("json"))
+                  : GGL_OBJ_BUF(GGL_STR("base64")) },
         { GGL_STR("message"), *message },
     );
 
@@ -95,6 +96,6 @@ GglError ggl_handle_publish_to_topic(
         handle,
         stream_id,
         GGL_STR("aws.greengrass#PublishToTopicResponse"),
-        GGL_OBJ_MAP()
+        GGL_OBJ_MAP({ 0 })
     );
 }

--- a/ggipcd/src/services/pubsub/subscribe_to_topic.c
+++ b/ggipcd/src/services/pubsub/subscribe_to_topic.c
@@ -59,14 +59,15 @@ static GglError subscribe_to_topic_callback(
         return GGL_ERR_INVALID;
     }
 
-    GglObject inner = GGL_OBJ_MAP(
+    GglObject inner = GGL_OBJ_MAP(GGL_MAP(
         { GGL_STR("message"), *message_obj },
-        { GGL_STR("context"), GGL_OBJ_MAP({ GGL_STR("topic"), *topic_obj }) }
-    );
+        { GGL_STR("context"),
+          GGL_OBJ_MAP(GGL_MAP({ GGL_STR("topic"), *topic_obj })) }
+    ));
 
-    GglObject response = GGL_OBJ_MAP(
+    GglObject response = GGL_OBJ_MAP(GGL_MAP(
         { is_json ? GGL_STR("jsonMessage") : GGL_STR("binaryMessage"), inner }
-    );
+    ));
 
     ret = ggl_ipc_response_send(
         resp_handle,
@@ -126,6 +127,6 @@ GglError ggl_handle_subscribe_to_topic(
         handle,
         stream_id,
         GGL_STR("aws.greengrass#SubscribeToTopicResponse"),
-        GGL_OBJ_MAP()
+        GGL_OBJ_MAP({ 0 })
     );
 }

--- a/ggl-cli/bin/ggl-cli.c
+++ b/ggl-cli/bin/ggl-cli.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
         GglError ret = ggl_kv_vec_push(
             &args,
             (GglKV) { GGL_STR("recipe_directory_path"),
-                      GGL_OBJ(ggl_buffer_from_null_term(recipe_dir)) }
+                      GGL_OBJ_BUF(ggl_buffer_from_null_term(recipe_dir)) }
         );
         if (ret != GGL_ERR_OK) {
             assert(false);
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
         GglError ret = ggl_kv_vec_push(
             &args,
             (GglKV) { GGL_STR("artifacts_directory_path"),
-                      GGL_OBJ(ggl_buffer_from_null_term(artifacts_dir)) }
+                      GGL_OBJ_BUF(ggl_buffer_from_null_term(artifacts_dir)) }
         );
         if (ret != GGL_ERR_OK) {
             assert(false);
@@ -106,13 +106,13 @@ int main(int argc, char **argv) {
     }
     GglKV component;
     if (component_name != NULL) {
-        component
-            = (GglKV) { ggl_buffer_from_null_term(component_name),
-                        GGL_OBJ(ggl_buffer_from_null_term(component_version)) };
+        component = (GglKV
+        ) { ggl_buffer_from_null_term(component_name),
+            GGL_OBJ_BUF(ggl_buffer_from_null_term(component_version)) };
         GglError ret = ggl_kv_vec_push(
             &args,
             (GglKV) { GGL_STR("root_component_versions_to_add"),
-                      GGL_OBJ((GglMap) { .pairs = &component, .len = 1 }) }
+                      GGL_OBJ_MAP((GglMap) { .pairs = &component, .len = 1 }) }
         );
         if (ret != GGL_ERR_OK) {
             assert(false);

--- a/ggl-json/src/json_decode.c
+++ b/ggl-json/src/json_decode.c
@@ -627,7 +627,7 @@ static GglError decode_json_str(GglBuffer content, GglObject *obj) {
         GGL_LOGE("Error decoding JSON string.");
         return GGL_ERR_PARSE;
     }
-    *obj = GGL_OBJ(str);
+    *obj = GGL_OBJ_BUF(str);
     return GGL_ERR_OK;
 }
 
@@ -700,7 +700,7 @@ static GglError decode_json_array(
         }
     }
 
-    *obj = GGL_OBJ((GglList) { .items = items, .len = count });
+    *obj = GGL_OBJ_LIST((GglList) { .items = items, .len = count });
     return GGL_ERR_OK;
 }
 
@@ -755,7 +755,7 @@ static GglError decode_json_object(
         }
     }
 
-    *obj = GGL_OBJ((GglMap) { .pairs = pairs, .len = count });
+    *obj = GGL_OBJ_MAP((GglMap) { .pairs = pairs, .len = count });
     return GGL_ERR_OK;
 }
 

--- a/ggl-json/src/json_encode.c
+++ b/ggl-json/src/json_encode.c
@@ -159,7 +159,7 @@ static GglError json_write_map(GglMap map, GglBuffer *buf) {
                 return ret;
             }
         }
-        ret = json_write(GGL_OBJ(map.pairs[i].key), buf);
+        ret = json_write(GGL_OBJ_BUF(map.pairs[i].key), buf);
         if (ret != GGL_ERR_OK) {
             return ret;
         }

--- a/ggl-lib/include/ggl/object.h
+++ b/ggl-lib/include/ggl/object.h
@@ -132,60 +132,23 @@ typedef struct GglKV {
         .type = GGL_TYPE_F64, .f64 = (value) \
     }
 
-/// Create buffer object literal from a string literal.
-#define GGL_OBJ_STR(strlit) \
-    (GglObject) { \
-        .type = GGL_TYPE_BUF, .buf = GGL_STR(strlit), \
-    }
-
-/// Create buffer object literal from a byte array.
+/// Create buffer object literal.
 #define GGL_OBJ_BUF(...) \
     (GglObject) { \
-        .type = GGL_TYPE_BUF, .buf = GGL_BUF(__VA_ARGS__), \
+        .type = GGL_TYPE_BUF, .buf = __VA_ARGS__, \
     }
 
-/// Create map object literal from `Ggl_KV` literals.
+/// Create map object literal.
 #define GGL_OBJ_MAP(...) \
     (GglObject) { \
-        .type = GGL_TYPE_MAP, .map = GGL_MAP(__VA_ARGS__), \
+        .type = GGL_TYPE_MAP, .map = __VA_ARGS__, \
     }
 
-/// Create list object literal from object literals.
+/// Create list object literal.
 #define GGL_OBJ_LIST(...) \
     (GglObject) { \
-        .type = GGL_TYPE_LIST, .list = GGL_LIST(__VA_ARGS__), \
+        .type = GGL_TYPE_LIST, .list = __VA_ARGS__, \
     }
-
-#ifndef __COVERITY__
-// NOLINTBEGIN(bugprone-macro-parentheses)
-#define GGL_FORCE(type, value) \
-    _Generic((value), type: (value), default: (type) { 0 })
-// NOLINTEND(bugprone-macro-parentheses)
-
-/// Create object literal from any contained type.
-#define GGL_OBJ(...) \
-    _Generic( \
-        (__VA_ARGS__), \
-        GglBuffer: (GglObject) { .type = GGL_TYPE_BUF, \
-                                 .buf = GGL_FORCE(GglBuffer, (__VA_ARGS__)) }, \
-        GglList: (GglObject) { .type = GGL_TYPE_LIST, \
-                               .list = GGL_FORCE(GglList, (__VA_ARGS__)) }, \
-        GglMap: (GglObject) { .type = GGL_TYPE_MAP, \
-                              .map = GGL_FORCE(GglMap, (__VA_ARGS__)) }, \
-        bool: (GglObject) { .type = GGL_TYPE_BOOLEAN, \
-                            .boolean = GGL_FORCE(bool, (__VA_ARGS__)) }, \
-        int64_t: (GglObject) { .type = GGL_TYPE_I64, \
-                               .i64 = GGL_FORCE(int64_t, (__VA_ARGS__)) }, \
-        double: (GglObject) { .type = GGL_TYPE_F64, \
-                              .f64 = GGL_FORCE(double, (__VA_ARGS__)) } \
-    )
-
-#else
-#define GGL_OBJ(...) \
-    (GglObject) { \
-        0 \
-    }
-#endif
 
 /// Modifies an object's references to point to copies in alloc
 GglError ggl_obj_deep_copy(GglObject *obj, GglAlloc *alloc);

--- a/ggl-yaml/src/yaml_decode.c
+++ b/ggl-yaml/src/yaml_decode.c
@@ -52,7 +52,7 @@ static GglError yaml_scalar_to_obj(
         return ret;
     }
 
-    *obj = GGL_OBJ(result);
+    *obj = GGL_OBJ_BUF(result);
     return GGL_ERR_OK;
 }
 
@@ -118,7 +118,7 @@ static GglError yaml_mapping_to_obj(
         }
     }
 
-    *obj = GGL_OBJ((GglMap) { .pairs = pairs, .len = len });
+    *obj = GGL_OBJ_MAP((GglMap) { .pairs = pairs, .len = len });
     return GGL_ERR_OK;
 }
 
@@ -164,7 +164,7 @@ static GglError yaml_sequence_to_obj(
         }
     }
 
-    *obj = GGL_OBJ((GglList) { .items = items, .len = len });
+    *obj = GGL_OBJ_LIST((GglList) { .items = items, .len = len });
     return GGL_ERR_OK;
 }
 

--- a/ggpubsubd/src/bus_server.c
+++ b/ggpubsubd/src/bus_server.c
@@ -111,7 +111,7 @@ static void rpc_publish(void *ctx, GglMap params, uint32_t handle) {
                 &matches
             );
             if (matches) {
-                ggl_respond(sub_handle[i], GGL_OBJ(params));
+                ggl_respond(sub_handle[i], GGL_OBJ_MAP(params));
             }
         }
     }

--- a/iotcored/src/subscription_dispatch.c
+++ b/iotcored/src/subscription_dispatch.c
@@ -104,10 +104,10 @@ void iotcored_mqtt_receive(const IotcoredMsg *msg) {
             )) {
             ggl_respond(
                 handles[i],
-                GGL_OBJ_MAP(
-                    { GGL_STR("topic"), GGL_OBJ(msg->topic) },
-                    { GGL_STR("payload"), GGL_OBJ(msg->payload) }
-                )
+                GGL_OBJ_MAP(GGL_MAP(
+                    { GGL_STR("topic"), GGL_OBJ_BUF(msg->topic) },
+                    { GGL_STR("payload"), GGL_OBJ_BUF(msg->payload) }
+                ))
             );
         }
     }

--- a/recipe2unit/src/unit_file_generator.c
+++ b/recipe2unit/src/unit_file_generator.c
@@ -624,13 +624,13 @@ static GglError parse_install_section(
             &ret, &socketpath_vec, GGL_STR("/gg-ipc.socket")
         );
 
-        GglObject out_object = GGL_OBJ_MAP(
+        GglObject out_object = GGL_OBJ_MAP(GGL_MAP(
             { GGL_STR("requiresprivilege"), GGL_OBJ_BOOL(is_root) },
-            { GGL_STR("script"), GGL_OBJ(selected_script) },
-            { GGL_STR("set_env"), GGL_OBJ(set_env_as_map) },
+            { GGL_STR("script"), GGL_OBJ_BUF(selected_script) },
+            { GGL_STR("set_env"), GGL_OBJ_MAP(set_env_as_map) },
             { GGL_STR("AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT"),
-              GGL_OBJ(socketpath_vec.buf) }
-        );
+              GGL_OBJ_BUF(socketpath_vec.buf) }
+        ));
 
         ret = ggl_obj_deep_copy(&out_object, allocator);
         if (ret != GGL_ERR_OK) {
@@ -652,7 +652,7 @@ static GglError create_standardized_install_file(
     static uint8_t json_buf[MAX_SCRIPT_SIZE];
     GglBuffer install_json_payload = GGL_BUF(json_buf);
     GglError ret = ggl_json_encode(
-        GGL_OBJ(standardized_install_map), &install_json_payload
+        GGL_OBJ_MAP(standardized_install_map), &install_json_payload
     );
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("Failed to encode JSON.");

--- a/samples/deployment-client/bin/deployment-client.c
+++ b/samples/deployment-client/bin/deployment-client.c
@@ -18,9 +18,9 @@ int main(void) {
 
     GglMap args = GGL_MAP(
         { GGL_STR("recipe_directory_path"),
-          GGL_OBJ_STR("/home/ubuntu/recipes") },
+          GGL_OBJ_BUF(GGL_STR("/home/ubuntu/recipes")) },
         { GGL_STR("artifact_directory_path"),
-          GGL_OBJ_STR("/home/ubuntu/artifacts") }
+          GGL_OBJ_BUF(GGL_STR("/home/ubuntu/artifacts")) }
     );
 
     GglBumpAlloc alloc = ggl_bump_alloc_init(GGL_BUF(buffer));

--- a/samples/echo-server/bin/echo-server.c
+++ b/samples/echo-server/bin/echo-server.c
@@ -10,7 +10,7 @@
 
 static void handle_echo(void *ctx, GglMap params, uint32_t handle) {
     (void) ctx;
-    ggl_respond(handle, GGL_OBJ(params));
+    ggl_respond(handle, GGL_OBJ_MAP(params));
 }
 
 int main(void) {

--- a/samples/example-client/bin/example-client.c
+++ b/samples/example-client/bin/example-client.c
@@ -16,7 +16,8 @@ int main(void) {
     GglBuffer server = GGL_STR("/aws/ggl/echo-server");
     static uint8_t buffer[10 * sizeof(GglObject)] = { 0 };
 
-    GglMap args = GGL_MAP({ GGL_STR("message"), GGL_OBJ_STR("hello world") });
+    GglMap args
+        = GGL_MAP({ GGL_STR("message"), GGL_OBJ_BUF(GGL_STR("hello world")) });
 
     struct timespec before;
     struct timespec after;

--- a/samples/status-monitor-client/bin/status-monitor-client.c
+++ b/samples/status-monitor-client/bin/status-monitor-client.c
@@ -24,7 +24,8 @@ int main(void) {
         GglError call_error = ggl_call(
             GGL_STR("/aws/ggl/gghealthd"),
             GGL_STR("get_status"),
-            GGL_MAP({ GGL_STR("component_name"), GGL_OBJ_STR("gghealthd") }),
+            GGL_MAP({ GGL_STR("component_name"),
+                      GGL_OBJ_BUF(GGL_STR("gghealthd")) }),
             &method_error,
             &alloc.alloc,
             &result

--- a/tesd/src/token_service.c
+++ b/tesd/src/token_service.c
@@ -148,7 +148,7 @@ static void rpc_request_formatted_creds(
         return;
     }
 
-    ggl_respond(handle, GGL_OBJ(server_json_creds));
+    ggl_respond(handle, GGL_OBJ_MAP(server_json_creds));
 }
 
 static void start_tes_core_bus_server(void) {


### PR DESCRIPTION
Coverity doesnt handle _Generic.
Using explicit types will also speed up clang-tidy.