### PR TITLE
Use backoff in connecting to IoT core; Unregister all mqtt subs on disconnect

### DIFF
--- a/iotcored/CMakeLists.txt
+++ b/iotcored/CMakeLists.txt
@@ -2,5 +2,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ggl_init_module(iotcored LIBS ggl-lib core-bus core-bus-gg-config core_mqtt
-                              ggl-backoff PkgConfig::openssl)
+ggl_init_module(
+  iotcored
+  LIBS ggl-lib
+       core-bus
+       core-bus-gg-config
+       core_mqtt
+       ggl-backoff
+       ggl-file
+       PkgConfig::openssl)

--- a/iotcored/src/mqtt.c
+++ b/iotcored/src/mqtt.c
@@ -7,6 +7,7 @@
 #include "ggl/log.h"
 #include "ggl/utils.h"
 #include "iotcored.h"
+#include "subscription_dispatch.h"
 #include "tls.h"
 #include <sys/types.h>
 #include <assert.h>

--- a/iotcored/src/subscription_dispatch.c
+++ b/iotcored/src/subscription_dispatch.c
@@ -112,3 +112,15 @@ void iotcored_mqtt_receive(const IotcoredMsg *msg) {
         }
     }
 }
+
+void iotcored_unregister_all_subs(void) {
+    GGL_MTX_SCOPE_GUARD(&mtx);
+
+    for (size_t i = 0; i < IOTCORED_MAX_SUBSCRIPTIONS; i++) {
+        if (topic_filter_len[i] != 0) {
+            ggl_server_sub_close(handles[i]);
+
+            topic_filter_len[i] = 0;
+        }
+    }
+}

--- a/iotcored/src/subscription_dispatch.h
+++ b/iotcored/src/subscription_dispatch.h
@@ -16,4 +16,6 @@ GglError iotcored_register_subscriptions(
 
 void iotcored_unregister_subscriptions(uint32_t handle);
 
+void iotcored_unregister_all_subs(void);
+
 #endif


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
