### PR TITLE
Add unsubscribe logic in iotcored

### DIFF
--- a/iotcored/src/mqtt.c
+++ b/iotcored/src/mqtt.c
@@ -350,6 +350,44 @@ GglError iotcored_mqtt_subscribe(
     return 0;
 }
 
+GglError iotcored_mqtt_unsubscribe(GglBuffer *topic_filters, size_t count) {
+    assert(count > 0);
+    assert(count < GGL_MQTT_MAX_SUBSCRIBE_FILTERS);
+
+    static MQTTSubscribeInfo_t sub_infos[GGL_MQTT_MAX_SUBSCRIBE_FILTERS];
+
+    for (size_t i = 0; i < count; i++) {
+        sub_infos[i] = (MQTTSubscribeInfo_t) {
+            .pTopicFilter = (char *) topic_filters[i].data,
+            .topicFilterLength = (uint16_t) topic_filters[i].len,
+            .qos = 0,
+        };
+    }
+
+    MQTTStatus_t result = MQTT_Unsubscribe(
+        &mqtt_ctx, sub_infos, count, MQTT_GetPacketId(&mqtt_ctx)
+    );
+
+    if (result != MQTTSuccess) {
+        GGL_LOGE(
+            "%s to %.*s failed: %s",
+            "Unsubscribe",
+            (int) (uint16_t) topic_filters[0].len,
+            topic_filters[0].data,
+            MQTT_Status_strerror(result)
+        );
+        return GGL_ERR_FAILURE;
+    }
+
+    GGL_LOGD(
+        "Unsubscribe sent for: %.*s",
+        (int) (uint16_t) topic_filters[0].len,
+        topic_filters[0].data
+    );
+
+    return 0;
+}
+
 bool iotcored_mqtt_topic_filter_match(GglBuffer topic_filter, GglBuffer topic) {
     bool matches = false;
     MQTTStatus_t result = MQTT_MatchTopic(

--- a/iotcored/src/mqtt.h
+++ b/iotcored/src/mqtt.h
@@ -26,6 +26,7 @@ GglError iotcored_mqtt_publish(const IotcoredMsg *msg, uint8_t qos);
 GglError iotcored_mqtt_subscribe(
     GglBuffer *topic_filters, size_t count, uint8_t qos
 );
+GglError iotcored_mqtt_unsubscribe(GglBuffer *topic_filters, size_t count);
 
 bool iotcored_mqtt_topic_filter_match(GglBuffer topic_filter, GglBuffer topic);
 

--- a/iotcored/src/subscription_dispatch.c
+++ b/iotcored/src/subscription_dispatch.c
@@ -84,11 +84,36 @@ GglError iotcored_register_subscriptions(
     return GGL_ERR_NOMEM;
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void iotcored_unregister_subscriptions(uint32_t handle) {
     GGL_MTX_SCOPE_GUARD(&mtx);
 
     for (size_t i = 0; i < IOTCORED_MAX_SUBSCRIPTIONS; i++) {
         if (handles[i] == handle) {
+            size_t j;
+            for (j = 0; j < IOTCORED_MAX_SUBSCRIPTIONS; j++) {
+                if (i == j) {
+                    continue;
+                }
+                if ((topic_filter_len[j] != 0)
+                    && (topic_filter_len[i] == topic_filter_len[j])
+                    && (memcmp(
+                            sub_topic_filters[i],
+                            sub_topic_filters[j],
+                            topic_filter_len[i]
+                        )
+                        == 0)) {
+                    // Found a matching topic filter. No need to check
+                    // further.
+                    break;
+                }
+            }
+
+            // This is the only subscription to this topic. Send an unsubscribe.
+            if (j == IOTCORED_MAX_SUBSCRIPTIONS) {
+                GglBuffer buf[] = { topic_filter_buf(i) };
+                iotcored_mqtt_unsubscribe(buf, 1U);
+            }
             topic_filter_len[i] = 0;
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR sends an unsubscribe request for any topic to which only the handle being removed is subscribing to.

If more than one handle is subscribing to the topic whose handle is being removed, then no UNSUB request is sent to the IoT core.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
