### PR TITLE
Fix fleet status sequence number bug

### DIFF
--- a/gg-fleet-statusd/src/fleet_status_service.c
+++ b/gg-fleet-statusd/src/fleet_status_service.c
@@ -172,9 +172,9 @@ GglError publish_fleet_status_update(GglFleetStatusServiceThreadArgs *args) {
             continue;
         }
         ret = ggl_buf_clone(version_resp, &balloc.alloc, &version_resp);
-        if(ret != GGL_ERR_OK) {
-          GGL_LOGE("Failed to copy version response buffer.");
-          return ret;
+        if (ret != GGL_ERR_OK) {
+            GGL_LOGE("Failed to copy version response buffer.");
+            return ret;
         }
 
         // retrieve component health status
@@ -185,9 +185,9 @@ GglError publish_fleet_status_update(GglFleetStatusServiceThreadArgs *args) {
             return ret;
         }
         ret = ggl_buf_clone(component_health, &balloc.alloc, &component_health);
-        if(ret != GGL_ERR_OK) {
-          GGL_LOGE("Failed to copy component health buffer.");
-          return ret;
+        if (ret != GGL_ERR_OK) {
+            GGL_LOGE("Failed to copy component health buffer.");
+            return ret;
         }
 
         // if a component is broken, mark the device as unhealthy


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Check to see if a version is listed as invalid - if it is we do not attempt to get the status of the component since it no longer exists on the device.
- Store the fleet status sequence number under `fleetStatusSequenceNum` in the system config, and read and increment the saved number. This allows the sequence number to be persisted across device restarts. This is because the cloud does not accept repeated sequence numbers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
