### PR TITLE
Remove use of StateDirectory

### DIFF
--- a/gg-fleet-statusd/unit/template.service.in
+++ b/gg-fleet-statusd/unit/template.service.in
@@ -15,9 +15,7 @@ RestartSec=1
 CapabilityBoundingSet=~CAP_SYS_ADMIN ~CAP_SYS_PTRACE
 User=@GGL_SYSTEMD_SYSTEM_USER@
 Group=@GGL_SYSTEMD_SYSTEM_GROUP@
-# Working directory in StateDirectory (/var/lib/greengrass)
-StateDirectory=greengrass
-WorkingDirectory=%S/greengrass
+WorkingDirectory=/var/lib/greengrass
 
 [Unit]
 Description=Core-bus daemon. Sends fleet status updates periodically and when signalled.

--- a/ggconfigd/unit/template.service.in
+++ b/ggconfigd/unit/template.service.in
@@ -15,9 +15,7 @@ RestartSec=1
 CapabilityBoundingSet=~CAP_SYS_ADMIN ~CAP_SYS_PTRACE
 User=@GGL_SYSTEMD_SYSTEM_USER@
 Group=@GGL_SYSTEMD_SYSTEM_GROUP@
-# Working directory in StateDirectory (/var/lib/greengrass)
-StateDirectory=greengrass
-WorkingDirectory=%S/greengrass
+WorkingDirectory=/var/lib/greengrass
 
 
 [Unit]

--- a/ggdeploymentd/unit/template.service.in
+++ b/ggdeploymentd/unit/template.service.in
@@ -15,9 +15,7 @@ User=root
 Group=@GGL_SYSTEMD_SYSTEM_GROUP@
 # Disallow from having overly-permissive capabilities
 CapabilityBoundingSet=~CAP_SYS_PTRACE
-# Working directory in StateDirectory (/var/lib/greengrass)
-StateDirectory=greengrass
-WorkingDirectory=%S/greengrass
+WorkingDirectory=/var/lib/greengrass
 
 [Unit]
 Description=Greengrass Lite deployment queue and processor

--- a/gghealthd/unit/template.service.in
+++ b/gghealthd/unit/template.service.in
@@ -15,9 +15,7 @@ RestartSec=1
 CapabilityBoundingSet=~CAP_SYS_ADMIN ~CAP_SYS_PTRACE
 User=@GGL_SYSTEMD_SYSTEM_USER@
 Group=@GGL_SYSTEMD_SYSTEM_GROUP@
-# Working directory in StateDirectory (/var/lib/greengrass)
-StateDirectory=greengrass
-WorkingDirectory=%S/greengrass
+WorkingDirectory=/var/lib/greengrass
 
 [Unit]
 Description=core-bus abstract orchestrator interface

--- a/ggipcd/unit/template.service.in
+++ b/ggipcd/unit/template.service.in
@@ -15,9 +15,7 @@ RestartSec=1
 CapabilityBoundingSet=~CAP_SYS_ADMIN ~CAP_SYS_PTRACE
 User=@GGL_SYSTEMD_SYSTEM_USER@
 Group=@GGL_SYSTEMD_SYSTEM_GROUP@
-# Working directory in StateDirectory (/var/lib/greengrass)
-StateDirectory=greengrass
-WorkingDirectory=%S/greengrass
+WorkingDirectory=/var/lib/greengrass
 
 [Unit]
 Description=Proxy service between core-bus and GG Classic IPC

--- a/ggpubsubd/unit/template.service.in
+++ b/ggpubsubd/unit/template.service.in
@@ -15,9 +15,7 @@ RestartSec=1
 CapabilityBoundingSet=~CAP_SYS_ADMIN ~CAP_SYS_PTRACE
 User=@GGL_SYSTEMD_SYSTEM_USER@
 Group=@GGL_SYSTEMD_SYSTEM_GROUP@
-# Working directory in StateDirectory (/var/lib/greengrass)
-StateDirectory=greengrass
-WorkingDirectory=%S/greengrass
+WorkingDirectory=/var/lib/greengrass
 
 
 [Unit]

--- a/iotcored/unit/template.service.in
+++ b/iotcored/unit/template.service.in
@@ -15,9 +15,7 @@ RestartSec=1
 CapabilityBoundingSet=~CAP_SYS_ADMIN ~CAP_SYS_PTRACE
 User=@GGL_SYSTEMD_SYSTEM_USER@
 Group=@GGL_SYSTEMD_SYSTEM_GROUP@
-# Working directory in StateDirectory (/var/lib/greengrass)
-StateDirectory=greengrass
-WorkingDirectory=%S/greengrass
+WorkingDirectory=/var/lib/greengrass
 
 [Unit]
 Description=core-bus IoT Core mqtt proxy

--- a/tesd/unit/template.service.in
+++ b/tesd/unit/template.service.in
@@ -16,9 +16,7 @@ RestartSec=1
 CapabilityBoundingSet=~CAP_SYS_ADMIN ~CAP_SYS_PTRACE
 User=@GGL_SYSTEMD_SYSTEM_USER@
 Group=@GGL_SYSTEMD_SYSTEM_GROUP@
-# Working directory in StateDirectory (/var/lib/greengrass)
-StateDirectory=greengrass
-WorkingDirectory=%S/greengrass
+WorkingDirectory=/var/lib/greengrass
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Systemd chmods StateDirectory when the service starts, which can cause conflicts and also erases component ownership of files.