### PR TITLE
Make the same root path as /var/lib/greengrass

### DIFF
--- a/.github/workflows/packaging/readme.template.txt
+++ b/.github/workflows/packaging/readme.template.txt
@@ -43,7 +43,7 @@ sudo ./install-greengrass-lite.sh
 ###############################################################################
 
 Add a parameter "-u" to the script. Be careful this will delete /etc/greengrass
-and /var/lib/aws-greengrass-v2!
+and /var/lib/greengrass!
 
 sudo ./install-greengrass-lite.sh -u
 

--- a/docs/examples/sample_nucleus_config.yml
+++ b/docs/examples/sample_nucleus_config.yml
@@ -1,9 +1,9 @@
 ---
 system:
-  privateKeyPath: "/var/lib/aws-greengrass-v2/device.key"
-  certificateFilePath: "/var/lib/aws-greengrass-v2/device.pem"
-  rootCaPath: "/var/lib/aws-greengrass-v2/AmazonRootCA1.pem"
-  rootPath: "/var/lib/aws-greengrass-v2"
+  privateKeyPath: "/var/lib/greengrass/device.key"
+  certificateFilePath: "/var/lib/greengrass/device.pem"
+  rootCaPath: "/var/lib/greengrass/AmazonRootCA1.pem"
+  rootPath: "/var/lib/greengrass"
   thingName: "ExampleGGDevice"
 services:
   aws.greengrass.Nucleus-Lite:

--- a/ggdeploymentd/src/component_store.c
+++ b/ggdeploymentd/src/component_store.c
@@ -21,7 +21,7 @@
 
 #define MAX_PATH_LENGTH 128
 
-static GglBuffer root_path = GGL_STR("/var/lib/aws-greengrass-v2");
+static GglBuffer root_path = GGL_STR("/var/lib/greengrass");
 
 static GglError update_root_path(void) {
     static uint8_t resp_mem[MAX_PATH_LENGTH] = { 0 };


### PR DESCRIPTION
The default root path should always be /var/lib/greengrass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
