### PR TITLE
Ignore the dependency on Nucleus and Nucleus Lite

### DIFF
--- a/ggdeploymentd/src/deployment_handler.c
+++ b/ggdeploymentd/src/deployment_handler.c
@@ -2315,8 +2315,6 @@ static void handle_deployment(
             GGL_LOGI("ComponentConfiguration not found in the recipe");
         }
 
-        // TODO: add install file processing logic here.
-
         if (component_updated) {
             ret = ggl_buf_vec_push(&updated_comp_name_vec, pair->key);
             if (ret != GGL_ERR_OK) {

--- a/ggdeploymentd/src/deployment_handler.c
+++ b/ggdeploymentd/src/deployment_handler.c
@@ -2377,7 +2377,7 @@ static void handle_deployment(
                         return;
                     }
 
-                    // run link command
+                    // initiate link command for 'install'
                     static uint8_t link_command_buf[PATH_MAX];
                     GglByteVec link_command_vec
                         = GGL_BYTE_VEC(link_command_buf);
@@ -2391,7 +2391,11 @@ static void handle_deployment(
                     );
                     ggl_byte_vec_chain_push(&ret, &link_command_vec, '\0');
                     if (ret != GGL_ERR_OK) {
-                        GGL_LOGE("Failed to create systemctl link command.");
+                        GGL_LOGE(
+                            "Failed to create systemctl link command for:%.*s",
+                            (int) install_service_file_path_vec.buf.len,
+                            install_service_file_path_vec.buf.data
+                        );
                         return;
                     }
 
@@ -2399,19 +2403,30 @@ static void handle_deployment(
                     int system_ret = system((char *) link_command_vec.buf.data);
                     if (WIFEXITED(system_ret)) {
                         if (WEXITSTATUS(system_ret) != 0) {
-                            GGL_LOGE("systemctl link failed");
+                            GGL_LOGE(
+                                "systemctl link failed for:%.*s",
+                                (int) install_service_file_path_vec.buf.len,
+                                install_service_file_path_vec.buf.data
+                            );
                             return;
                         }
                         GGL_LOGI(
-                            "systemctl link exited with child status %d\n",
+                            "systemctl link exited for %.*s with child status "
+                            "%d\n",
+                            (int) install_service_file_path_vec.buf.len,
+                            install_service_file_path_vec.buf.data,
                             WEXITSTATUS(system_ret)
                         );
                     } else {
-                        GGL_LOGE("systemctl link did not exit normally");
+                        GGL_LOGE(
+                            "systemctl link did not exit normally for %.*s",
+                            (int) install_service_file_path_vec.buf.len,
+                            install_service_file_path_vec.buf.data
+                        );
                         return;
                     }
 
-                    // run start command
+                    // initiate start command for 'install'
                     static uint8_t start_command_buf[PATH_MAX];
                     GglByteVec start_command_vec
                         = GGL_BYTE_VEC(start_command_buf);
@@ -2425,7 +2440,11 @@ static void handle_deployment(
                     );
                     ggl_byte_vec_chain_push(&ret, &start_command_vec, '\0');
                     if (ret != GGL_ERR_OK) {
-                        GGL_LOGE("Failed to create systemctl start command.");
+                        GGL_LOGE(
+                            "Failed to create systemctl start command for %.*s",
+                            (int) install_service_file_path_vec.buf.len,
+                            install_service_file_path_vec.buf.data
+                        );
                         return;
                     }
 
@@ -2433,7 +2452,11 @@ static void handle_deployment(
                     // NOLINTEND(concurrency-mt-unsafe)
                     if (WIFEXITED(system_ret)) {
                         if (WEXITSTATUS(system_ret) != 0) {
-                            GGL_LOGE("systemctl start failed");
+                            GGL_LOGE(
+                                "systemctl start failed for%.*s",
+                                (int) install_service_file_path_vec.buf.len,
+                                install_service_file_path_vec.buf.data
+                            );
                             return;
                         }
                         GGL_LOGI(
@@ -2441,7 +2464,11 @@ static void handle_deployment(
                             WEXITSTATUS(system_ret)
                         );
                     } else {
-                        GGL_LOGE("systemctl start did not exit normally");
+                        GGL_LOGE(
+                            "systemctl start did not exit normally for %.*s",
+                            (int) install_service_file_path_vec.buf.len,
+                            install_service_file_path_vec.buf.data
+                        );
                         return;
                     }
                 }

--- a/recipe-runner/src/runner.c
+++ b/recipe-runner/src/runner.c
@@ -110,7 +110,7 @@ static GglError substitute_escape(
         return ret;
     }
 
-    GGL_LOGD(
+    GGL_LOGT(
         "Current variable substitution: %.*s. type = %.*s; arg = %.*s",
         (int) escape_seq.len,
         escape_seq.data,

--- a/recipe2unit/src/parser.c
+++ b/recipe2unit/src/parser.c
@@ -120,9 +120,11 @@ GglError convert_to_unit(
         GGL_LOGE("Component name was NULL");
         return GGL_ERR_FAILURE;
     }
+
     if (ret == GGL_ERR_NOENTRY) {
         GGL_LOGW("No Install phase present");
-    } else if (ret != GGL_ERR_OK) {
+
+    } else if (ret == GGL_ERR_OK) {
         return ret;
     } else {
         is_install = true;
@@ -142,6 +144,7 @@ GglError convert_to_unit(
         component_name,
         RUN_STARTUP
     );
+
     if (ret == GGL_ERR_NOENTRY) {
         GGL_LOGW("No run or phase present");
     } else if (ret != GGL_ERR_OK) {
@@ -155,6 +158,7 @@ GglError convert_to_unit(
             GGL_LOGE("Failed to create the run or startup unit file.");
             return ret;
         }
+        GGL_LOGD("Created run or startup unit file.");
     }
 
     return GGL_ERR_OK;

--- a/recipe2unit/src/parser.c
+++ b/recipe2unit/src/parser.c
@@ -109,6 +109,7 @@ GglError convert_to_unit(
         = (GglBuffer) { .data = (uint8_t *) run_startup_unit_file_buffer,
                         .len = MAX_UNIT_FILE_BUF_SIZE };
 
+    GGL_LOGD("Attempting to find install phase from recipe");
     ret = generate_systemd_unit(
         &recipe_obj->map,
         &install_response_buffer,
@@ -124,7 +125,7 @@ GglError convert_to_unit(
     if (ret == GGL_ERR_NOENTRY) {
         GGL_LOGW("No Install phase present");
 
-    } else if (ret == GGL_ERR_OK) {
+    } else if (ret != GGL_ERR_OK) {
         return ret;
     } else {
         is_install = true;
@@ -137,6 +138,7 @@ GglError convert_to_unit(
         }
     }
 
+    GGL_LOGD("Attempting to find run phase from recipe");
     ret = generate_systemd_unit(
         &recipe_obj->map,
         &run_startup_response_buffer,

--- a/recipe2unit/src/unit_file_generator.c
+++ b/recipe2unit/src/unit_file_generator.c
@@ -350,6 +350,7 @@ static GglError manifest_builder(
 
         lifecycle_script_selection = GGL_STR("install");
         ggl_byte_vec_chain_append(&ret, out, GGL_STR("Type=oneshot\n"));
+        ggl_byte_vec_chain_append(&ret, out, GGL_STR("RemainAfterExit=true\n"));
         if (ret != GGL_ERR_OK) {
             GGL_LOGE("Failed to add unit type information");
             return GGL_ERR_FAILURE;


### PR DESCRIPTION
Also provides more detail to user if no lifecylce is provided or if there is mismatched casing

*Issue #, if available:*

*Description of changes:*
- Ignores the Dependency on  Nucleus and Nucleus Lite while create unit file out of a recipe
- Also provides more detail to user if no lifecycle is provided or if there is mismatched casing
- Adds more detailed logs to ggdeploymentd to help out with debugging

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
