### PR TITLE
Fail the deployment when got the version conflict of Nucleus-Lite component

### DIFF
--- a/ggdeploymentd/src/deployment_handler.c
+++ b/ggdeploymentd/src/deployment_handler.c
@@ -36,6 +36,7 @@
 #include <ggl/uri.h>
 #include <ggl/utils.h>
 #include <ggl/vector.h>
+#include <ggl/version.h>
 #include <ggl/zip.h>
 #include <limits.h>
 #include <string.h>
@@ -1154,6 +1155,16 @@ static GglError resolve_dependencies(
                 return GGL_ERR_INVALID;
             }
             component_version = val->buf;
+        }
+
+        if (ggl_buffer_eq(pair->key, GGL_STR("aws.greengrass.NucleusLite"))) {
+            if (!ggl_buffer_eq(component_version, GGL_STR(GGL_VERSION))) {
+                GGL_LOGE("The version of the aws.greengrass.NucleusLite "
+                         "component does not "
+                         "match the already installed version. "
+                         "Deployment failed.");
+                return GGL_ERR_INVALID;
+            }
         }
 
         ret = ggl_kv_vec_push(

--- a/ggdeploymentd/src/deployment_handler.c
+++ b/ggdeploymentd/src/deployment_handler.c
@@ -1158,11 +1158,19 @@ static GglError resolve_dependencies(
         }
 
         if (ggl_buffer_eq(pair->key, GGL_STR("aws.greengrass.NucleusLite"))) {
-            if (!ggl_buffer_eq(component_version, GGL_STR(GGL_VERSION))) {
-                GGL_LOGE("The version of the aws.greengrass.NucleusLite "
-                         "component does not "
-                         "match the already installed version. "
-                         "Deployment failed.");
+            GglBuffer software_version = GGL_STR(GGL_VERSION);
+            if (!ggl_buffer_eq(component_version, software_version)) {
+                GGL_LOGE(
+                    "The deployment failed. The aws.greengrass.NucleusLite "
+                    "component version specified in the deployment is %.*s, "
+                    "but the version of the GG Lite software is %.*s. Please "
+                    "ensure that the version in the deployment matches before "
+                    "attempting the deployment again.",
+                    (int) component_version.len,
+                    component_version.data,
+                    (int) software_version.len,
+                    software_version.data
+                );
                 return GGL_ERR_INVALID;
             }
         }


### PR DESCRIPTION
*Description of changes:* If a customer deploys an aws.greengrass.NucleusLite component version that’s different from the version macro, we fail the deployment with an appropriate error message.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
