### PR TITLE
Config reset json pointer support

### DIFF
--- a/ggdeploymentd/CMakeLists.txt
+++ b/ggdeploymentd/CMakeLists.txt
@@ -6,6 +6,7 @@ ggl_init_module(
   ggdeploymentd
   LIBS ggl-lib
        core-bus
+       ggl-constants
        ggl-file
        ggl-http
        ggl-json

--- a/ggl-json/CMakeLists.txt
+++ b/ggl-json/CMakeLists.txt
@@ -2,4 +2,4 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ggl_init_module(ggl-json LIBS ggl-lib)
+ggl_init_module(ggl-json LIBS ggl-lib ggl-constants)

--- a/ggl-json/include/ggl/json_pointer.h
+++ b/ggl-json/include/ggl/json_pointer.h
@@ -1,0 +1,15 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GGL_JSON_POINTER_H
+#define GGL_JSON_POINTER_H
+
+#include <ggl/buffer.h>
+#include <ggl/error.h>
+#include <ggl/vector.h>
+
+// Parse a json pointer buffer into a list of keys
+GglError ggl_gg_config_jsonp_parse(GglBuffer json_ptr, GglBufVec *key_path);
+
+#endif

--- a/ggl-json/src/json_pointer.c
+++ b/ggl-json/src/json_pointer.c
@@ -1,0 +1,46 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ggl/json_pointer.h"
+#include <assert.h>
+#include <ggl/buffer.h>
+#include <ggl/constants.h>
+#include <ggl/log.h>
+#include <ggl/vector.h>
+#include <stddef.h>
+#include <stdint.h>
+
+GglError ggl_gg_config_jsonp_parse(GglBuffer json_ptr, GglBufVec *key_path) {
+    assert(key_path->capacity == GGL_MAX_OBJECT_DEPTH);
+
+    // TODO: Do full parsing of JSON pointer
+
+    if ((json_ptr.len < 1) || (json_ptr.data[0] != '/')) {
+        GGL_LOGE("Invalid json pointer.");
+        return GGL_ERR_FAILURE;
+    }
+
+    size_t begin = 1;
+    for (size_t i = 1; i < json_ptr.len; i++) {
+        if (json_ptr.data[i] == '/') {
+            GglError ret = ggl_buf_vec_push(
+                key_path, ggl_buffer_substr(json_ptr, begin, i)
+            );
+            if (ret != GGL_ERR_OK) {
+                GGL_LOGE("Too many configuration levels.");
+                return ret;
+            }
+            begin = i + 1;
+        }
+    }
+    GglError ret = ggl_buf_vec_push(
+        key_path, ggl_buffer_substr(json_ptr, begin, SIZE_MAX)
+    );
+    if (ret != GGL_ERR_OK) {
+        GGL_LOGE("Too many configuration levels.");
+        return ret;
+    }
+
+    return GGL_ERR_OK;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Moves json pointer parsing out from recipe runner to ggl-json for shared use.

Config reset supports json pointer keys now, instead of just single buffers (fixes this behavior).

Config reset supports an empty string resetting the whole configuration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
