### PR TITLE
Remove component configuration on cleanup

### DIFF
--- a/gg-fleet-statusd/src/fleet_status_service.c
+++ b/gg-fleet-statusd/src/fleet_status_service.c
@@ -169,11 +169,6 @@ GglError publish_fleet_status_update(GglBuffer thing_name, GglBuffer trigger) {
             &version_resp
         );
 
-        if (ggl_buffer_eq(version_resp, GGL_STR("inactive"))) {
-            // this component is no longer on the device
-            continue;
-        }
-
         if (ret != GGL_ERR_OK) {
             GGL_LOGE(
                 "Unable to retrieve version of %s. Cannot publish fleet status "

--- a/ggdeploymentd/src/component_manager.c
+++ b/ggdeploymentd/src/component_manager.c
@@ -41,9 +41,8 @@ static GglError find_active_version(
         return GGL_ERR_NOENTRY;
     }
 
-    // active component found, update the version if it is a real version
-    if (ggl_buffer_eq(GGL_STR("inactive"), version_resp)
-        || !is_in_range(version_resp, version_requirement)) {
+    // active component found, update the version if it is a valid version
+    if (!is_in_range(version_resp, version_requirement)) {
         return GGL_ERR_NOENTRY;
     }
     *version = version_resp;

--- a/ggdeploymentd/src/deployment_handler.c
+++ b/ggdeploymentd/src/deployment_handler.c
@@ -2229,6 +2229,9 @@ static void handle_deployment(
             return;
         }
 
+        // TODO: See if there is a better requirement. If a customer has the
+        // same version as before but somehow updated their component
+        // version their component may not get the updates.
         bool component_updated = true;
 
         static uint8_t old_component_version_mem[128] = { 0 };
@@ -2252,9 +2255,6 @@ static void handle_deployment(
                 component_updated = false;
             }
         }
-        // TODO: See if there is a better requirement. If a customer has the
-        // same version as before but somehow updated their component
-        // version their component may not get the updates.
 
         ret = ggl_gg_config_write(
             GGL_BUF_LIST(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove the component configuration as the first action on cleanup. This means that this config update isn't reliant on the success of the other cleanup tasks. This also means that the component configuration is properly removed on cleanup as it should be.

No longer set the version to "inactive" on cleanup as we can now delete the whole configuration object. Updates FSS and deployments to no longer check for this value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
