### PR TITLE
Fix FSS not liking TES configuration and use expected config arn from cloud

### DIFF
--- a/ggdeploymentd/src/deployment_queue.c
+++ b/ggdeploymentd/src/deployment_queue.c
@@ -215,9 +215,7 @@ static GglError parse_deployment_obj(
             get_slash_and_colon_locations_from_arn(
                 configuration_arn, &slash_index, &last_colon_index
             );
-            doc->configuration_arn = ggl_buffer_substr(
-                configuration_arn->buf, 0, last_colon_index
-            );
+            doc->configuration_arn = configuration_arn->buf;
             doc->thing_group = ggl_buffer_substr(
                 configuration_arn->buf, slash_index + 1, last_colon_index
             );

--- a/tes-serverd/bin/tes-serverd.c
+++ b/tes-serverd/bin/tes-serverd.c
@@ -6,6 +6,10 @@
 
 #include "tes-serverd.h"
 #include <ggl/error.h>
+#include <ggl/version.h>
+
+__attribute__((visibility("default"))) const char *argp_program_version
+    = GGL_VERSION;
 
 int main(void) {
     GglError ret = run_tes_serverd();

--- a/tes-serverd/src/http_server.c
+++ b/tes-serverd/src/http_server.c
@@ -16,6 +16,7 @@
 #include <ggl/json_encode.h>
 #include <ggl/log.h>
 #include <ggl/object.h>
+#include <ggl/version.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <systemd/sd-daemon.h>
@@ -252,6 +253,35 @@ GglError http_server(void) {
     );
 
     GglError ret = ggl_gg_config_write(
+        GGL_BUF_LIST(
+            GGL_STR("services"),
+            GGL_STR("aws.greengrass.TokenExchangeService"),
+            GGL_STR("version")
+        ),
+        GGL_OBJ_BUF(GGL_STR(GGL_VERSION)),
+        NULL
+    );
+    if (ret != GGL_ERR_OK) {
+        GGL_LOGE("Error writing the TES version to the config");
+        return ret;
+    }
+
+    ret = ggl_gg_config_write(
+        GGL_BUF_LIST(
+            GGL_STR("services"),
+            GGL_STR("aws.greengrass.TokenExchangeService"),
+            GGL_STR("configArn")
+        ),
+        GGL_OBJ_LIST(GGL_LIST()),
+        NULL
+    );
+    if (ret != GGL_ERR_OK) {
+        GGL_LOGE("Failed to write configuration arn list for TES to the config."
+        );
+        return ret;
+    }
+
+    ret = ggl_gg_config_write(
         GGL_BUF_LIST(
             GGL_STR("services"),
             GGL_STR("aws.greengrass.TokenExchangeService"),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
FSS has been broken due to failing to read TES's config. Fixed by adding the needed config values under the services/aws.greengrass.TokenExchangeService key. Using the GGL version as the TES version as TES is a core component of GGL.

Cloud is expecting a configuration arn including a version field, so providing the full arn as well. This fixes devices not showing up under the "Devices" tab of a deployment after the deployment has succeeded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
