### PR TITLE
Update FSS bus api to take deployment info and send it

### DIFF
--- a/docs/spec/executable/gg-fleet-statusd.md
+++ b/docs/spec/executable/gg-fleet-statusd.md
@@ -41,3 +41,7 @@ to send a fleet status update to IoT Core.
     - `RECONNECT`
     - `LAUNCH`
     - `NETWORK_RECONFIGURE`
+- [gg-fleet-statusd-send_fleet_status_update-2] `deployment_info` is a required
+  parameter of type map
+  - [gg-fleet-statusd-send_fleet_status_update-2.1] `deployment_info` includes a
+    map of deployment information to send to cloud after a deployment

--- a/gg-fleet-statusd/src/entry.c
+++ b/gg-fleet-statusd/src/entry.c
@@ -78,7 +78,9 @@ static GglError connection_status_callback(
             (int) connection_trigger.len,
             connection_trigger.data
         );
-        ret = publish_fleet_status_update(thing_name, connection_trigger);
+        ret = publish_fleet_status_update(
+            thing_name, connection_trigger, GGL_MAP()
+        );
         if (ret != GGL_ERR_OK) {
             GGL_LOGE("Failed to publish fleet status update.");
         }
@@ -108,7 +110,9 @@ static void *ggl_fleet_status_service_thread(void *ctx) {
             return NULL;
         }
 
-        ret = publish_fleet_status_update(thing_name, GGL_STR("CADENCE"));
+        ret = publish_fleet_status_update(
+            thing_name, GGL_STR("CADENCE"), GGL_MAP()
+        );
         if (ret != GGL_ERR_OK) {
             GGL_LOGE("Failed to publish fleet status update.");
         }
@@ -130,7 +134,16 @@ static GglError send_fleet_status_update(
         return GGL_ERR_INVALID;
     }
 
-    GglError ret = publish_fleet_status_update(thing_name, trigger->buf);
+    GglObject *deployment_info = NULL;
+    found = ggl_map_get(params, GGL_STR("deployment_info"), &deployment_info);
+    if (!found || deployment_info->type != GGL_TYPE_MAP) {
+        GGL_LOGE("Missing required GGL_TYPE_MAP `deployment_info`.");
+        return GGL_ERR_INVALID;
+    }
+
+    GglError ret = publish_fleet_status_update(
+        thing_name, trigger->buf, deployment_info->map
+    );
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("Failed to publish fleet status update.");
         return ret;

--- a/gg-fleet-statusd/src/fleet_status_service.c
+++ b/gg-fleet-statusd/src/fleet_status_service.c
@@ -100,7 +100,9 @@ static const GglBuffer ARCHITECTURE =
 
 // TODO: Split this function up
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-GglError publish_fleet_status_update(GglBuffer thing_name, GglBuffer trigger) {
+GglError publish_fleet_status_update(
+    GglBuffer thing_name, GglBuffer trigger, GglMap deployment_info
+) {
     static pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
     GGL_MTX_SCOPE_GUARD(&mtx);
 
@@ -322,7 +324,8 @@ GglError publish_fleet_status_update(GglBuffer thing_name, GglBuffer trigger) {
         { GGL_STR("messageType"), GGL_OBJ_BUF(GGL_STR("COMPLETE")) },
         { GGL_STR("trigger"), GGL_OBJ_BUF(trigger) },
         { GGL_STR("overallDeviceStatus"), GGL_OBJ_BUF(overall_device_status) },
-        { GGL_STR("components"), GGL_OBJ_LIST(component_statuses.list) }
+        { GGL_STR("components"), GGL_OBJ_LIST(component_statuses.list) },
+        { GGL_STR("deploymentInformation"), GGL_OBJ_MAP(deployment_info) }
     ));
 
     // build payload

--- a/gg-fleet-statusd/src/fleet_status_service.h
+++ b/gg-fleet-statusd/src/fleet_status_service.h
@@ -7,9 +7,12 @@
 
 #include <ggl/buffer.h>
 #include <ggl/error.h>
+#include <ggl/object.h>
 
 #define MAX_THING_NAME_LEN 128
 
-GglError publish_fleet_status_update(GglBuffer thing_name, GglBuffer trigger);
+GglError publish_fleet_status_update(
+    GglBuffer thing_name, GglBuffer trigger, GglMap deployment_info
+);
 
 #endif // GG_FLEET_STATUSD_FLEET_STATUS_SERVICE_H

--- a/ggdeploymentd/src/deployment_queue.c
+++ b/ggdeploymentd/src/deployment_queue.c
@@ -169,7 +169,7 @@ static GglError parse_deployment_obj(
               GGL_TYPE_MAP,
               &root_component_versions_to_add },
             { GGL_STR("components"), false, GGL_TYPE_MAP, &cloud_components },
-            { GGL_STR("deployment_id"), false, GGL_TYPE_BUF, &deployment_id },
+            { GGL_STR("deploymentId"), false, GGL_TYPE_BUF, &deployment_id },
             { GGL_STR("configurationArn"),
               false,
               GGL_TYPE_BUF,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
FSS needs to send up deployment information to the cloud after a deployment so that the cloud gets information about the completed deployment, including stuff like deployment codes and more.

Updates the FSS corebus api to take this deployment info and add it to the message it publishes to the cloud.

Updated deployment handler to submit the minimum information required for cloud to correctly parse component sources that can be displayed on console. This means that when going on console, going to your core device, and seeing the list of components, you will also see the latest deployment source for each of those components. We don't yet have deployment error codes or support a list of unchanged components but this can be added in the future in deploymentd without needing to additionally update the FSS corebus api.

Update the spec with the new deployment_info parameter in the FSS publish API.

Also makes a fix that lets us actually use the deployment ID from a cloud deployment, instead of always generating a new one, which seems to have been an issue for a while.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
