### PR TITLE
Add config list on corebus

### DIFF
--- a/core-bus-gg-config/include/ggl/core_bus/gg_config.h
+++ b/core-bus-gg-config/include/ggl/core_bus/gg_config.h
@@ -23,6 +23,11 @@ GglError ggl_gg_config_read(
 /// `result` must point to buffer with memory to read into
 GglError ggl_gg_config_read_str(GglBufList key_path, GglBuffer *result);
 
+/// Wrapper for core-bus `gg_config` `list`
+GglError ggl_gg_config_list(
+    GglBufList key_path, GglAlloc *alloc, GglList *subkeys_out
+);
+
 /// Wrapper for core-bus `gg_config` `write`
 GglError ggl_gg_config_write(
     GglBufList key_path, GglObject value, const int64_t *timestamp

--- a/core-bus-gg-config/src/gg_config.c
+++ b/core-bus-gg-config/src/gg_config.c
@@ -44,6 +44,46 @@ GglError ggl_gg_config_read(
     return err;
 }
 
+GglError ggl_gg_config_list(
+    GglBufList key_path, GglAlloc *alloc, GglList *subkeys_out
+) {
+    if (key_path.len > GGL_MAX_OBJECT_DEPTH) {
+        GGL_LOGE("Key path depth exceeds maximum handled.");
+        return GGL_ERR_UNSUPPORTED;
+    }
+
+    GglObject path_obj[GGL_MAX_OBJECT_DEPTH] = { 0 };
+    for (size_t i = 0; i < key_path.len; i++) {
+        path_obj[i] = GGL_OBJ_BUF(key_path.bufs[i]);
+    }
+
+    GglMap args = GGL_MAP(
+        { GGL_STR("key_path"),
+          GGL_OBJ_LIST((GglList) { .items = path_obj, .len = key_path.len }) },
+    );
+
+    GglError remote_err = GGL_ERR_OK;
+    GglObject result_obj;
+    GglError err = ggl_call(
+        GGL_STR("gg_config"),
+        GGL_STR("list"),
+        args,
+        &remote_err,
+        alloc,
+        &result_obj
+    );
+    if ((err == GGL_ERR_REMOTE) && (remote_err != GGL_ERR_OK)) {
+        err = remote_err;
+    }
+    if (result_obj.type != GGL_TYPE_LIST) {
+        GGL_LOGE("Configuration list failed to return a list.");
+        return GGL_ERR_FAILURE;
+    }
+    subkeys_out->items = result_obj.list.items;
+    subkeys_out->len = result_obj.list.len;
+    return err;
+}
+
 GglError ggl_gg_config_delete(GglBufList key_path) {
     if (key_path.len > GGL_MAX_OBJECT_DEPTH) {
         GGL_LOGE("Key path depth exceeds maximum handled.");

--- a/docs/spec/core-bus-interface/gg_config.md
+++ b/docs/spec/core-bus-interface/gg_config.md
@@ -31,6 +31,32 @@ are read recursively.
   - [gg-config-read-resp-2.1] `GG_ERR_NOENTRY` will be returned if the key was
     not in the configuration.
 
+## list
+
+The `list` method returns a list of immediate subkeys of an object at the given
+`key_path`. Unlike `read`, this method does not recursively fetch all nested
+keys and values.
+
+- [gg-config-list-1] `list` can be invoked with call.
+- [gg-config-list-2] `list` returns only the immediate subkeys of the object
+  specified at the key path.
+
+### Parameters
+
+- [gg-config-list-params-1] `key_path` is a required parameter of type list.
+  - [gg-config-list-params-1.1] list elements are buffers containing a single
+    level in the key hierarchy.
+
+### Response
+
+- [gg-config-list-resp-1] The response value is a list of buffers, where each
+  buffer is an immediate subkey of the specified `key_path` object.
+- [gg-config-list-resp-2] If the specified `key_path` does not exist,
+  `GGL_ERR_NOENTRY` is returned.
+- [gg-config-list-resp-3] If the specified `key_path` exists but is not a
+  object/map (i.e. keyPath directly holds a value), `GGL_ERR_INVALID` is
+  returned.
+
 ## write
 
 The `write` method updates the value associated with `key_path`. If the `value`

--- a/ggconfigd/include/ggconfigd.h
+++ b/ggconfigd/include/ggconfigd.h
@@ -22,6 +22,7 @@ GglError ggconfig_write_value_at_key(
 GglError ggconfig_write_empty_map(GglList *key_path);
 GglError ggconfig_delete_key(GglList *key_path);
 GglError ggconfig_get_value_from_key(GglList *key_path, GglObject *value);
+GglError ggconfig_list_subkeys(GglList *key_path, GglList *subkeys);
 GglError ggconfig_get_key_notification(GglList *key_path, uint32_t handle);
 GglError ggconfig_open(void);
 GglError ggconfig_close(void);

--- a/ggl-constants/include/ggl/constants.h
+++ b/ggl-constants/include/ggl/constants.h
@@ -11,7 +11,10 @@
 
 /// The maximum expected config keys (including nested) held under one component
 /// configuration
-#define MAX_CONFIG_KEYS_PER_COMPONENT 256
+#define MAX_CONFIG_DESCENDANTS_PER_COMPONENT 256
+
+/// The maximum expected config keys held as children of a single config object
+#define MAX_CONFIG_CHILDREN_PER_OBJECT 64
 
 // According to
 // https://docs.aws.amazon.com/iot/latest/apireference/API_ThingAttribute.html


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is needed to allow "exploration" of keys in the config without reading everything underneath a particular key (which could run out of memory if there are too many keys). For example, when FSS needs to check all components, it gets all the configuration under `services`, which we have seen running out of memory. As a follow up to this I will put in use of this new api in that situation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
