### PR TITLE
Improve active version check to check component is running

### DIFF
--- a/ggdeploymentd/src/deployment_handler.c
+++ b/ggdeploymentd/src/deployment_handler.c
@@ -2480,7 +2480,8 @@ static void handle_deployment(
             }
 
             // Skip redeploying components in a RUNNING state
-            if (ggl_buffer_eq(component_status, GGL_STR("RUNNING"))) {
+            if (ggl_buffer_eq(component_status, GGL_STR("RUNNING"))
+                || ggl_buffer_eq(component_status, GGL_STR("FINISHED"))) {
                 GGL_LOGD(
                     "Component %.*s is already running. Will not redeploy.",
                     (int) pair->key.len,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Makes active version check actually check the component is running or finished. This means that we will attempt to restart broken components on a new deployment and are more resilient to failures in case user has messed with their config and the active version found from config isn't actually running.

Also fixes bootstrap logic to include finished components as part of the existing version check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
