### PR TITLE
Add missing . to install service file name

### DIFF
--- a/ggdeploymentd/src/deployment_handler.c
+++ b/ggdeploymentd/src/deployment_handler.c
@@ -1982,6 +1982,11 @@ static GglError wait_for_phase_status(
         GglError ret = ggl_byte_vec_append(
             &full_comp_name_vec, component_vec.buf_list.bufs[i]
         );
+        ggl_byte_vec_chain_push(&ret, &full_comp_name_vec, '.');
+        if (ret != GGL_ERR_OK) {
+            GGL_LOGE("Failed to push '.' character to component name vector.");
+            return ret;
+        }
         ggl_byte_vec_append(&full_comp_name_vec, phase);
         if (ret != GGL_ERR_OK) {
             GGL_LOGE(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding a missing `.` character. This was causing the install phase wait to last forever, and deployments weren't able to be completed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
