### PR TITLE
Save IoT Jobs version for bootstrap deployments

### DIFF
--- a/ggdeploymentd/src/bootstrap_manager.c
+++ b/ggdeploymentd/src/bootstrap_manager.c
@@ -16,6 +16,7 @@
 #include <ggl/map.h>
 #include <ggl/object.h>
 #include <ggl/vector.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -112,7 +113,10 @@ GglError save_iot_jobs_id(GglBuffer jobs_id) {
 }
 
 GglError save_iot_jobs_version(int64_t jobs_version) {
-    GGL_LOGD("Saving IoT Jobs version %" PRIi64 " in case of bootstrap.", jobs_version);
+    GGL_LOGD(
+        "Saving IoT Jobs version %" PRIi64 " in case of bootstrap.",
+        jobs_version
+    );
 
     GglError ret = ggl_gg_config_write(
         GGL_BUF_LIST(

--- a/ggdeploymentd/src/bootstrap_manager.c
+++ b/ggdeploymentd/src/bootstrap_manager.c
@@ -112,7 +112,7 @@ GglError save_iot_jobs_id(GglBuffer jobs_id) {
 }
 
 GglError save_iot_jobs_version(int64_t jobs_version) {
-    GGL_LOGD("Saving IoT Jobs version %li in case of bootstrap.", jobs_version);
+    GGL_LOGD("Saving IoT Jobs version %" PRIi64 " in case of bootstrap.", jobs_version);
 
     GglError ret = ggl_gg_config_write(
         GGL_BUF_LIST(

--- a/ggdeploymentd/src/bootstrap_manager.c
+++ b/ggdeploymentd/src/bootstrap_manager.c
@@ -191,7 +191,7 @@ GglError save_deployment_info(GglDeployment *deployment) {
 }
 
 GglError retrieve_in_progress_deployment(
-    GglDeployment *deployment, GglBuffer *jobs_id, int64_t jobs_version
+    GglDeployment *deployment, GglBuffer *jobs_id, int64_t *jobs_version
 ) {
     GGL_LOGD("Searching config for any in progress deployment.");
 
@@ -229,7 +229,7 @@ GglError retrieve_in_progress_deployment(
         GGL_LOGE("Did not receive an int64_t for IoT jobs version.");
         return GGL_ERR_INVALID;
     }
-    jobs_version = jobs_version_obj.i64;
+    *jobs_version = jobs_version_obj.i64;
 
     GglBuffer config_mem = GGL_BUF((uint8_t[2500]) { 0 });
     GglBumpAlloc balloc = ggl_bump_alloc_init(config_mem);

--- a/ggdeploymentd/src/bootstrap_manager.c
+++ b/ggdeploymentd/src/bootstrap_manager.c
@@ -111,6 +111,26 @@ GglError save_iot_jobs_id(GglBuffer jobs_id) {
     return GGL_ERR_OK;
 }
 
+GglError save_iot_jobs_version(int64_t jobs_version) {
+    GGL_LOGD("Saving IoT Jobs version %li in case of bootstrap.", jobs_version);
+
+    GglError ret = ggl_gg_config_write(
+        GGL_BUF_LIST(
+            GGL_STR("services"),
+            GGL_STR("DeploymentService"),
+            GGL_STR("deploymentState"),
+            GGL_STR("jobsVersion")
+        ),
+        GGL_OBJ_I64(jobs_version),
+        &(int64_t) { 0 }
+    );
+    if (ret != GGL_ERR_OK) {
+        GGL_LOGE("Failed to write IoT Jobs Version to config.");
+        return ret;
+    }
+    return GGL_ERR_OK;
+}
+
 GglError save_deployment_info(GglDeployment *deployment) {
     GGL_LOGD("Encountered component requiring bootstrap. Saving deployment "
              "state to config.");
@@ -171,7 +191,7 @@ GglError save_deployment_info(GglDeployment *deployment) {
 }
 
 GglError retrieve_in_progress_deployment(
-    GglDeployment *deployment, GglBuffer *jobs_id
+    GglDeployment *deployment, GglBuffer *jobs_id, int64_t jobs_version
 ) {
     GGL_LOGD("Searching config for any in progress deployment.");
 
@@ -188,6 +208,28 @@ GglError retrieve_in_progress_deployment(
         GGL_LOGW("Failed to retrieve IoT Jobs ID from config.");
         return ret;
     }
+
+    GglBuffer version_mem = GGL_BUF((uint8_t[10]) { 0 });
+    GglBumpAlloc version_balloc = ggl_bump_alloc_init(version_mem);
+    GglObject jobs_version_obj;
+    ret = ggl_gg_config_read(
+        GGL_BUF_LIST(
+            GGL_STR("services"),
+            GGL_STR("DeploymentService"),
+            GGL_STR("deploymentState"),
+            GGL_STR("jobsVersion")
+        ),
+        &version_balloc.alloc,
+        &jobs_version_obj
+    );
+    if (ret != GGL_ERR_OK) {
+        return ret;
+    }
+    if (jobs_version_obj.type != GGL_TYPE_I64) {
+        GGL_LOGE("Did not receive an int64_t for IoT jobs version.");
+        return GGL_ERR_INVALID;
+    }
+    jobs_version = jobs_version_obj.i64;
 
     GglBuffer config_mem = GGL_BUF((uint8_t[2500]) { 0 });
     GglBumpAlloc balloc = ggl_bump_alloc_init(config_mem);

--- a/ggdeploymentd/src/bootstrap_manager.h
+++ b/ggdeploymentd/src/bootstrap_manager.h
@@ -10,6 +10,7 @@
 #include <ggl/error.h>
 #include <ggl/object.h>
 #include <ggl/vector.h>
+#include <stdint.h>
 
 /*
   deployment info will be saved to config in the following format:
@@ -25,6 +26,7 @@
           deploymentType: local/IoT Jobs
           deploymentDoc:
           jobsID:
+          jobsVersion:
 */
 
 // type can be "bootstrap" or "completed"
@@ -35,9 +37,10 @@ GglError save_component_info(
 );
 
 GglError save_iot_jobs_id(GglBuffer jobs_id);
+GglError save_iot_jobs_version(int64_t jobs_version);
 GglError save_deployment_info(GglDeployment *deployment);
 GglError retrieve_in_progress_deployment(
-    GglDeployment *deployment, GglBuffer *jobs_id
+    GglDeployment *deployment, GglBuffer *jobs_id, int64_t jobs_version
 );
 GglError delete_saved_deployment_from_config(void);
 GglError process_bootstrap_phase(

--- a/ggdeploymentd/src/bootstrap_manager.h
+++ b/ggdeploymentd/src/bootstrap_manager.h
@@ -40,7 +40,7 @@ GglError save_iot_jobs_id(GglBuffer jobs_id);
 GglError save_iot_jobs_version(int64_t jobs_version);
 GglError save_deployment_info(GglDeployment *deployment);
 GglError retrieve_in_progress_deployment(
-    GglDeployment *deployment, GglBuffer *jobs_id, int64_t jobs_version
+    GglDeployment *deployment, GglBuffer *jobs_id, int64_t *jobs_version
 );
 GglError delete_saved_deployment_from_config(void);
 GglError process_bootstrap_phase(

--- a/ggdeploymentd/src/deployment_handler.c
+++ b/ggdeploymentd/src/deployment_handler.c
@@ -2896,9 +2896,11 @@ static GglError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
     GglDeployment bootstrap_deployment = { 0 };
     uint8_t jobs_id_resp_mem[64] = { 0 };
     GglBuffer jobs_id = GGL_BUF(jobs_id_resp_mem);
+    int64_t jobs_version = 0;
 
-    GglError ret
-        = retrieve_in_progress_deployment(&bootstrap_deployment, &jobs_id);
+    GglError ret = retrieve_in_progress_deployment(
+        &bootstrap_deployment, &jobs_id, jobs_version
+    );
     if (ret != GGL_ERR_OK) {
         GGL_LOGD("No deployments previously in progress detected.");
     } else {
@@ -2908,8 +2910,10 @@ static GglError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
             (int) bootstrap_deployment.deployment_id.len,
             bootstrap_deployment.deployment_id.data
         );
-        update_current_jobs_deployment(
-            bootstrap_deployment.deployment_id, GGL_STR("IN_PROGRESS")
+        update_bootstrap_jobs_deployment(
+            bootstrap_deployment.deployment_id,
+            GGL_STR("IN_PROGRESS"),
+            jobs_version
         );
 
         bool bootstrap_deployment_succeeded = false;
@@ -2922,14 +2926,18 @@ static GglError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
         if (bootstrap_deployment_succeeded) {
             GGL_LOGI("Completed deployment processing and reporting job as "
                      "SUCCEEDED.");
-            update_current_jobs_deployment(
-                bootstrap_deployment.deployment_id, GGL_STR("SUCCEEDED")
+            update_bootstrap_jobs_deployment(
+                bootstrap_deployment.deployment_id,
+                GGL_STR("SUCCEEDED"),
+                jobs_version
             );
         } else {
             GGL_LOGW("Completed deployment processing and reporting job as "
                      "FAILED.");
-            update_current_jobs_deployment(
-                bootstrap_deployment.deployment_id, GGL_STR("FAILED")
+            update_bootstrap_jobs_deployment(
+                bootstrap_deployment.deployment_id,
+                GGL_STR("FAILED"),
+                jobs_version
             );
         }
         // clear any potential saved deployment info for next deployment

--- a/ggdeploymentd/src/deployment_handler.c
+++ b/ggdeploymentd/src/deployment_handler.c
@@ -2899,7 +2899,7 @@ static GglError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
     int64_t jobs_version = 0;
 
     GglError ret = retrieve_in_progress_deployment(
-        &bootstrap_deployment, &jobs_id, jobs_version
+        &bootstrap_deployment, &jobs_id, &jobs_version
     );
     if (ret != GGL_ERR_OK) {
         GGL_LOGD("No deployments previously in progress detected.");

--- a/ggdeploymentd/src/iot_jobs_listener.c
+++ b/ggdeploymentd/src/iot_jobs_listener.c
@@ -485,3 +485,14 @@ GglError update_current_jobs_deployment(
     // overwriting current_job_id while deployment thread updates job state
     return update_job(current_job_id.buf, status, &current_job_version);
 }
+
+GglError update_bootstrap_jobs_deployment(
+    GglBuffer deployment_id, GglBuffer status, int64_t version
+) {
+    if (!ggl_buffer_eq(deployment_id, current_deployment_id.buf)) {
+        return GGL_ERR_NOENTRY;
+    }
+
+    current_job_version = version;
+    return update_job(current_job_id.buf, status, &version);
+}

--- a/ggdeploymentd/src/iot_jobs_listener.h
+++ b/ggdeploymentd/src/iot_jobs_listener.h
@@ -13,5 +13,8 @@ void listen_for_jobs_deployments(void);
 GglError update_current_jobs_deployment(
     GglBuffer deployment_id, GglBuffer status
 );
+GglError update_bootstrap_jobs_deployment(
+    GglBuffer deployment_id, GglBuffer status, int64_t version
+);
 
 #endif

--- a/ggdeploymentd/src/iot_jobs_listener.h
+++ b/ggdeploymentd/src/iot_jobs_listener.h
@@ -7,6 +7,7 @@
 
 #include <ggl/buffer.h>
 #include <ggl/error.h>
+#include <stdint.h>
 
 void listen_for_jobs_deployments(void);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bootstrap deployments were not reporting their updated status to the cloud correctly due to a version conflict in IoT Jobs. This pr fixes that issue by saving the IoT jobs version to the config and retrieving and using it in case of bootstrap.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
