### PR TITLE
Notify systemd before exiting recipe runner

### DIFF
--- a/recipe-runner/src/runner.c
+++ b/recipe-runner/src/runner.c
@@ -492,6 +492,23 @@ static GglError write_script_with_replacement(
         return ret;
     }
 
+    // if startup, send a ready notification before exiting
+    // otherwise, simple startup scripts will fail with 'protocol' by systemd
+    if (ggl_buffer_eq(GGL_STR("startup"), phase)) {
+        ret = ggl_file_write(out_fd, GGL_STR("\n"));
+        if (ret != GGL_ERR_OK) {
+            return ret;
+        }
+        ret = ggl_file_write(out_fd, GGL_STR("systemd-notify --ready\n"));
+        if (ret != GGL_ERR_OK) {
+            return ret;
+        }
+        ret = ggl_file_write(out_fd, GGL_STR("systemd-notify --stopping\n"));
+        if (ret != GGL_ERR_OK) {
+            return ret;
+        }
+    }
+
     return GGL_ERR_OK;
 }
 


### PR DESCRIPTION
Otherwise, systemd fails simple startup components which do not use IPC to signal readiness

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
