### PR TITLE
Add limited support for architecture.detail platform attribute

### DIFF
--- a/docs/examples/sample_nucleus_config.yml
+++ b/docs/examples/sample_nucleus_config.yml
@@ -16,6 +16,7 @@ services:
       runWithDefault:
         posixUser: "gg_component:gg_component"
       greengrassDataPlanePort: "8443"
+      platformOverride: {}
   # aws.greengrass.fleet_provisioning:
   #   configuration:
   #     iotDataEndpoint: "<CONFIGURE_THIS>"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds limited support for the architecture.detail platform attribute.

We will only attempt to read this value under platformOverride in the nucleus config. We do NOT support platformOverride for other attributes. We do NOT support automatically reading the architecture.detail value based on processor. This is meant as a temporary workaround to support components with architecture.detail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
