### PR TITLE
Split the last hyphen to retrieve the correct component name

### DIFF
--- a/ggdeploymentd/src/component_store.c
+++ b/ggdeploymentd/src/component_store.c
@@ -87,7 +87,7 @@ GglError iterate_over_components(
         // Split the last "-" character to retrieve the component name
         GglBuffer recipe_component;
         GglBuffer rest = GGL_STR("");
-        for (size_t i = entry_buf.len; i-- > 0;) {
+        for (size_t i = entry_buf.len; i < 0; --i) {
             if (entry_buf.data[i] == '-') {
                 recipe_component = ggl_buffer_substr(entry_buf, 0, i);
                 rest = ggl_buffer_substr(entry_buf, i + 1, SIZE_MAX);

--- a/ggdeploymentd/src/component_store.c
+++ b/ggdeploymentd/src/component_store.c
@@ -87,10 +87,10 @@ GglError iterate_over_components(
         // Split the last "-" character to retrieve the component name
         GglBuffer recipe_component;
         GglBuffer rest = GGL_STR("");
-        for (size_t i = entry_buf.len; i < 0; --i) {
-            if (entry_buf.data[i] == '-') {
-                recipe_component = ggl_buffer_substr(entry_buf, 0, i);
-                rest = ggl_buffer_substr(entry_buf, i + 1, SIZE_MAX);
+        for (size_t i = entry_buf.len; i > 0; --i) {
+            if (entry_buf.data[i - 1] == '-') {
+                recipe_component = ggl_buffer_substr(entry_buf, 0, i - 1);
+                rest = ggl_buffer_substr(entry_buf, i, SIZE_MAX);
                 break;
             }
         }

--- a/ggdeploymentd/src/component_store.c
+++ b/ggdeploymentd/src/component_store.c
@@ -84,10 +84,10 @@ GglError iterate_over_components(
         GglBuffer entry_buf = ggl_buffer_from_null_term((*entry)->d_name);
         // recipe file names follow this format:
         // <component_name>-<version>.<extension>
-        // Split directory entry on the index of the "-" character.
+        // Split the last "-" character to retrieve the component name
         GglBuffer recipe_component;
         GglBuffer rest = GGL_STR("");
-        for (size_t i = 0; i < entry_buf.len; ++i) {
+        for (size_t i = entry_buf.len; i-- > 0;) {
             if (entry_buf.data[i] == '-') {
                 recipe_component = ggl_buffer_substr(entry_buf, 0, i);
                 rest = ggl_buffer_substr(entry_buf, i + 1, SIZE_MAX);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:
When we deployed the component named 'nucleus-all,' the stale component functionality incorrectly attempted to remove the 'nucleus' component instead of 'nucleus-all.' This also caused the issue where, when revising the deployment twice, the deployment would always fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
