### PR TITLE
Skip reprocessing component artifacts for bootstrap components

### DIFF
--- a/ggdeploymentd/src/bootstrap_manager.h
+++ b/ggdeploymentd/src/bootstrap_manager.h
@@ -10,6 +10,7 @@
 #include <ggl/error.h>
 #include <ggl/object.h>
 #include <ggl/vector.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 /*
@@ -28,6 +29,8 @@
           jobsID:
           jobsVersion:
 */
+
+bool component_bootstrap_phase_completed(GglBuffer component_name);
 
 // type can be "bootstrap" or "completed"
 // bootstrap type indicates that the component's bootstrap steps have completed


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Encountered a bug where bootstrap components would redownload any artifacts listed in the recipe after rebooting. We now check if a component has already completed its bootstrap steps, if it has then we will skip to the part of the deployment that will only process other lifecycle stages in the recipe.

Added more robust logging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
