### PR TITLE
Use systemctl to reboot after bootstrap

### DIFF
--- a/ggdeploymentd/src/bootstrap_manager.c
+++ b/ggdeploymentd/src/bootstrap_manager.c
@@ -11,7 +11,6 @@
 #include <ggl/bump_alloc.h>
 #include <ggl/core_bus/gg_config.h>
 #include <ggl/error.h>
-#include <ggl/exec.h>
 #include <ggl/file.h>
 #include <ggl/log.h>
 #include <ggl/map.h>

--- a/ggdeploymentd/src/bootstrap_manager.c
+++ b/ggdeploymentd/src/bootstrap_manager.c
@@ -614,11 +614,18 @@ GglError process_bootstrap_phase(
         }
 
         GGL_LOGI("Rebooting device for bootstrap.");
-        char *reboot_args[] = { "reboot", NULL };
-        ret = ggl_exec_command_async(reboot_args, NULL);
-        if (ret != GGL_ERR_OK) {
-            GGL_LOGE("Failed to reboot system for bootstrap.");
-            return ret;
+        // NOLINTNEXTLINE(concurrency-mt-unsafe)
+        int system_ret = system("systemctl reboot");
+        if (WIFEXITED(system_ret)) {
+            if (WEXITSTATUS(system_ret) != 0) {
+                GGL_LOGE("systemctl reboot failed");
+            }
+            GGL_LOGI(
+                "systemctl reboot exited with child status %d\n",
+                WEXITSTATUS(system_ret)
+            );
+        } else {
+            GGL_LOGE("systemctl reboot did not exit normally");
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously, the reboot command after a bootstrap phase was only rebooting `ggdeploymentd`. By using `systemctl reboot` we are able to reboot the whole device.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
