### PR TITLE
Compare deployment IDs before removing from deployment queue

### DIFF
--- a/ggdeploymentd/src/deployment_queue.c
+++ b/ggdeploymentd/src/deployment_queue.c
@@ -471,7 +471,9 @@ GglError ggl_deployment_dequeue(GglDeployment **deployment) {
 }
 
 void ggl_deployment_release(GglDeployment *deployment) {
-    assert(deployment == &deployments[queue_index]);
+    assert(ggl_buffer_eq(
+        deployment->deployment_id, deployments[queue_index].deployment_id
+    ));
 
     GGL_LOGD("Removing deployment from queue.");
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We now assert that the deployment ID of the deployment being released matches that of the deployment being processed on the queue. This is in place of comparing their memory addresses, since during bootstrap the original memory address is lost due to a copy being created after rebooting. 

This fixes an issue where the assertion was failing after a successful bootstrap deployment, causing ggdeploymentd to restart.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
