### PR TITLE
Update bootstrap config write timestamps

### DIFF
--- a/ggdeploymentd/src/bootstrap_manager.c
+++ b/ggdeploymentd/src/bootstrap_manager.c
@@ -73,7 +73,7 @@ GglError save_component_info(
                 component_name
             ),
             GGL_OBJ_BUF(component_version),
-            &(int64_t) { 0 }
+            &(int64_t) { 3 }
         );
         if (ret != GGL_ERR_OK) {
             GGL_LOGE(
@@ -93,7 +93,7 @@ GglError save_component_info(
                 component_name
             ),
             GGL_OBJ_BUF(component_version),
-            &(int64_t) { 0 }
+            &(int64_t) { 3 }
         );
         if (ret != GGL_ERR_OK) {
             GGL_LOGE(
@@ -131,7 +131,7 @@ GglError save_iot_jobs_id(GglBuffer jobs_id) {
             GGL_STR("jobsID")
         ),
         GGL_OBJ_BUF(jobs_id),
-        &(int64_t) { 0 }
+        &(int64_t) { 3 }
     );
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("Failed to write IoT Jobs ID to config.");
@@ -154,7 +154,7 @@ GglError save_iot_jobs_version(int64_t jobs_version) {
             GGL_STR("jobsVersion")
         ),
         GGL_OBJ_I64(jobs_version),
-        &(int64_t) { 0 }
+        &(int64_t) { 3 }
     );
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("Failed to write IoT Jobs Version to config.");
@@ -187,7 +187,7 @@ GglError save_deployment_info(GglDeployment *deployment) {
             GGL_STR("deploymentDoc")
         ),
         deployment_doc,
-        &(int64_t) { 0 }
+        &(int64_t) { 3 }
     );
 
     if (ret != GGL_ERR_OK) {
@@ -211,7 +211,7 @@ GglError save_deployment_info(GglDeployment *deployment) {
             GGL_STR("deploymentType")
         ),
         GGL_OBJ_BUF(deployment_type),
-        &(int64_t) { 0 }
+        &(int64_t) { 3 }
     );
 
     if (ret != GGL_ERR_OK) {

--- a/ggdeploymentd/src/deployment_handler.c
+++ b/ggdeploymentd/src/deployment_handler.c
@@ -1920,7 +1920,7 @@ static GglError add_arn_list_to_config(
                         GGL_STR("configArn")
                     ),
                     GGL_OBJ_LIST(arn_list.list),
-                    0
+                    &(int64_t) { 3 }
                 );
                 if (ret != GGL_ERR_OK) {
                     GGL_LOGE(
@@ -1941,7 +1941,7 @@ static GglError add_arn_list_to_config(
     ret = ggl_gg_config_write(
         GGL_BUF_LIST(GGL_STR("services"), component_name, GGL_STR("configArn")),
         GGL_OBJ_LIST(new_arn_list.list),
-        0
+        &(int64_t) { 3 }
     );
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("Failed to write configuration arn list to the config.");


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating config writes to write with a timestamp of 3 instead of 0. This is to prevent customers overwriting necessary config with their own boot time configurations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
