### PR TITLE
fix(fleet-provisioning): remove csr version set

### DIFF
--- a/fleet-provisioning/src/generate_certificate.c
+++ b/fleet-provisioning/src/generate_certificate.c
@@ -57,12 +57,6 @@ static GglError generate_csr(EVP_PKEY *pkey, X509_REQ **req) {
         return GGL_ERR_FAILURE;
     }
 
-    X509_REQ_set_version(*req, 1);
-    if (ret == 0) {
-        GGL_LOGE("x509 csr set version request failed");
-        return GGL_ERR_FAILURE;
-    }
-
     X509_NAME *name = X509_NAME_new();
     X509_NAME_add_entry_by_txt(
         name, "C", MBSTRING_ASC, (unsigned char *) "US", -1, -1, 0


### PR DESCRIPTION
`fleet-provisioning` fails with `x509 csr set version request failed` on every attempts.

`X509_REQ_set_version` param is zero indexed, it should be set to `0` or `X509_REQ_VERSION_1` (== 0), or preferably not set at all.

References:
- https://github.com/openssl/openssl/issues/20663
- https://github.com/openssl/openssl/discussions/23968#discussioncomment-8902748

Additionally, the error check did not apply on this call, since `ret` was not assigned, making the function return with failure for every calls.

*Description of changes:*
Avoid setting X509 REQ Version by removing the block.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
