### PR TITLE
fix(fleet-provisioning): CSR creation null check

### DIFF
--- a/fleet-provisioning/src/generate_certificate.c
+++ b/fleet-provisioning/src/generate_certificate.c
@@ -50,7 +50,7 @@ static GglError generate_keys(EVP_PKEY **pkey) {
 static GglError generate_csr(EVP_PKEY *pkey, X509_REQ **req) {
     int ret = 0;
     *req = X509_REQ_new();
-    if (req == NULL) {
+    if (*req == NULL) {
         GGL_LOGE(
             "Failed to create a openssl x509 certificate signing request object"
         );


### PR DESCRIPTION
Errors are not catched.

Since `req` is a pointer to the `X509_REQ *` variable, it should be dereferenced.

*Description of changes:*
Dereference `req` in the error check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
