### PR TITLE
Rework synchronization in iot_jobs_listener

### DIFF
--- a/ggdeploymentd/src/deployment_handler.c
+++ b/ggdeploymentd/src/deployment_handler.c
@@ -3037,11 +3037,12 @@ static GglError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
             (int) bootstrap_deployment.deployment_id.len,
             bootstrap_deployment.deployment_id.data
         );
-        update_bootstrap_jobs_deployment(
-            bootstrap_deployment.deployment_id,
-            GGL_STR("IN_PROGRESS"),
-            jobs_version
-        );
+
+        bool send_deployment_update
+            = (GGL_ERR_OK
+               == set_jobs_deployment_for_bootstrap(
+                   jobs_id, bootstrap_deployment.deployment_id, jobs_version
+               ));
 
         bool bootstrap_deployment_succeeded = false;
         handle_deployment(
@@ -3050,22 +3051,20 @@ static GglError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
 
         send_fss_update(&bootstrap_deployment, bootstrap_deployment_succeeded);
 
-        if (bootstrap_deployment_succeeded) {
+        if (send_deployment_update && bootstrap_deployment_succeeded) {
             GGL_LOGI("Completed deployment processing and reporting job as "
                      "SUCCEEDED.");
-            update_bootstrap_jobs_deployment(
-                bootstrap_deployment.deployment_id,
-                GGL_STR("SUCCEEDED"),
-                jobs_version
+            update_current_jobs_deployment(
+                bootstrap_deployment.deployment_id, GGL_STR("SUCCEEDED")
             );
-        } else {
+        } else if (send_deployment_update) {
             GGL_LOGW("Completed deployment processing and reporting job as "
                      "FAILED.");
-            update_bootstrap_jobs_deployment(
-                bootstrap_deployment.deployment_id,
-                GGL_STR("FAILED"),
-                jobs_version
+            update_current_jobs_deployment(
+                bootstrap_deployment.deployment_id, GGL_STR("FAILED")
             );
+        } else {
+            GGL_LOGI("Completed deployment, but job was canceled.");
         }
         // clear any potential saved deployment info for next deployment
         ret = delete_saved_deployment_from_config();

--- a/ggdeploymentd/src/deployment_queue.c
+++ b/ggdeploymentd/src/deployment_queue.c
@@ -429,7 +429,7 @@ GglError ggl_deployment_enqueue(
     if (exists) {
         if (deployments[index].state != GGL_DEPLOYMENT_QUEUED) {
             GGL_LOGI("Existing deployment not replaceable.");
-            return GGL_ERR_FAILURE;
+            return GGL_ERR_OK;
         }
         GGL_LOGI("Replacing existing deployment in queue.");
     } else {

--- a/ggdeploymentd/src/iot_jobs_listener.c
+++ b/ggdeploymentd/src/iot_jobs_listener.c
@@ -249,8 +249,9 @@ static GglError update_job(
         if (ret != GGL_ERR_OK) {
             return ret;
         }
-        if (ggl_buffer_eq(job_status, GGL_STR("CANCELLED"))) {
-            GGL_LOGD("Job was cancelled.");
+        if (ggl_buffer_eq(job_status, GGL_STR("CANCELED"))) {
+            // TODO: Cancelation?
+            GGL_LOGD("Job was canceled.");
             return GGL_ERR_OK;
         }
         if (version_number->i64 != *version) {
@@ -411,7 +412,7 @@ static GglError process_job_execution(GglMap job_execution) {
     }
     switch (action) {
     case DSA_CANCEL_JOB:
-        // TODO: cancellation?
+        // TODO: cancelation?
         break;
 
     case DSA_ENQUEUE_JOB: {
@@ -461,7 +462,7 @@ static GglError next_job_execution_changed_callback(
         return GGL_ERR_FAILURE;
     }
     if (job_execution == NULL) {
-        // TODO: job cancellation
+        // TODO: job cancelation
         return GGL_ERR_OK;
     }
     ret = process_job_execution(job_execution->map);

--- a/ggdeploymentd/src/iot_jobs_listener.h
+++ b/ggdeploymentd/src/iot_jobs_listener.h
@@ -14,8 +14,8 @@ void *job_listener_thread(void *ctx);
 GglError update_current_jobs_deployment(
     GglBuffer deployment_id, GglBuffer status
 );
-GglError update_bootstrap_jobs_deployment(
-    GglBuffer deployment_id, GglBuffer status, int64_t version
+GglError set_jobs_deployment_for_bootstrap(
+    GglBuffer job_id, GglBuffer deployment_id, int64_t version
 );
 
 #endif


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Remove shared buffers and mutex around them.
* Remove shared tracking of subscription handles 
* Add mutex around current job/deployment ID and expected version
* Add retries to updating job state
* Reduce responsibility of thread started by IoT Jobs Listener.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
