### PR TITLE
Fix fleet provisioning to use correct user/group

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,11 @@ function(ggl_init_module name)
   if(NOT SRCS_LEN EQUAL 0)
     add_library(${name} STATIC ${SRCS})
     target_compile_definitions(${name} PRIVATE "GGL_MODULE=(\"${name}\")")
+    target_compile_definitions(
+      ${name} PRIVATE "GGL_SYSTEMD_SYSTEM_USER=\"${GGL_SYSTEMD_SYSTEM_USER}\"")
+    target_compile_definitions(
+      ${name}
+      PRIVATE "GGL_SYSTEMD_SYSTEM_GROUP=\"${GGL_SYSTEMD_SYSTEM_GROUP}\"")
     target_include_directories(${name} PRIVATE ${COMP_ARG_INCDIRS})
     target_include_directories(${name} SYSTEM INTERFACE ${COMP_ARG_INCDIRS})
     target_link_libraries(${name} PRIVATE ${COMP_ARG_LIBS})

--- a/docs/FLEET_PROVISIONING.md
+++ b/docs/FLEET_PROVISIONING.md
@@ -133,11 +133,8 @@ $ cp ./run/config.yaml /etc/greengrass/config.yaml
 $ ./misc/run_nucleus
 ```
 
-In root user shell, run the fleet provisioning binary.
-
-If you changed `GGL_SYSTEMD_SYSTEM_USER` and `GGL_SYSTEMD_SYSTEM_GROUP`
-mentioned in [CMakeLists.txt](../CMakeLists.txt), you can override default by
-adding `-u "ggcore:ggcore"` at the end of following command:
+In root user shell, run the fleet provisioning binary with the following
+command:
 
 ```sh
 $ ../build/bin/fleet-provisioning

--- a/fleet-provisioning/bin/fleet-provisioning.c
+++ b/fleet-provisioning/bin/fleet-provisioning.c
@@ -12,7 +12,6 @@
 #include <ggl/object.h>
 #include <ggl/vector.h>
 #include <ggl/version.h>
-#include <string.h>
 #include <stdint.h>
 
 __attribute__((visibility("default"))) const char *argp_program_version
@@ -23,13 +22,7 @@ static char doc[] = "fleet provisioner -- Executable to automatically "
 static GglBuffer component_name = GGL_STR("fleet-provisioning");
 
 static struct argp_option opts[]
-    = { { "user-group",
-          'u',
-          "name",
-          0,
-          "[optional]GGL_SYSTEMD_SYSTEM_USER user and group \":\" seprated",
-          0 },
-        { "claim-key",
+    = { { "claim-key",
           'k',
           "path",
           0,
@@ -87,15 +80,6 @@ static error_t arg_parser(int key, char *arg, struct argp_state *state) {
         break;
     case 'r':
         args->root_ca_path = arg;
-        break;
-    case 'u':
-        args->user_group = arg;
-        break;
-    case ARGP_KEY_END:
-        if (args->user_group == NULL) {
-            args->user_group = "ggcore:ggcore";
-        }
-        // All keys are optional other are set down the line
         break;
     default:
         return ARGP_ERR_UNKNOWN;

--- a/fleet-provisioning/include/fleet-provisioning.h
+++ b/fleet-provisioning/include/fleet-provisioning.h
@@ -16,7 +16,6 @@ typedef struct {
     char *data_endpoint;
     char *root_ca_path;
     char *iotcored_path;
-    char *user_group;
 } FleetProvArgs;
 
 GglError run_fleet_prov(FleetProvArgs *args, pid_t *pid);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR updates the fleet provisioning code to use the compiled user and user-group provided by CMake instead of parsing command line arguments.

Additionally, this PR also updates the fleet-provisioning code to update the configuration correctly ('system' -> 'services').


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
