### PR TITLE
Changing, restructoring of packaging GitHub workflows

### DIFF
--- a/.github/workflows/ubuntu-22.04-packaging-aarch64-static.yml
+++ b/.github/workflows/ubuntu-22.04-packaging-aarch64-static.yml
@@ -1,4 +1,4 @@
-name: Build static deb arm64 packages and put them in zip files
+name: Ubuntu 22.04 - Build static deb packages and zip files
 on:
   push:
     branches:
@@ -8,28 +8,28 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04-arm
     strategy:
       fail-fast: false
       matrix:
-        architecture: [aarch64-linux-gnu]
         build_type: [RelWithDebInfo, MinSizeRel]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Set up Podman
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
 
       - name: Cache Podman image
         uses: actions/cache@v4
         with:
           path: ~/podman-image.tar
           key:
-            ${{ runner.os }}-${{ matrix.architecture }}-podman-${{
+            ${{ runner.os }}-podman-${{
             hashFiles('misc/staticbuildtestcontainer/*') }}
 
       - name: Build and save container for aarch64-linux-gnu
-        if: matrix.architecture == 'aarch64-linux-gnu'
         run: |
           if [ ! -f ~/podman-image.tar ]; then
             podman build --from=docker.io/arm64v8/ubuntu:22.04 --arch=arm64 misc/staticbuildtestcontainer -t container
@@ -73,16 +73,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name:
-            aws-greengrass-lite-ubuntu-${{ matrix.architecture || 'x86-64'}}_${{
-            matrix.build_type }}-static
+            aws-greengrass-lite-ubuntu-aarch64-linux-gnu_${{ matrix.build_type
+            }}-static
           path: |
             ${{ github.workspace }}/zipfile/*
           retention-days: 1
       - name:
           Save arm64 package without build type - default package to download
-        if:
-          matrix.build_type  == 'MinSizeRel' && matrix.architecture ==
-          'aarch64-linux-gnu'
+        if: matrix.build_type  == 'MinSizeRel'
         uses: actions/upload-artifact@v4
         with:
           name: aws-greengrass-lite-ubuntu-arm64-static

--- a/.github/workflows/ubuntu-24.04-packaging-aarch64.yml
+++ b/.github/workflows/ubuntu-24.04-packaging-aarch64.yml
@@ -1,0 +1,93 @@
+name: Ubuntu 24.04 aarch64 - Build deb packages and zip files
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [RelWithDebInfo, MinSizeRel]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Podman
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+
+      - name: Cache Podman image
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/podman-aarch64-linux-gnu-image.tar
+          key:
+            ${{ runner.os }}-podman-${{ hashFiles('misc/buildtestcontainer/*')
+            }}
+
+      - name: Build and save container for aarch64-linux-gnu
+        run: |
+          if [ ! -f ~/podman-aarch64-linux-gnu-image.tar ]; then
+            podman build --from=docker.io/arm64v8/ubuntu:24.04 --arch=arm64 misc/buildtestcontainer -t container
+            podman save container:latest > ~/podman-aarch64-linux-gnu-image.tar
+          else
+            podman load < ~/podman-aarch64-linux-gnu-image.tar
+          fi
+
+      - name: Run build in container
+        shell: bash
+        run: |
+          podman run -v $PWD/.:/aws-greengrass-lite --replace --name ggl container:latest bash -c "\
+            cd /aws-greengrass-lite && \
+            rm -rf build/ && \
+            cmake -B build \
+            -DGGL_LOG_LEVEL=DEBUG \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_FIND_DEBUG_MODE=ON \
+            -DGGL_SYSTEMD_SYSTEM_USER=ggcore \
+            -DGGL_SYSTEMD_SYSTEM_GROUP=ggcore  \
+            -DGGL_SYSTEMD_SYSTEM_DIR=/lib/systemd/system \
+            -DCMAKE_INSTALL_PREFIX=/usr && \
+            make -C build -j$(nproc) && \
+            cd build && cpack -v -G DEB && cd - \
+            "
+
+      - name: Save package
+        run: |
+          mkdir ${{ github.workspace }}/zipfile/
+          cp ${{ github.workspace }}/build/*.deb ${{ github.workspace }}/zipfile/
+
+      - name: Generate readme / install file
+        run: |
+          cat ${{ github.workspace }}/.github/workflows/packaging/readme.template.txt >> ${{ github.workspace }}/zipfile/readme.txt
+          cp ${{ github.workspace }}/.github/workflows/packaging/install-greengrass-lite.sh ${{ github.workspace }}/zipfile/
+          sed -i 's|{{ VERSION_LINK }}|${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|g' ${{ github.workspace }}/zipfile/readme.txt
+          sed -i 's|{{ UBUNTU_VERSION }}|24.04|g' ${{ github.workspace }}/zipfile/install-greengrass-lite.sh
+          cat ${{ github.workspace }}/LICENSE >> ${{ github.workspace }}/zipfile/readme.txt
+
+      - name: md5sums
+        run: |
+          md5sum ${{ github.workspace }}/zipfile/*
+
+      - name: Save package
+        uses: actions/upload-artifact@v4
+        with:
+          name: aws-greengrass-lite-ubuntu-${{ matrix.build_type }}
+          path: |
+            ${{ github.workspace }}/zipfile/*
+          retention-days: 1
+
+      - name:
+          Save arm64 package without build type - default package to download
+        if: matrix.build_type  == 'MinSizeRel'
+        uses: actions/upload-artifact@v4
+        with:
+          name: aws-greengrass-lite-ubuntu-arm64
+          path: |
+            ${{ github.workspace }}/zipfile/*
+          retention-days: 1

--- a/.github/workflows/ubuntu-24.04-packaging-x86-64.yml
+++ b/.github/workflows/ubuntu-24.04-packaging-x86-64.yml
@@ -1,17 +1,17 @@
-name: Build deb packages and put them in zip files
+name: Ubuntu 24.04 x86-64 - Build deb packages and zip files
 on:
   push:
     branches:
       - main
   workflow_dispatch:
   pull_request:
+
 jobs:
   build:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        architecture: [aarch64-linux-gnu, ""]
         build_type: [RelWithDebInfo, MinSizeRel]
     steps:
       - uses: actions/checkout@v4
@@ -23,24 +23,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/podman-aarch64-linux-gnu-image.tar
             ~/podman-x86-64-image.tar
           key:
-            ${{ runner.os }}-${{ matrix.architecture }}-podman-${{
-            hashFiles('misc/buildtestcontainer/*') }}
-
-      - name: Build and save container for aarch64-linux-gnu
-        if: matrix.architecture == 'aarch64-linux-gnu'
-        run: |
-          if [ ! -f ~/podman-aarch64-linux-gnu-image.tar ]; then
-            podman build --from=docker.io/arm64v8/ubuntu:24.04 --arch=arm64 misc/buildtestcontainer -t container
-            podman save container:latest > ~/podman-aarch64-linux-gnu-image.tar
-          else
-            podman load < ~/podman-aarch64-linux-gnu-image.tar
-          fi
+            ${{ runner.os }}-podman-${{ hashFiles('misc/buildtestcontainer/*')
+            }}
 
       - name: Build and save container for x86-64
-        if: matrix.architecture == ''
         run: |
           if [ ! -f ~/podman-x86-64-image.tar ]; then
             podman build misc/buildtestcontainer -t container
@@ -87,31 +75,17 @@ jobs:
       - name: Save package
         uses: actions/upload-artifact@v4
         with:
-          name:
-            aws-greengrass-lite-ubuntu-${{ matrix.architecture || 'x86-64'}}_${{
-            matrix.build_type }}
+          name: aws-greengrass-lite-ubuntu-x86-64_${{matrix.build_type }}
           path: |
             ${{ github.workspace }}/zipfile/*
           retention-days: 1
 
       - name:
           Save x86-64 package without build type - default package to download
-        if: matrix.build_type  == 'MinSizeRel' && matrix.architecture == ''
+        if: matrix.build_type  == 'MinSizeRel'
         uses: actions/upload-artifact@v4
         with:
-          name: aws-greengrass-lite-ubuntu-${{ matrix.architecture || 'x86-64'}}
-          path: |
-            ${{ github.workspace }}/zipfile/*
-          retention-days: 1
-
-      - name:
-          Save arm64 package without build type - default package to download
-        if:
-          matrix.build_type  == 'MinSizeRel' && matrix.architecture ==
-          'aarch64-linux-gnu'
-        uses: actions/upload-artifact@v4
-        with:
-          name: aws-greengrass-lite-ubuntu-arm64
+          name: aws-greengrass-lite-ubuntu-x86-64
           path: |
             ${{ github.workspace }}/zipfile/*
           retention-days: 1


### PR DESCRIPTION
There is a bug in qemu when cross compiling packages in qemu, probably something with out of memory. This will remove the use of qemu and use ubuntu-arm runners instead.

