### PR TITLE
Remove undesirable usage of static

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -70,7 +70,7 @@ Then run:
 
 ```
 sudo mkdir /ggcredentials
-//cp your aws credentials(device certificates, private key, root ca) to this folder
+# cp your aws credentials(device certificates, private key, root ca) to this folder
 chown -R ggcore:ggcore /ggcredentials
 
 mkdir /var/lib/greengrass

--- a/ggdeploymentd/src/deployment_handler.c
+++ b/ggdeploymentd/src/deployment_handler.c
@@ -1278,7 +1278,7 @@ static GglError resolve_dependencies(
     }
 
     // Get list of thing groups
-    static uint8_t list_thing_groups_response_buf[2048] = { 0 };
+    uint8_t list_thing_groups_response_buf[2048] = { 0 };
     GglBuffer list_thing_groups_response
         = GGL_BUF(list_thing_groups_response_buf);
 
@@ -1577,7 +1577,11 @@ static GglError resolve_dependencies(
 
         if (!found_local_candidate) {
             // Resolve with cloud and download recipe
-            static uint8_t resolve_component_candidates_response_buf[16384]
+            static uint8_t resolve_component_candidates_response_buf
+                [16384] // TODO: Clean up usages of static variables in this
+                        // file, many may be more appropriately non-static to
+                        // prevent issues where the memory is not re-initalized
+                        // to zero when the function is re-called
                 = { 0 };
             GglBuffer resolve_component_candidates_response
                 = GGL_BUF(resolve_component_candidates_response_buf);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes an issue where the buffer is reused on subsequent calls without being re-initialized to zero, causing messages from a previous call to show up in newer call logs.

Not needed for the 2.0.1 release, but can optionally be included.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
