### PR TITLE
Fix proxy config error handling

### DIFF
--- a/bins/recipe-runner/src/runner.c
+++ b/bins/recipe-runner/src/runner.c
@@ -605,7 +605,8 @@ GglError runner(const RecipeRunnerArgs *args) {
         &resp
     );
     switch (ret) {
-    case GGL_ERR_NOENTRY:
+    case GGL_ERR_NOMEM:
+        GGL_LOGE("Proxy URL too large.");
         break;
     case GGL_ERR_OK: {
         resp.data[resp.len] = '\0';
@@ -618,8 +619,8 @@ GglError runner(const RecipeRunnerArgs *args) {
         break;
     }
     default:
-        GGL_LOGE("Failed to get proxy url from config.");
-        return ret;
+        GGL_LOGW("Failed to get proxy url from config.");
+        break;
     }
 
     resp = GGL_BUF(resp_mem);
@@ -631,7 +632,8 @@ GglError runner(const RecipeRunnerArgs *args) {
         &resp
     );
     switch (ret) {
-    case GGL_ERR_NOENTRY:
+    case GGL_ERR_NOMEM:
+        GGL_LOGE("noProxyAddresses value too large.");
         break;
     case GGL_ERR_OK: {
         resp.data[resp.len] = '\0';
@@ -640,8 +642,8 @@ GglError runner(const RecipeRunnerArgs *args) {
         break;
     }
     default:
-        GGL_LOGE("Failed to get noProxyAddresses from config.");
-        return ret;
+        GGL_LOGW("Failed to get noProxyAddresses from config.");
+        break;
     }
 
     static uint8_t thing_name_mem[MAX_THING_NAME_LEN + 1];

--- a/docs/examples/sample_nucleus_config.yaml
+++ b/docs/examples/sample_nucleus_config.yaml
@@ -17,6 +17,10 @@ services:
         posixUser: "gg_component:gg_component"
       greengrassDataPlanePort: "8443"
       platformOverride: {}
+      networkProxy:
+        proxy:
+          url: ""
+        noProxyAddresses: ""
   # aws.greengrass.fleet_provisioning:
   #   configuration:
   #     iotDataEndpoint: "<CONFIGURE_THIS>"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Components will crash if the proxy configuration values are not specified in the configuration. Instead of returning when the config call doesn't work, just move on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
