### PR TITLE
handle IPC call errors and bubble them up

### DIFF
--- a/bins/ggipcd/src/ipc_dispatch.c
+++ b/bins/ggipcd/src/ipc_dispatch.c
@@ -23,7 +23,11 @@ static const size_t SERVICE_COUNT
     = sizeof(SERVICE_TABLE) / sizeof(SERVICE_TABLE[0]);
 
 GglError ggl_ipc_handle_operation(
-    GglBuffer operation, GglMap args, uint32_t handle, int32_t stream_id
+    GglBuffer operation,
+    GglMap args,
+    uint32_t handle,
+    int32_t stream_id,
+    GglIpcError *ipc_error
 ) {
     for (size_t i = 0; i < SERVICE_COUNT; i++) {
         const GglIpcService *service = SERVICE_TABLE[i];
@@ -71,7 +75,7 @@ GglError ggl_ipc_handle_operation(
                 GglBumpAlloc balloc = ggl_bump_alloc_init(GGL_BUF(resp_mem));
 
                 return service_op->handler(
-                    &info, args, handle, stream_id, &balloc.alloc
+                    &info, args, handle, stream_id, ipc_error, &balloc.alloc
                 );
             }
         }

--- a/bins/ggipcd/src/ipc_dispatch.h
+++ b/bins/ggipcd/src/ipc_dispatch.h
@@ -5,13 +5,18 @@
 #ifndef GGL_IPC_DISPATCH_H
 #define GGL_IPC_DISPATCH_H
 
+#include "ipc_server.h"
 #include <ggl/buffer.h>
 #include <ggl/error.h>
 #include <ggl/object.h>
 #include <stdint.h>
 
 GglError ggl_ipc_handle_operation(
-    GglBuffer operation, GglMap args, uint32_t handle, int32_t stream_id
+    GglBuffer operation,
+    GglMap args,
+    uint32_t handle,
+    int32_t stream_id,
+    GglIpcError *ipc_error
 );
 
 #endif

--- a/bins/ggipcd/src/ipc_server.h
+++ b/bins/ggipcd/src/ipc_server.h
@@ -18,6 +18,24 @@
 
 #define GGL_IPC_PAYLOAD_MAX_SUBOBJECTS 50
 
+typedef enum {
+    GGL_IPC_ERR_SERVICE_ERROR = 0,
+    GGL_IPC_ERR_RESOURCE_NOT_FOUND,
+    GGL_IPC_ERR_COMPONENT_NOT_FOUND,
+    GGL_IPC_ERR_INVALID_ARGUMENTS,
+    GGL_IPC_ERR_UNAUTHORIZED_ERROR,
+    GGL_IPC_ERR_CONFLICT_ERROR,
+    GGL_IPC_ERR_FAILED_UPDATE_CONDITION_CHECK_ERROR,
+    GGL_IPC_ERR_INVALID_TOKEN_ERROR,
+    GGL_IPC_ERR_INVALID_RECIPE_DIRECTORY_PATH_ERROR,
+    GGL_IPC_ERR_INVALID_ARTIFACTS_DIRECTORY_PATH_ERROR
+} GglIpcErrorCode;
+
+typedef struct {
+    GglIpcErrorCode error_code;
+    GglBuffer message;
+} GglIpcError;
+
 /// Start the GG-IPC server on a given socket
 GglError ggl_ipc_listen(const char *socket_name, const char *socket_path);
 

--- a/bins/ggipcd/src/ipc_service.h
+++ b/bins/ggipcd/src/ipc_service.h
@@ -5,6 +5,7 @@
 #ifndef GGL_IPC_SERVICE_H
 #define GGL_IPC_SERVICE_H
 
+#include "ipc_server.h"
 #include <ggl/alloc.h>
 #include <ggl/buffer.h>
 #include <ggl/error.h>
@@ -22,6 +23,7 @@ typedef GglError GglIpcOperationHandler(
     GglMap args,
     uint32_t handle,
     int32_t stream_id,
+    GglIpcError *ipc_error,
     GglAlloc *alloc
 );
 

--- a/bins/ggipcd/src/services/cli/create_local_deployment.c
+++ b/bins/ggipcd/src/services/cli/create_local_deployment.c
@@ -21,6 +21,7 @@ GglError ggl_handle_create_local_deployment(
     GglMap args,
     uint32_t handle,
     int32_t stream_id,
+    GglIpcError *ipc_error,
     GglAlloc *alloc
 ) {
     GGL_MAP_FOREACH(pair, args) {
@@ -53,6 +54,9 @@ GglError ggl_handle_create_local_deployment(
         = ggl_ipc_auth(info, GGL_STR(""), ggl_ipc_default_policy_matcher);
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("IPC Operation not authorized.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GGL_STR("IPC Operation not authorized.") };
         return GGL_ERR_INVALID;
     }
 
@@ -68,11 +72,16 @@ GglError ggl_handle_create_local_deployment(
 
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("Failed to create local deployment.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GGL_STR("Failed to create local deployment.") };
         return ret;
     }
 
     if (result.type != GGL_TYPE_BUF) {
-        GGL_LOGE("Response not a string.");
+        GGL_LOGE("Received deployment ID not a string.");
+        *ipc_error = (GglIpcError) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+                                     .message = GGL_STR("Internal error.") };
         return GGL_ERR_FAILURE;
     }
 

--- a/bins/ggipcd/src/services/lifecycle/update_state.c
+++ b/bins/ggipcd/src/services/lifecycle/update_state.c
@@ -20,6 +20,7 @@ GglError ggl_handle_update_state(
     GglMap args,
     uint32_t handle,
     int32_t stream_id,
+    GglIpcError *ipc_error,
     GglAlloc *alloc
 ) {
     (void) alloc;
@@ -29,7 +30,10 @@ GglError ggl_handle_update_state(
         GGL_MAP_SCHEMA({ GGL_STR("state"), true, GGL_TYPE_BUF, &state_obj }, )
     );
     if (ret != GGL_ERR_OK) {
-        GGL_LOGE("Received invalid paramters.");
+        GGL_LOGE("Received invalid parameters.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GGL_STR("Received invalid parameters.") };
         return GGL_ERR_INVALID;
     }
 
@@ -55,6 +59,9 @@ GglError ggl_handle_update_state(
         NULL
     );
     if (ret != GGL_ERR_OK) {
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GGL_STR("Failed to update the lifecycle state.") };
         return ret;
     }
 

--- a/bins/ggipcd/src/services/mqttproxy/subscribe_to_iot_core.c
+++ b/bins/ggipcd/src/services/mqttproxy/subscribe_to_iot_core.c
@@ -67,6 +67,7 @@ GglError ggl_handle_subscribe_to_iot_core(
     GglMap args,
     uint32_t handle,
     int32_t stream_id,
+    GglIpcError *ipc_error,
     GglAlloc *alloc
 ) {
     (void) alloc;
@@ -82,6 +83,9 @@ GglError ggl_handle_subscribe_to_iot_core(
     );
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("Received invalid parameters.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GGL_STR("Received invalid parameters.") };
         return GGL_ERR_INVALID;
     }
 
@@ -89,11 +93,17 @@ GglError ggl_handle_subscribe_to_iot_core(
     if (qos_obj != NULL) {
         ret = ggl_str_to_int64(qos_obj->buf, &qos);
         if (ret != GGL_ERR_OK) {
-            GGL_LOGE("Failed to parse qos string value.");
+            GGL_LOGE("Failed to parse 'qos' string value.");
+            *ipc_error = (GglIpcError
+            ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+                .message = GGL_STR("Failed to parse 'qos' string value.") };
             return ret;
         }
         if ((qos < 0) || (qos > 2)) {
-            GGL_LOGE("qos not a valid value.");
+            GGL_LOGE("'qos' not a valid value.");
+            *ipc_error = (GglIpcError
+            ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+                .message = GGL_STR("'qos' not a valid value.") };
             return GGL_ERR_INVALID;
         }
     }
@@ -101,6 +111,9 @@ GglError ggl_handle_subscribe_to_iot_core(
     ret = ggl_ipc_auth(info, topic_name_obj->buf, ggl_ipc_mqtt_policy_matcher);
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("IPC Operation not authorized.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_UNAUTHORIZED_ERROR,
+            .message = GGL_STR("IPC Operation not authorized.") };
         return GGL_ERR_INVALID;
     }
 
@@ -119,6 +132,10 @@ GglError ggl_handle_subscribe_to_iot_core(
         NULL
     );
     if (ret != GGL_ERR_OK) {
+        GGL_LOGE("Failed to bind the subscription.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GGL_STR("Failed to bind the subscription.") };
         return ret;
     }
 

--- a/bins/ggipcd/src/services/private/private.c
+++ b/bins/ggipcd/src/services/private/private.c
@@ -34,6 +34,7 @@ GglError handle_get_system_config(
     GglMap args,
     uint32_t handle,
     int32_t stream_id,
+    GglIpcError *ipc_error,
     GglAlloc *alloc
 ) {
     (void) info;
@@ -44,6 +45,9 @@ GglError handle_get_system_config(
     );
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("Received invalid parameters.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_INVALID_ARGUMENTS,
+            .message = GGL_STR("Received invalid parameters.") };
         return GGL_ERR_INVALID;
     }
 
@@ -52,6 +56,10 @@ GglError handle_get_system_config(
         GGL_BUF_LIST(GGL_STR("system"), key_obj->buf), alloc, &read_value
     );
     if (ret != GGL_ERR_OK) {
+        GGL_LOGE("Failed to read the system configuration.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GGL_STR("Failed to read the system configuration.") };
         return ret;
     }
 

--- a/bins/ggipcd/src/services/pubsub/publish_to_topic.c
+++ b/bins/ggipcd/src/services/pubsub/publish_to_topic.c
@@ -21,6 +21,7 @@ GglError ggl_handle_publish_to_topic(
     GglMap args,
     uint32_t handle,
     int32_t stream_id,
+    GglIpcError *ipc_error,
     GglAlloc *alloc
 ) {
     (void) alloc;
@@ -35,7 +36,10 @@ GglError ggl_handle_publish_to_topic(
         )
     );
     if (ret != GGL_ERR_OK) {
-        GGL_LOGE("Received invalid paramters.");
+        GGL_LOGE("Received invalid parameters.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GGL_STR("Received invalid parameters.") };
         return GGL_ERR_INVALID;
     }
 
@@ -49,13 +53,19 @@ GglError ggl_handle_publish_to_topic(
         )
     );
     if (ret != GGL_ERR_OK) {
-        GGL_LOGE("Received invalid paramters.");
+        GGL_LOGE("Received invalid parameters.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GGL_STR("Received invalid parameters.") };
         return GGL_ERR_INVALID;
     }
 
     if ((json_message == NULL) == (binary_message == NULL)) {
-        GGL_LOGE("publishMessage must have exactly one of binaryMessage or "
-                 "jsonMessage.");
+        GGL_LOGE("'publishMessage' must have exactly one of 'binaryMessage' or "
+                 "'jsonMessage'.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GGL_STR("Received invalid parameters.") };
         return GGL_ERR_INVALID;
     }
 
@@ -72,13 +82,19 @@ GglError ggl_handle_publish_to_topic(
         )
     );
     if (ret != GGL_ERR_OK) {
-        GGL_LOGE("Received invalid paramters.");
+        GGL_LOGE("Received invalid parameters.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GGL_STR("Received invalid parameters.") };
         return GGL_ERR_INVALID;
     }
 
     ret = ggl_ipc_auth(info, topic->buf, ggl_ipc_default_policy_matcher);
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("IPC Operation not authorized.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_UNAUTHORIZED_ERROR,
+            .message = GGL_STR("IPC Operation not authorized.") };
         return GGL_ERR_INVALID;
     }
 
@@ -94,6 +110,10 @@ GglError ggl_handle_publish_to_topic(
         GGL_STR("gg_pubsub"), GGL_STR("publish"), call_args, NULL, NULL, NULL
     );
     if (ret != GGL_ERR_OK) {
+        GGL_LOGE("Failed to publish the message.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GGL_STR("Failed to publish the message.") };
         return ret;
     }
 

--- a/bins/ggipcd/src/services/pubsub/subscribe_to_topic.c
+++ b/bins/ggipcd/src/services/pubsub/subscribe_to_topic.c
@@ -92,6 +92,7 @@ GglError ggl_handle_subscribe_to_topic(
     GglMap args,
     uint32_t handle,
     int32_t stream_id,
+    GglIpcError *ipc_error,
     GglAlloc *alloc
 ) {
     (void) alloc;
@@ -103,12 +104,18 @@ GglError ggl_handle_subscribe_to_topic(
     );
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("Received invalid parameters.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GGL_STR("Received invalid parameters.") };
         return GGL_ERR_INVALID;
     }
 
     ret = ggl_ipc_auth(info, topic_obj->buf, ggl_ipc_default_policy_matcher);
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("IPC Operation not authorized.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_UNAUTHORIZED_ERROR,
+            .message = GGL_STR("IPC Operation not authorized.") };
         return GGL_ERR_INVALID;
     }
 
@@ -124,6 +131,10 @@ GglError ggl_handle_subscribe_to_topic(
         NULL
     );
     if (ret != GGL_ERR_OK) {
+        GGL_LOGE("Failed to bind subscription.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GGL_STR("Failed to bind subscription.") };
         return ret;
     }
 

--- a/bins/recipe-runner/src/runner.c
+++ b/bins/recipe-runner/src/runner.c
@@ -608,11 +608,11 @@ GglError runner(const RecipeRunnerArgs *args) {
     );
     switch (ret) {
     case GGL_ERR_NOMEM:
-        GGL_LOGW("Failed to get network proxy url from config - lack of memory."
-        );
-        break;
+        GGL_LOGE("Failed to get network proxy url from config - value longer "
+                 "than supported.");
+        return ret;
     case GGL_ERR_NOENTRY:
-        GGL_LOGW("Failed to get network proxy url - no such entry.");
+        GGL_LOGD("No network proxy set.");
         break;
     case GGL_ERR_OK: {
         resp.data[resp.len] = '\0';
@@ -625,7 +625,8 @@ GglError runner(const RecipeRunnerArgs *args) {
         break;
     }
     default:
-        GGL_LOGE("Failed to get proxy url from config.");
+        GGL_LOGE("Failed to get proxy url from config. Error: %d.", ret);
+        // TODO: Return here once client errors are propagated through.
         break;
     }
 
@@ -639,11 +640,11 @@ GglError runner(const RecipeRunnerArgs *args) {
     );
     switch (ret) {
     case GGL_ERR_NOMEM:
-        GGL_LOGW("Failed to get noProxyAddresses from config - lack of memory."
-        );
-        break;
+        GGL_LOGE("Failed to get network proxy url from config - value longer "
+                 "than supported.");
+        return ret;
     case GGL_ERR_NOENTRY:
-        GGL_LOGW("Failed to get noProxyAddresses - no such entry.");
+        GGL_LOGD("No network proxy set.");
         break;
     case GGL_ERR_OK: {
         resp.data[resp.len] = '\0';
@@ -652,7 +653,8 @@ GglError runner(const RecipeRunnerArgs *args) {
         break;
     }
     default:
-        GGL_LOGE("Failed to get noProxyAddresses from config.");
+        GGL_LOGE("Failed to get proxy url from config. Error: %d.", ret);
+        // TODO: Return here once client errors are propagated through.
         break;
     }
 

--- a/bins/recipe-runner/src/runner.c
+++ b/bins/recipe-runner/src/runner.c
@@ -542,6 +542,7 @@ GglError runner(const RecipeRunnerArgs *args) {
         ggl_buffer_from_null_term(socket_path), &resp, &conn
     );
     if (ret != GGL_ERR_OK) {
+        GGL_LOGE("Runner failed to authenticate with nucleus.");
         return ret;
     }
 
@@ -577,6 +578,7 @@ GglError runner(const RecipeRunnerArgs *args) {
         &GGL_STR("aws.greengrass.NucleusLite"),
         &resp
     );
+
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("Failed to get region from config.");
         return ret;
@@ -605,7 +607,12 @@ GglError runner(const RecipeRunnerArgs *args) {
         &resp
     );
     switch (ret) {
+    case GGL_ERR_NOMEM:
+        GGL_LOGW("Failed to get network proxy url from config - lack of memory."
+        );
+        break;
     case GGL_ERR_NOENTRY:
+        GGL_LOGW("Failed to get network proxy url - no such entry.");
         break;
     case GGL_ERR_OK: {
         resp.data[resp.len] = '\0';
@@ -619,7 +626,7 @@ GglError runner(const RecipeRunnerArgs *args) {
     }
     default:
         GGL_LOGE("Failed to get proxy url from config.");
-        return ret;
+        break;
     }
 
     resp = GGL_BUF(resp_mem);
@@ -631,7 +638,12 @@ GglError runner(const RecipeRunnerArgs *args) {
         &resp
     );
     switch (ret) {
+    case GGL_ERR_NOMEM:
+        GGL_LOGW("Failed to get noProxyAddresses from config - lack of memory."
+        );
+        break;
     case GGL_ERR_NOENTRY:
+        GGL_LOGW("Failed to get noProxyAddresses - no such entry.");
         break;
     case GGL_ERR_OK: {
         resp.data[resp.len] = '\0';
@@ -641,7 +653,7 @@ GglError runner(const RecipeRunnerArgs *args) {
     }
     default:
         GGL_LOGE("Failed to get noProxyAddresses from config.");
-        return ret;
+        break;
     }
 
     static uint8_t thing_name_mem[MAX_THING_NAME_LEN + 1];

--- a/modules/ggipc-client/src/client.c
+++ b/modules/ggipc-client/src/client.c
@@ -261,13 +261,13 @@ GglError ggipc_call(
     if (result != NULL) {
         ret = ggl_json_decode_destructive(msg.payload, alloc, result);
         if (ret != GGL_ERR_OK) {
-            GGL_LOGE("ggl_json_decode_destructive returned %d", ret);
+            GGL_LOGE("Failed to decode IPC response payload.");
             return ret;
         }
 
         ret = ggl_obj_buffer_copy(result, alloc);
         if (ret != GGL_ERR_OK) {
-            GGL_LOGE("Failed to copy buffer %d", ret);
+            GGL_LOGE("Insufficient memory provided for IPC response payload.");
             return ret;
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR modifies the IPC client to handle the call errors more gracefully and bubble up the errors to the caller.


Supersedes https://github.com/aws-greengrass/aws-greengrass-lite/pull/830.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
