### PR TITLE
install-greengrass-lite.sh: make version mismatch a warning

### DIFF
--- a/.github/workflows/packaging/install-greengrass-lite.sh
+++ b/.github/workflows/packaging/install-greengrass-lite.sh
@@ -31,9 +31,9 @@ check_ubuntu_version() {
             return 0
         fi
     fi
-    echo "Error: This greengrass lite package is only working with Ubuntu {{ UBUNTU_VERSION }}"
+    echo "Warning: This greengrass lite package is only tested working with Ubuntu {{ UBUNTU_VERSION }}"
     echo "Current system: $PRETTY_NAME"
-    exit 1
+    return 0
 }
 
 


### PR DESCRIPTION
As customers install this package on different systems, like Debian 12 this should not be a hard fail. Making it a warning instead.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
