### PR TITLE
Cleanup IPC connect handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ option(ENABLE_WERROR "Compile warnings as errors")
 
 set(GGL_LOG_LEVEL CACHE STRING "GGL log level")
 
-option(GGL_IPC_AUTH_DISABLE "Put IPC authentication in debug mode")
-
 option(GGL_SYSTEMD_SERVICE_BUILD "Install GGL as a set of systemd services"
        TRUE)
 set(GGL_SYSTEMD_SYSTEM_DIR
@@ -178,10 +176,6 @@ add_compile_definitions(_GNU_SOURCE)
 add_compile_definitions(CURL_NO_OLDIES)
 
 add_compile_definitions($<$<NOT:$<CONFIG:Debug>>:_FORTIFY_SOURCE=3>)
-
-if(GGL_IPC_AUTH_DISABLE)
-  add_compile_definitions(GGL_IPC_AUTH_DISABLE)
-endif()
 
 file(READ version GGL_VERSION)
 string(STRIP "${GGL_VERSION}" GGL_VERSION)

--- a/bins/ggipcd/src/ipc_components.c
+++ b/bins/ggipcd/src/ipc_components.c
@@ -238,13 +238,13 @@ static void get_svcuid(GglComponentHandle component_handle, GglBuffer *svcuid) {
 }
 
 GglError ggl_ipc_components_register(
-    int client_fd, GglComponentHandle *component_handle, GglBuffer *svcuid
+    pid_t pid, GglComponentHandle *component_handle, GglBuffer *svcuid
 ) {
     uint8_t component_name_buf[MAX_COMPONENT_NAME_LENGTH];
     GglBumpAlloc balloc = ggl_bump_alloc_init(GGL_BUF(component_name_buf));
     GglBuffer component_name;
     GglError ret
-        = ggl_ipc_auth_lookup_name(client_fd, &balloc.alloc, &component_name);
+        = ggl_ipc_auth_lookup_name(pid, &balloc.alloc, &component_name);
     if (ret != GGL_ERR_OK) {
         return ret;
     }

--- a/bins/ggipcd/src/ipc_components.h
+++ b/bins/ggipcd/src/ipc_components.h
@@ -5,7 +5,6 @@
 #ifndef GGL_IPC_COMPONENTS_H
 #define GGL_IPC_COMPONENTS_H
 
-#include <sys/types.h>
 #include <ggl/buffer.h>
 #include <ggl/error.h>
 #include <stdint.h>
@@ -43,7 +42,9 @@ GglBuffer ggl_ipc_components_get_name(GglComponentHandle component_handle);
 
 /// Authenticate client and create component entry and SVCUID.
 GglError ggl_ipc_components_register(
-    pid_t pid, GglComponentHandle *component_handle, GglBuffer *svcuid
+    GglBuffer component_name,
+    GglComponentHandle *component_handle,
+    GglBuffer *svcuid
 );
 
 #endif

--- a/bins/ggipcd/src/ipc_components.h
+++ b/bins/ggipcd/src/ipc_components.h
@@ -26,9 +26,6 @@ typedef uint16_t GglComponentHandle;
 #error "Maximum number of generic components is too large."
 #endif
 
-/// Helper function to verify svcuid exists.
-GglError ipc_svcuid_exists(GglBuffer svcuid_buf);
-
 /// Start the IPC component server used to verify svcuid.
 GglError ggl_ipc_start_component_server(void);
 

--- a/bins/ggipcd/src/ipc_components.h
+++ b/bins/ggipcd/src/ipc_components.h
@@ -5,6 +5,7 @@
 #ifndef GGL_IPC_COMPONENTS_H
 #define GGL_IPC_COMPONENTS_H
 
+#include <sys/types.h>
 #include <ggl/buffer.h>
 #include <ggl/error.h>
 #include <stdint.h>
@@ -42,7 +43,7 @@ GglBuffer ggl_ipc_components_get_name(GglComponentHandle component_handle);
 
 /// Authenticate client and create component entry and SVCUID.
 GglError ggl_ipc_components_register(
-    int client_fd, GglComponentHandle *component_handle, GglBuffer *svcuid
+    pid_t pid, GglComponentHandle *component_handle, GglBuffer *svcuid
 );
 
 #endif

--- a/bins/ggipcd/src/ipc_server.c
+++ b/bins/ggipcd/src/ipc_server.c
@@ -221,6 +221,24 @@ static GglError handle_conn_init(
             );
             return ret;
         }
+
+        if (component_name_obj != NULL) {
+            GGL_LOGD("Client %d also provided componentName.", handle);
+
+            GglBuffer component_name = component_name_obj->buf;
+            GglBuffer stored_name
+                = ggl_ipc_components_get_name(component_handle);
+
+            if (!ggl_buffer_eq(component_name, stored_name)) {
+                GGL_LOGE(
+                    "Client %d componentName (%.*s) does not match svcuid.",
+                    handle,
+                    (int) component_name.len,
+                    component_name.data
+                );
+                return GGL_ERR_FAILURE;
+            }
+        }
     } else if (component_name_obj != NULL) {
         GGL_LOGD("Client %d provided componentName.", handle);
 
@@ -257,11 +275,6 @@ static GglError handle_conn_init(
             component_name, &component_handle, &auth_token
         );
         if (ret != GGL_ERR_OK) {
-            GGL_LOGE(
-                "Client %d failed authentication: pid cannot be associated "
-                "with a component.",
-                handle
-            );
             return ret;
         }
     } else {

--- a/bins/ggipcd/src/ipc_server.c
+++ b/bins/ggipcd/src/ipc_server.c
@@ -104,79 +104,9 @@ static void set_conn_component(void *ctx, size_t index) {
     client_components[index] = *component_handle;
 }
 
-static GglError complete_conn_init(
-    uint32_t handle,
-    GglComponentHandle component_handle,
-    bool send_svcuid,
-    GglBuffer svcuid
+static GglError validate_conn_msg(
+    EventStreamMessage *msg, EventStreamCommonHeaders common_headers
 ) {
-    GGL_LOGT("Setting %d as connected.", handle);
-
-    GglError ret = ggl_socket_handle_protected(
-        set_conn_component, &component_handle, &pool, handle
-    );
-    if (ret != GGL_ERR_OK) {
-        return ret;
-    }
-
-    GGL_MTX_SCOPE_GUARD(&resp_array_mtx);
-    GglBuffer resp_buffer = GGL_BUF(resp_array);
-
-    ret = eventstream_encode(
-        &resp_buffer,
-        (EventStreamHeader[]) {
-            { GGL_STR(":message-type"),
-              { EVENTSTREAM_INT32, .int32 = EVENTSTREAM_CONNECT_ACK } },
-            { GGL_STR(":message-flags"),
-              { EVENTSTREAM_INT32, .int32 = EVENTSTREAM_CONNECTION_ACCEPTED } },
-            { GGL_STR(":stream-id"), { EVENTSTREAM_INT32, .int32 = 0 } },
-            { GGL_STR("svcuid"), { EVENTSTREAM_STRING, .string = svcuid } },
-        },
-        send_svcuid ? 4 : 3,
-        GGL_NULL_READER
-    );
-    if (ret != GGL_ERR_OK) {
-        return ret;
-    }
-
-    ret = ggl_socket_handle_write(&pool, handle, resp_buffer);
-    if (ret != GGL_ERR_OK) {
-        return ret;
-    }
-
-    GGL_LOGD("Successful connection.");
-    return GGL_ERR_OK;
-}
-
-static GglError handle_authentication_request(uint32_t handle) {
-    GGL_LOGD("Client %d requesting svcuid.", handle);
-
-    pid_t pid = 0;
-    GglError ret = ggl_socket_handle_get_peer_pid(&pool, handle, &pid);
-    if (ret != GGL_ERR_OK) {
-        return ret;
-    }
-
-    GglComponentHandle component_handle = 0;
-    uint8_t svcuid_buf[GGL_IPC_SVCUID_LEN];
-    GglBuffer svcuid = GGL_BUF(svcuid_buf);
-    ret = ggl_ipc_components_register(pid, &component_handle, &svcuid);
-    if (ret != GGL_ERR_OK) {
-        GGL_LOGE("Client %d failed authentication.", handle);
-        return ret;
-    }
-
-    return complete_conn_init(handle, component_handle, true, svcuid);
-}
-
-static GglError handle_conn_init(
-    uint32_t handle,
-    EventStreamMessage *msg,
-    EventStreamCommonHeaders common_headers,
-    GglAlloc *alloc
-) {
-    GGL_LOGD("Handling connect for %d.", handle);
-
     if (common_headers.message_type != EVENTSTREAM_CONNECT) {
         GGL_LOGE("Client initial message not of type connect.");
         return GGL_ERR_INVALID;
@@ -190,68 +120,148 @@ static GglError handle_conn_init(
         return GGL_ERR_INVALID;
     }
 
-    bool request_auth = false;
+    EventStreamHeaderIter iter = msg->headers;
+    EventStreamHeader header;
 
-    {
-        EventStreamHeaderIter iter = msg->headers;
-        EventStreamHeader header;
-
-        while (eventstream_header_next(&iter, &header) == GGL_ERR_OK) {
-            if (ggl_buffer_eq(header.name, GGL_STR(":version"))) {
-                if (header.value.type != EVENTSTREAM_STRING) {
-                    GGL_LOGE(":version header not string.");
-                    return GGL_ERR_INVALID;
-                }
-                if (!ggl_buffer_eq(header.value.string, GGL_STR("0.1.0"))) {
-                    GGL_LOGE("Client protocol version not 0.1.0.");
-                    return GGL_ERR_INVALID;
-                }
-            } else if (ggl_buffer_eq(header.name, GGL_STR("authenticate"))) {
-                if (header.value.type != EVENTSTREAM_INT32) {
-                    GGL_LOGE("request_svcuid header not an int.");
-                    return GGL_ERR_INVALID;
-                }
-                if (header.value.int32 == 1) {
-                    request_auth = true;
-                }
+    while (eventstream_header_next(&iter, &header) == GGL_ERR_OK) {
+        if (ggl_buffer_eq(header.name, GGL_STR(":version"))) {
+            if (header.value.type != EVENTSTREAM_STRING) {
+                GGL_LOGE(":version header not string.");
+                return GGL_ERR_INVALID;
+            }
+            if (!ggl_buffer_eq(header.value.string, GGL_STR("0.1.0"))) {
+                GGL_LOGE("Client protocol version not 0.1.0.");
+                return GGL_ERR_INVALID;
             }
         }
     }
 
-    if (request_auth) {
-        return handle_authentication_request(handle);
+    return GGL_ERR_OK;
+}
+
+static GglError send_conn_resp(uint32_t handle, GglBuffer *svcuid) {
+    GGL_MTX_SCOPE_GUARD(&resp_array_mtx);
+    GglBuffer resp_buffer = GGL_BUF(resp_array);
+
+    GglBuffer svcuid_buf = (svcuid != NULL) ? *svcuid : GGL_STR("");
+
+    GglError ret = eventstream_encode(
+        &resp_buffer,
+        (EventStreamHeader[]) {
+            { GGL_STR(":message-type"),
+              { EVENTSTREAM_INT32, .int32 = EVENTSTREAM_CONNECT_ACK } },
+            { GGL_STR(":message-flags"),
+              { EVENTSTREAM_INT32, .int32 = EVENTSTREAM_CONNECTION_ACCEPTED } },
+            { GGL_STR(":stream-id"), { EVENTSTREAM_INT32, .int32 = 0 } },
+            { GGL_STR("svcuid"), { EVENTSTREAM_STRING, .string = svcuid_buf } },
+
+        },
+        (svcuid != NULL) ? 4 : 3,
+        GGL_NULL_READER
+    );
+    if (ret != GGL_ERR_OK) {
+        return ret;
+    }
+
+    return ggl_socket_handle_write(&pool, handle, resp_buffer);
+}
+
+static GglError handle_conn_init(
+    uint32_t handle,
+    EventStreamMessage *msg,
+    EventStreamCommonHeaders common_headers,
+    GglAlloc *alloc
+) {
+    GGL_LOGD("Handling connect for %d.", handle);
+
+    GglError ret = validate_conn_msg(msg, common_headers);
+    if (ret != GGL_ERR_OK) {
+        return ret;
     }
 
     GglMap payload_data = { 0 };
-    GglError ret = deserialize_payload(msg->payload, &payload_data, alloc);
+    ret = deserialize_payload(msg->payload, &payload_data, alloc);
     if (ret != GGL_ERR_OK) {
+        GGL_LOGE("Connect payload is not valid json.");
         return ret;
     }
 
-    GglObject *value;
-    bool found = ggl_map_get(payload_data, GGL_STR("authToken"), &value);
-    if (!found) {
-        GGL_LOGE("Connect message payload missing authToken.");
-        return GGL_ERR_INVALID;
-    }
-    if (value->type != GGL_TYPE_BUF) {
-        GGL_LOGE("Connect message authToken not a string.");
-        return GGL_ERR_INVALID;
-    }
-    GglBuffer auth_token = value->buf;
-
-    GGL_LOGD("Client connecting.");
-
-    GglComponentHandle component_handle = 0;
-    ret = ggl_ipc_components_get_handle(auth_token, &component_handle);
-    if (ret != GGL_ERR_OK) {
-        GGL_LOGE("Client failed authentication.");
-        return ret;
-    }
-
-    return complete_conn_init(
-        handle, component_handle, false, (GglBuffer) { 0 }
+    GglObject *auth_token_obj;
+    GglObject *component_name_obj;
+    ret = ggl_map_validate(
+        payload_data,
+        GGL_MAP_SCHEMA(
+            { GGL_STR("authToken"), false, GGL_TYPE_BUF, &auth_token_obj },
+            { GGL_STR("componentName"),
+              false,
+              GGL_TYPE_BUF,
+              &component_name_obj },
+        )
     );
+    if (ret != GGL_ERR_OK) {
+        GGL_LOGE("Connect payload key has unexpected non-string value.");
+        return GGL_ERR_INVALID;
+    }
+
+    uint8_t svcuid_buf[GGL_IPC_SVCUID_LEN];
+    GglBuffer auth_token;
+    GglComponentHandle component_handle = 0;
+
+    if (auth_token_obj != NULL) {
+        GGL_LOGD("Client %d provided authToken.", handle);
+
+        auth_token = auth_token_obj->buf;
+
+        ret = ggl_ipc_components_get_handle(auth_token, &component_handle);
+        if (ret != GGL_ERR_OK) {
+            GGL_LOGE(
+                "Client %d failed authentication: invalid svcuid.", handle
+            );
+            return ret;
+        }
+    } else if (component_name_obj != NULL) {
+        GGL_LOGD("Client %d provided componentName.", handle);
+
+        pid_t pid = 0;
+        ret = ggl_socket_handle_get_peer_pid(&pool, handle, &pid);
+        if (ret != GGL_ERR_OK) {
+            GGL_LOGE("Failed to get pid of client %d.", handle);
+            return ret;
+        }
+
+        auth_token = GGL_BUF(svcuid_buf);
+        ret = ggl_ipc_components_register(pid, &component_handle, &auth_token);
+        if (ret != GGL_ERR_OK) {
+            GGL_LOGE(
+                "Client %d failed authentication: pid cannot be associated "
+                "with a component.",
+                handle
+            );
+            return ret;
+        }
+    } else {
+        GGL_LOGE(
+            "Client %d did not provide authToken or componentName.", handle
+        );
+        return GGL_ERR_INVALID;
+    }
+
+    GGL_LOGT("Setting %d as connected.", handle);
+
+    ret = ggl_socket_handle_protected(
+        set_conn_component, &component_handle, &pool, handle
+    );
+    if (ret != GGL_ERR_OK) {
+        return ret;
+    }
+
+    ret = send_conn_resp(handle, (auth_token_obj == NULL) ? &auth_token : NULL);
+    if (ret != GGL_ERR_OK) {
+        return ret;
+    }
+
+    GGL_LOGD("Successful connection.");
+    return GGL_ERR_OK;
 }
 
 static GglError send_stream_error(

--- a/bins/ggipcd/src/ipc_server.c
+++ b/bins/ggipcd/src/ipc_server.c
@@ -14,7 +14,6 @@
 #include <ggl/buffer.h>
 #include <ggl/bump_alloc.h>
 #include <ggl/cleanup.h>
-#include <ggl/constants.h>
 #include <ggl/error.h>
 #include <ggl/eventstream/decode.h>
 #include <ggl/eventstream/encode.h>
@@ -251,23 +250,15 @@ static GglError handle_conn_init(
             return ret;
         }
 
-        uint8_t component_name_buf[MAX_COMPONENT_NAME_LENGTH];
-        GglBumpAlloc balloc = ggl_bump_alloc_init(GGL_BUF(component_name_buf));
-
-        GglBuffer validated_name;
-        ret = ggl_ipc_auth_lookup_name(pid, &balloc.alloc, &validated_name);
+        ret = ggl_ipc_auth_validate_name(pid, component_name);
         if (ret != GGL_ERR_OK) {
-            return ret;
-        }
-
-        if (!ggl_buffer_eq(component_name, validated_name)) {
             GGL_LOGE(
                 "Client %d failed to authenticate as %.*s.",
                 handle,
                 (int) component_name.len,
                 component_name.data
             );
-            return GGL_ERR_FAILURE;
+            return ret;
         }
 
         auth_token = GGL_BUF(svcuid_buf);

--- a/bins/ggipcd/src/services/authorizationagent/token_validator.c
+++ b/bins/ggipcd/src/services/authorizationagent/token_validator.c
@@ -14,6 +14,7 @@
 #include <ggl/log.h>
 #include <ggl/map.h>
 #include <ggl/object.h>
+#include <stddef.h>
 #include <stdint.h>
 
 GglError ggl_handle_token_validation(
@@ -58,7 +59,7 @@ GglError ggl_handle_token_validation(
         return GGL_ERR_INVALID;
     }
 
-    if (ipc_svcuid_exists(svcuid_obj->buf) != GGL_ERR_OK) {
+    if (ggl_ipc_components_get_handle(svcuid_obj->buf, NULL) != GGL_ERR_OK) {
         *ipc_error = (GglIpcError
         ) { .error_code = GGL_IPC_ERR_INVALID_TOKEN_ERROR,
             .message = GGL_STR(

--- a/bins/recipe-runner/src/runner.c
+++ b/bins/recipe-runner/src/runner.c
@@ -533,13 +533,15 @@ GglError runner(const RecipeRunnerArgs *args) {
 
     static uint8_t resp_mem[PATH_MAX];
 
+    GglBuffer component_name = ggl_buffer_from_null_term(args->component_name);
+
     // Fetch the SVCUID
     GglBuffer resp = GGL_BUF(resp_mem);
     resp.len = GGL_IPC_MAX_SVCUID_LEN;
 
     int conn = -1;
-    GglError ret = ggipc_connect_auth(
-        ggl_buffer_from_null_term(socket_path), &resp, &conn
+    GglError ret = ggipc_connect_by_name(
+        ggl_buffer_from_null_term(socket_path), component_name, &resp, &conn
     );
     if (ret != GGL_ERR_OK) {
         GGL_LOGE("Runner failed to authenticate with nucleus.");
@@ -687,7 +689,6 @@ GglError runner(const RecipeRunnerArgs *args) {
         GGL_LOGE("Failed to open rootPath.");
         return ret;
     }
-    GglBuffer component_name = ggl_buffer_from_null_term(args->component_name);
     GglBuffer component_version
         = ggl_buffer_from_null_term(args->component_version);
 

--- a/bins/recipe-runner/src/runner.c
+++ b/bins/recipe-runner/src/runner.c
@@ -537,7 +537,7 @@ GglError runner(const RecipeRunnerArgs *args) {
 
     // Fetch the SVCUID
     GglBuffer resp = GGL_BUF(resp_mem);
-    resp.len = GGL_IPC_MAX_SVCUID_LEN;
+    resp.len = GGL_IPC_SVCUID_LEN;
 
     int conn = -1;
     GglError ret = ggipc_connect_by_name(

--- a/modules/ggipc-auth/include/ggipc/auth.h
+++ b/modules/ggipc-auth/include/ggipc/auth.h
@@ -11,13 +11,11 @@
 //! SVCUID tokens, and a means for components to obtain SVCUID tokens.
 
 #include <sys/types.h>
-#include <ggl/alloc.h>
 #include <ggl/buffer.h>
 #include <ggl/error.h>
 
-/// Authenticate a client and get its component name.
-GglError ggl_ipc_auth_lookup_name(
-    pid_t pid, GglAlloc *alloc, GglBuffer *component_name
-);
+/// Authenticate a client by checking if its pid is associated with its claimed
+/// component name.
+GglError ggl_ipc_auth_validate_name(pid_t pid, GglBuffer component_name);
 
 #endif

--- a/modules/ggipc-auth/src/auth.c
+++ b/modules/ggipc-auth/src/auth.c
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ggipc/auth.h"
-#include <ggl/alloc.h>
 #include <ggl/buffer.h>
 #include <ggl/cleanup.h>
 #include <ggl/error.h>
@@ -11,17 +10,14 @@
 #include <ggl/object.h>
 #include <string.h>
 #include <systemd/sd-login.h>
-#include <stdint.h>
 
-GglError ggl_ipc_auth_lookup_name(
-    pid_t pid, GglAlloc *alloc, GglBuffer *component_name
-) {
+GglError ggl_ipc_auth_validate_name(pid_t pid, GglBuffer component_name) {
     char *unit_name = NULL;
     int error = sd_pid_get_unit(pid, &unit_name);
     GGL_CLEANUP(cleanup_free, unit_name);
     if ((error < 0) || (unit_name == NULL)) {
         GGL_LOGE("Failed to look up service for pid %d.", pid);
-        return GGL_ERR_NOENTRY;
+        return GGL_ERR_FAILURE;
     }
 
     GglBuffer name = ggl_buffer_from_null_term(unit_name);
@@ -30,7 +26,7 @@ GglError ggl_ipc_auth_lookup_name(
         GGL_LOGE(
             "Service for pid %d (%s) missing service extension.", pid, unit_name
         );
-        return GGL_ERR_NOENTRY;
+        return GGL_ERR_FAILURE;
     }
 
     (void) (ggl_buffer_remove_suffix(&name, GGL_STR(".install"))
@@ -42,17 +38,19 @@ GglError ggl_ipc_auth_lookup_name(
             pid,
             unit_name
         );
-        return GGL_ERR_NOENTRY;
+        return GGL_ERR_FAILURE;
     }
 
-    uint8_t *component_name_buf = GGL_ALLOCN(alloc, uint8_t, name.len);
-    if (component_name_buf == NULL) {
-        GGL_LOGE("Component name %.*s is too long.", (int) name.len, name.data);
-        return GGL_ERR_NOMEM;
+    if (!ggl_buffer_eq(name, component_name)) {
+        GGL_LOGE(
+            "Client claims to be %.*s, found to be %.*s instead.",
+            (int) component_name.len,
+            component_name.data,
+            (int) name.len,
+            name.data
+        );
+        return GGL_ERR_FAILURE;
     }
 
-    memcpy(component_name_buf, name.data, name.len);
-    *component_name
-        = (GglBuffer) { .data = component_name_buf, .len = name.len };
     return GGL_ERR_OK;
 }

--- a/modules/ggipc-client/include/ggipc/client.h
+++ b/modules/ggipc-client/include/ggipc/client.h
@@ -19,8 +19,12 @@
 #define GGL_IPC_MAX_SVCUID_LEN (128)
 #endif
 
-/// Connect to GG-IPC server, requesting an authentication token
-GglError ggipc_connect_auth(GglBuffer socket_path, GglBuffer *svcuid, int *fd);
+/// Connect to GG-IPC server using component name.
+/// If svcuid is non-null, it will be filled with the component's identity
+/// token.
+GglError ggipc_connect_by_name(
+    GglBuffer socket_path, GglBuffer component_name, GglBuffer *svcuid, int *fd
+);
 
 GglError ggipc_call(
     int conn,

--- a/modules/ggipc-client/include/ggipc/client.h
+++ b/modules/ggipc-client/include/ggipc/client.h
@@ -12,12 +12,7 @@
 #include <ggl/object.h>
 #include <stdint.h>
 
-#ifndef GGL_IPC_AUTH_DISABLE
-#define GGL_IPC_MAX_SVCUID_LEN (16)
-#else
-// Max component name length
-#define GGL_IPC_MAX_SVCUID_LEN (128)
-#endif
+#define GGL_IPC_SVCUID_LEN (16)
 
 /// Connect to GG-IPC server using component name.
 /// If svcuid is non-null, it will be filled with the component's identity

--- a/modules/ggipc-client/src/client.c
+++ b/modules/ggipc-client/src/client.c
@@ -113,7 +113,9 @@ static GglError get_message(
     return GGL_ERR_OK;
 }
 
-GglError ggipc_connect_auth(GglBuffer socket_path, GglBuffer *svcuid, int *fd) {
+GglError ggipc_connect_by_name(
+    GglBuffer socket_path, GglBuffer component_name, GglBuffer *svcuid, int *fd
+) {
     int conn = -1;
     GglError ret = ggl_connect(socket_path, &conn);
     if (ret != GGL_ERR_OK) {
@@ -126,13 +128,15 @@ GglError ggipc_connect_auth(GglBuffer socket_path, GglBuffer *svcuid, int *fd) {
           { EVENTSTREAM_INT32, .int32 = EVENTSTREAM_CONNECT } },
         { GGL_STR(":message-flags"), { EVENTSTREAM_INT32, .int32 = 0 } },
         { GGL_STR(":stream-id"), { EVENTSTREAM_INT32, .int32 = 0 } },
-        { GGL_STR("authenticate"), { EVENTSTREAM_INT32, .int32 = 1 } },
         { GGL_STR(":version"),
           { EVENTSTREAM_STRING, .string = GGL_STR("0.1.0") } },
     };
     size_t headers_len = sizeof(headers) / sizeof(headers[0]);
 
-    ret = send_message(conn, headers, headers_len, NULL);
+    GglMap payload
+        = GGL_MAP({ GGL_STR("componentName"), GGL_OBJ_BUF(component_name) });
+
+    ret = send_message(conn, headers, headers_len, &payload);
     if (ret != GGL_ERR_OK) {
         return ret;
     }

--- a/modules/ggl-constants/include/ggl/constants.h
+++ b/modules/ggl-constants/include/ggl/constants.h
@@ -24,4 +24,7 @@
 // TODO: Should be at least as big as MAX_COMPONENTS, add static assert?
 #define MAX_CONFIG_CHILDREN_PER_OBJECT 64
 
+/// Maximum length of generic component name.
+#define MAX_COMPONENT_NAME_LENGTH (128)
+
 #endif

--- a/modules/ggl-lib/include/ggl/buffer.h
+++ b/modules/ggl-lib/include/ggl/buffer.h
@@ -41,8 +41,14 @@ bool ggl_buffer_eq(GglBuffer buf1, GglBuffer buf2);
 /// Returns whether the buffer has the given prefix.
 bool ggl_buffer_has_prefix(GglBuffer buf, GglBuffer prefix);
 
+/// Removes a prefix. Returns whether the prefix was removed.
+bool ggl_buffer_remove_prefix(GglBuffer *buf, GglBuffer prefix);
+
 /// Returns whether the buffer has the given suffix.
 bool ggl_buffer_has_suffix(GglBuffer buf, GglBuffer suffix);
+
+/// Removes a suffix. Returns whether the suffix was removed.
+bool ggl_buffer_remove_suffix(GglBuffer *buf, GglBuffer suffix);
 
 /// Returns whether the buffer contains the given substring.
 /// Outputs start and end index.

--- a/modules/ggl-lib/src/buffer.c
+++ b/modules/ggl-lib/src/buffer.c
@@ -29,10 +29,26 @@ bool ggl_buffer_has_prefix(GglBuffer buf, GglBuffer prefix) {
     return false;
 }
 
+bool ggl_buffer_remove_prefix(GglBuffer *buf, GglBuffer prefix) {
+    if (ggl_buffer_has_prefix(*buf, prefix)) {
+        *buf = ggl_buffer_substr(*buf, prefix.len, SIZE_MAX);
+        return true;
+    }
+    return false;
+}
+
 bool ggl_buffer_has_suffix(GglBuffer buf, GglBuffer suffix) {
     if (suffix.len <= buf.len) {
         return memcmp(&buf.data[buf.len - suffix.len], suffix.data, suffix.len)
             == 0;
+    }
+    return false;
+}
+
+bool ggl_buffer_remove_suffix(GglBuffer *buf, GglBuffer suffix) {
+    if (ggl_buffer_has_suffix(*buf, suffix)) {
+        *buf = ggl_buffer_substr(*buf, 0, buf->len - suffix.len);
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
Cleans up the authentication code, as well as modifying how SVCUID-less authentication works. Now it sends the component name in the payload, which is verified during authentication. 

See individual commits.