### PR TITLE
CMake, libcurl: Lower version requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ endforeach()
 find_package(PkgConfig REQUIRED)
 
 pkg_search_module(openssl REQUIRED IMPORTED_TARGET openssl)
-pkg_search_module(libcurl REQUIRED IMPORTED_TARGET libcurl)
+pkg_search_module(libcurl REQUIRED IMPORTED_TARGET libcurl>=7.82)
 pkg_search_module(sqlite3 REQUIRED IMPORTED_TARGET sqlite3)
 pkg_search_module(yaml REQUIRED IMPORTED_TARGET yaml-0.1)
 pkg_search_module(libsystemd REQUIRED IMPORTED_TARGET libsystemd)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.22)
 project(aws-greengrass-lite C ASM)
 
 #
@@ -253,7 +253,7 @@ endforeach()
 find_package(PkgConfig REQUIRED)
 
 pkg_search_module(openssl REQUIRED IMPORTED_TARGET openssl)
-pkg_search_module(libcurl REQUIRED IMPORTED_TARGET libcurl>=7.86)
+pkg_search_module(libcurl REQUIRED IMPORTED_TARGET libcurl)
 pkg_search_module(sqlite3 REQUIRED IMPORTED_TARGET sqlite3)
 pkg_search_module(yaml REQUIRED IMPORTED_TARGET yaml-0.1)
 pkg_search_module(libsystemd REQUIRED IMPORTED_TARGET libsystemd)

--- a/modules/ggl-sdk/CMakeLists.txt
+++ b/modules/ggl-sdk/CMakeLists.txt
@@ -4,9 +4,7 @@
 
 ggl_init_module(ggl-sdk INCDIRS include priv_include)
 
-block()
 string(TOUPPER "${GGL_LOG_LEVEL}" level)
 set(default "$<IF:$<CONFIG:Debug>,DEBUG,WARN>")
 set(choose_level "$<IF:$<BOOL:${level}>,${level},${default}>")
 target_compile_definitions(ggl-sdk PUBLIC GGL_LOG_LEVEL=GGL_LOG_${choose_level})
-endblock()


### PR DESCRIPTION
As sig4 signing is now not done with libcurl anymore this requirement can be removed. Also CMake version is set to 3.22, which is the version that is provided by kirkstone yocto lts version.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
