### PR TITLE
Fix failure of components with config substitution

### DIFF
--- a/misc/iwyu_mappings.yml
+++ b/misc/iwyu_mappings.yml
@@ -7,6 +7,7 @@
 - symbol: ["PATH_MAX", "private", "<limits.h>", "public"]
 - symbol: ["PROT_READ", "private", "<sys/mman.h>", "public"]
 - symbol: ["PROT_WRITE", "private", "<sys/mman.h>", "public"]
+- symbol: ["memfd_create", "private", "<sys/mman.h>", "public"]
 - symbol: ["P_PID", "private", "<sys/wait.h>", "public"]
 - symbol: ["SOCK_CLOEXEC", "private", "<sys/socket.h>", "public"]
 - symbol: ["SOCK_STREAM", "private", "<sys/socket.h>", "public"]


### PR DESCRIPTION
Handling of config substitution was being handled in the child after fork, with the parent execing bash. This meant that the IPC receive thread was not running.

Swapping the parent and child does not work since systemd treats the first process specially (I was also having some issue with python exiting when recipe runner called waitid). Instead I removed the fork entirely. To minimize this change, a memfd is used to replace stdin of the shell, so exiting script building code works. 