### PR TITLE
Enable to run UAT for each PR

### DIFF
--- a/.github/workflows/uat-pytest.yml
+++ b/.github/workflows/uat-pytest.yml
@@ -6,13 +6,13 @@ on:
 
 env:
   AWS_REGION: "us-west-2"
-  AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT_ID }}
-  S3_BUCKET: ${{ secrets.S3_BUCKET }}
+  # AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT_ID }}
+  # S3_BUCKET: ${{ secrets.S3_BUCKET }}
   COMMIT_ID: "25ca698f878ee481a8a2ade0d54499992f339122" #TODO: replace to be ${{ github.event.pull_request.head.sha }}
-  AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }} #TODO: need to set another role
+  # AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }} #TODO: need to set another role
 
 jobs:
-  test:
+  uat-test:
     permissions:
       id-token: write
 
@@ -24,7 +24,7 @@ jobs:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
 
       # Checkout the public testing repo

--- a/.github/workflows/uat-pytest.yml
+++ b/.github/workflows/uat-pytest.yml
@@ -1,0 +1,48 @@
+name: UAT Pytest
+
+on:
+  pull_request:
+    branches: "*"
+
+env:
+  AWS_ACCOUNT: "891377305071"
+  AWS_REGION: "us-west-2"
+  S3_BUCKET: "lite-dev-uat-bucket"
+  COMMIT_ID: "25ca698f878ee481a8a2ade0d54499992f339122" #TODO: replace to be ${{ github.event.pull_request.head.sha }}
+  AWS_ROLE_TO_ASSUME: "arn:aws:iam::891377305071:role/Admin" #TODO: need to set another role
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # Checkout the public testing repo
+      - name: Checkout testing repository
+        uses: actions/checkout@v4
+        with:
+          repository: aws-greengrass/aws-greengrass-testing
+          ref: python_testing
+          path: aws-greengrass-testing
+
+      - name: Run UAT tests
+        run: |
+          cd aws-greengrass-testing
+          echo "Environment Variables:"
+          echo "AWS_ACCOUNT: ${{ env.AWS_ACCOUNT }}"
+          echo "AWS_REGION: ${{ env.AWS_REGION }}"
+          echo "S3_BUCKET: ${{ env.S3_BUCKET }}"
+          echo "COMMIT_ID: ${{ env.COMMIT_ID }}"
+
+        # ./run-tests.sh \
+        #   --aws-account= ${{ env.AWS_ACCOUNT }}\
+        #   --s3-bucket=${{ env.S3_BUCKET}} \
+        #   --commit-id=${{ env.COMMIT_ID }} \
+        #   --aws-region=${{ env.AWS_REGION }}

--- a/.github/workflows/uat-pytest.yml
+++ b/.github/workflows/uat-pytest.yml
@@ -6,26 +6,30 @@ on:
 
 env:
   AWS_REGION: "us-west-2"
-  # AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT_ID }}
-  # S3_BUCKET: ${{ secrets.S3_BUCKET }}
   COMMIT_ID: "25ca698f878ee481a8a2ade0d54499992f339122" #TODO: replace to be ${{ github.event.pull_request.head.sha }}
-  # AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }} #TODO: need to set another role
 
 jobs:
   uat-test:
     permissions:
       id-token: write
+      contents: read
 
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: configure aws credentials
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '>=3.12'
 
       # Checkout the public testing repo
       - name: Checkout testing repository

--- a/.github/workflows/uat-pytest.yml
+++ b/.github/workflows/uat-pytest.yml
@@ -5,14 +5,17 @@ on:
     branches: "*"
 
 env:
-  AWS_ACCOUNT: "891377305071"
   AWS_REGION: "us-west-2"
-  S3_BUCKET: "lite-dev-uat-bucket"
+  AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT_ID }}
+  S3_BUCKET: ${{ secrets.S3_BUCKET }}
   COMMIT_ID: "25ca698f878ee481a8a2ade0d54499992f339122" #TODO: replace to be ${{ github.event.pull_request.head.sha }}
-  AWS_ROLE_TO_ASSUME: "arn:aws:iam::891377305071:role/Admin" #TODO: need to set another role
+  AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }} #TODO: need to set another role
 
 jobs:
   test:
+    permissions:
+      id-token: write
+
     runs-on: ubuntu-24.04
 
     steps:
@@ -36,9 +39,6 @@ jobs:
         run: |
           cd aws-greengrass-testing
           echo "Environment Variables:"
-          echo "AWS_ACCOUNT: ${{ env.AWS_ACCOUNT }}"
-          echo "AWS_REGION: ${{ env.AWS_REGION }}"
-          echo "S3_BUCKET: ${{ env.S3_BUCKET }}"
           echo "COMMIT_ID: ${{ env.COMMIT_ID }}"
 
         # ./run-tests.sh \


### PR DESCRIPTION
The workflow's purpose is to automatically run UAT tests whenever a pr is created. These tests are defined in another aws-greengrass-testing repo (python_testing branch).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
