### PR TITLE
Fix: double the http response size to accommodate the headers array

### DIFF
--- a/modules/tes-serverd/src/http_server.c
+++ b/modules/tes-serverd/src/http_server.c
@@ -140,11 +140,11 @@ static void request_handler(struct evhttp_request *req, void *arg) {
         return;
     }
 
-    static uint8_t alloc_mem[4096];
+    static uint8_t alloc_mem[8192];
     GglArena alloc = ggl_arena_init(GGL_BUF(alloc_mem));
     GglObject tes_formatted_obj = fetch_creds(&alloc);
 
-    static uint8_t response_cred_mem[4096];
+    static uint8_t response_cred_mem[8192];
     GglByteVec response_cred_buffer = GGL_BYTE_VEC(response_cred_mem);
 
     GglError ret_err_json = ggl_json_encode(

--- a/modules/tesd/src/token_service.c
+++ b/modules/tesd/src/token_service.c
@@ -18,7 +18,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define MAX_HTTP_RESPONSE_LENGTH 4096
+#define MAX_HTTP_RESPONSE_LENGTH 8192
 #define MAX_HTTP_RESPONSE_SUB_OBJECTS 10
 
 typedef struct {


### PR DESCRIPTION
*Issue #, if available: In ggl-http.c, we had an error: The array 'arr' is not big enough to accommodate the headers. After one UAT testing, it seems we could resolve it by resizing http response size.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
