### PR TITLE
Add UAT workflow to run tests in PR

### DIFF
--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -1,0 +1,49 @@
+name: UAT Pytests
+
+on:
+  pull_request:
+    branches: "*"
+
+env:
+  AWS_REGION: "us-west-2"
+  COMMIT_ID: ${{ github.event.pull_request.head.sha }}
+
+jobs:
+  uat-test:
+    permissions:
+      id-token: write
+      contents: read
+
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          audience: sts.amazonaws.com
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ">=3.12"
+
+      - name: Checkout testing repository
+        uses: actions/checkout@v4
+        with:
+          repository: aws-greengrass/aws-greengrass-testing
+          ref: python_testing
+          path: aws-greengrass-testing
+
+      - name: Run UAT tests
+        run: |
+          cd aws-greengrass-testing
+          ./run-tests.sh \
+            --aws-account=${{ secrets.AWS_ACCOUNT_ID }}\
+            --s3-bucket=${{ secrets.S3_BUCKET }} \
+            --commit-id=${{ env.COMMIT_ID }} \
+            --aws-region=${{ env.AWS_REGION }}


### PR DESCRIPTION
The workflow's purpose is to automatically run UAT tests whenever a pr is created. These tests are defined in another aws-greengrass-testing repo (python_testing branch).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.