### PR TITLE
Add reset-failed after device is provisioned

### DIFF
--- a/modules/fleet-provisioning/src/entry.c
+++ b/modules/fleet-provisioning/src/entry.c
@@ -273,7 +273,12 @@ static GglError cleanup_actions(void) {
         GGL_LOGE("Failed to stop greengrass service");
         return ret;
     }
-
+    const char *args_reset[] = { "systemctl", "reset-failed ", NULL };
+    ret = ggl_exec_command(args_reset);
+    if (ret != GGL_ERR_OK) {
+        GGL_LOGE("Failed to reset services run counter");
+        return ret;
+    }
     const char *args_start[]
         = { "systemctl", "start", "greengrass-lite.target", NULL };
     ret = ggl_exec_command(args_start);


### PR DESCRIPTION
This ensures that any services that failed previously will attempt to start again.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
