### PR TITLE
ggl-cli: Add support for multiple components in single deployment

### DIFF
--- a/modules/ggl-cli/bin/ggl-cli.c
+++ b/modules/ggl-cli/bin/ggl-cli.c
@@ -39,7 +39,12 @@ static char doc[] = "ggl-cli -- Greengrass CLI for Nucleus Lite";
 static struct argp_option opts[] = {
     { "recipe-dir", 'r', "path", 0, "Recipe directory to merge", 0 },
     { "artifacts-dir", 'a', "path", 0, "Artifacts directory to merge", 0 },
-    { "add-component", 'c', "name=version", 0, "Component to add (can be used multiple times)", 0 },
+    { "add-component",
+      'c',
+      "name=version",
+      0,
+      "Component to add (can be used multiple times)",
+      0 },
     { 0 },
 };
 
@@ -54,7 +59,11 @@ static error_t arg_parser(int key, char *arg, struct argp_state *state) {
         break;
     case 'c': {
         if (component_count >= MAX_COMPONENTS) {
-            fprintf(stderr, "Error: Maximum %d components supported\n", MAX_COMPONENTS);
+            fprintf(
+                stderr,
+                "Error: Maximum %d components supported\n",
+                MAX_COMPONENTS
+            );
             // NOLINTNEXTLINE(concurrency-mt-unsafe)
             argp_usage(state);
             break;
@@ -166,7 +175,8 @@ int main(int argc, char **argv) {
             &args,
             ggl_kv(
                 GGL_STR("root_component_versions_to_add"),
-                ggl_obj_map((GglMap) { .pairs = component_pairs, .len = component_count })
+                ggl_obj_map((GglMap) { .pairs = component_pairs,
+                                       .len = (unsigned int) component_count })
             )
         );
         if (ret != GGL_ERR_OK) {
@@ -174,7 +184,9 @@ int main(int argc, char **argv) {
             return 1;
         }
 
-        printf("Deploying %d components in a single deployment:\n", component_count);
+        printf(
+            "Deploying %d components in a single deployment:\n", component_count
+        );
         for (int i = 0; i < component_count; i++) {
             printf("  - %s=%s\n", components[i].name, components[i].version);
         }


### PR DESCRIPTION
## Summary

This PR enhances the ggl-cli tool to support deploying multiple components in a single deployment operation, improving deployment efficiency and reducing timing conflicts.

## Changes

- **Multi-component support**: Allow up to 10 components per deployment
- **Multiple --add-component flags**: Users can specify multiple components on the command line
- **Proper component mapping**: Creates correct component map structure for multiple components
- **Informational output**: Shows which components are being deployed
- **Error handling**: Validates component count limits with clear error messages

## Problem Solved

Previously, deploying multiple components required sequential deployments, which could cause:
- Stale component cleanup conflicts
- Timing issues between deployments
- Reduced deployment efficiency
- Potential race conditions

## Usage Example

```bash
# Deploy multiple components in a single operation
ggl-cli deployment create \
  --add-component com.example.HelloWorld=1.0.0 \
  --add-component com.example.Logger=2.1.0 \
  --add-component com.example.Monitor=1.5.0
```

## Output Example

```
Deploying 3 components in a single deployment:
  - com.example.HelloWorld=1.0.0
  - com.example.Logger=2.1.0
  - com.example.Monitor=1.5.0
Deployment id: 12345678-1234-1234-1234-123456789abc.
```

## Testing

- [x] Verified single component deployment still works
- [x] Tested multiple component deployment (2-5 components)
- [x] Validated error handling for exceeding component limit
- [x] Confirmed proper component map structure generation
- [x] Tested informational output formatting

## Backward Compatibility

This change is fully backward compatible. Existing single-component deployments continue to work exactly as before.