### PR TITLE
Add Nix output for enumerating paths to cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   description = "AWS IoT Greengrass runtime for constrained devices.";
   inputs.flakelight.url = "github:nix-community/flakelight";
   outputs = { flakelight, ... }@inputs: flakelight ./. ({ lib, ... }: {
-    systems = lib.systems.flakeExposed;
+    systems = [ "x86_64-linux" "aarch64-linux" ];
     inherit inputs;
     pname = "ggl";
   });

--- a/nix/legacyPackages.nix
+++ b/nix/legacyPackages.nix
@@ -1,0 +1,27 @@
+pkgs: {
+  _type = "pkgs";
+  cached-paths = pkgs.stdenv.mkDerivation {
+    name = "cached-paths";
+    exportReferencesGraph =
+      let
+        getAttrSet = name: pkgs.lib.mapAttrs'
+          (n: pkgs.lib.nameValuePair ("${name}-" + n))
+          pkgs.outputs'.${name};
+        cached-outputs = pkgs.linkFarm "cached-outputs" (
+          (getAttrSet "packages") //
+          (getAttrSet "devShells") //
+          (getAttrSet "checks") //
+          { "formatter" = pkgs.outputs'.formatter; }
+        );
+      in
+      [ "cache-paths" cached-outputs.drvPath ];
+    buildPhase =
+      "grep '^/nix/store/' < cache-paths | sort | uniq > $out";
+    dontUnpack = true;
+    dontPatch = true;
+    dontConfigure = true;
+    dontInstall = true;
+    dontFixup = true;
+    allowSubstitutes = false;
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -16,7 +16,6 @@
 , libzip
 , dbus
 , systemdLibs
-, defaultMeta
 }:
 stdenv.mkDerivation {
   name = "aws-greengrass-lite";
@@ -36,5 +35,4 @@ stdenv.mkDerivation {
   ] ++ lib.optional (!stdenv.hostPlatform.isGnu) argp-standalone;
   cmakeBuildType = "MinSizeRel";
   cmakeFlags = gglUtil.fetchContentFlags ++ [ "-DENABLE_WERROR=1" ];
-  meta = defaultMeta;
 }


### PR DESCRIPTION
This output produces a file of paths used when updating the Nix flake cache.