### PR TITLE
Enable the kTLS in iotcored

### DIFF
--- a/misc/dictionary.txt
+++ b/misc/dictionary.txt
@@ -70,6 +70,7 @@ iotcoredfleet
 iwyu
 journalctl
 keyid
+ktls
 libcgroup
 libsystemd
 liburiparser
@@ -105,6 +106,7 @@ ptid
 PTRACE
 Pypi
 pyproject
+rbio
 Renesas
 respfd
 rlimits
@@ -134,6 +136,7 @@ unsuback
 uriparser
 uuid
 venv
+wbio
 WERROR
 xeau
 Xiwyu

--- a/modules/iotcored/src/tls.c
+++ b/modules/iotcored/src/tls.c
@@ -16,6 +16,7 @@
 #include <openssl/err.h>
 #include <openssl/http.h>
 #include <openssl/opensslv.h>
+#include <openssl/prov_ssl.h>
 #include <openssl/ssl.h>
 #include <openssl/types.h>
 #include <openssl/x509.h>
@@ -23,6 +24,7 @@
 #include <sys/utsname.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 // RFC 1035 specifies 255 max octets.
 // 2 octets are reserved for length and trailing dot which are not encoded here
@@ -130,7 +132,8 @@ static bool is_ktls_supported(void) {
     }
 
     // Kernel version should be 5.9+ for Rx offload
-    int major, minor;
+    int major;
+    int minor;
     if (sscanf(kernel_info.release, "%d.%d", &major, &minor) != 2) {
         GGL_LOGE("Failed to parse kernel version.");
         return false;

--- a/modules/iotcored/src/tls.c
+++ b/modules/iotcored/src/tls.c
@@ -15,10 +15,12 @@
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/http.h>
+#include <openssl/opensslv.h>
 #include <openssl/ssl.h>
 #include <openssl/types.h>
 #include <openssl/x509.h>
 #include <string.h>
+#include <sys/utsname.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -35,6 +37,8 @@ struct IotcoredTlsCtx {
     BIO *bio;
     bool connected;
 };
+
+struct utsname kernel_info;
 
 IotcoredTlsCtx conn;
 
@@ -118,6 +122,79 @@ static GglError proxy_get_info(
     return GGL_ERR_OK;
 }
 
+static bool is_ktls_supported(void) {
+    // Get Kernel Version
+    if (uname(&kernel_info) != 0) {
+        GGL_LOGE("Failed to get kernel version.");
+        return false;
+    }
+
+    // Kernel version should be 5.9+ for Rx offload
+    int major, minor;
+    if (sscanf(kernel_info.release, "%d.%d", &major, &minor) != 2) {
+        GGL_LOGE("Failed to parse kernel version.");
+        return false;
+    }
+
+    if (major < 5 || (major == 5 && minor < 9)) {
+        GGL_LOGD("kTLS is not supported on this kernel version.");
+        return false;
+    }
+
+    // Check if openSSL is 3.0.0 or higher
+    if (OPENSSL_VERSION_NUMBER < 0x30000000L) {
+        GGL_LOGD("kTLS is not supported on this openssl version.");
+        return false;
+    }
+
+    return true;
+}
+
+static GglError check_ktls_status(SSL *ssl) {
+    BIO *wbio = SSL_get_wbio(ssl);
+    BIO *rbio = SSL_get_rbio(ssl);
+
+    int tx_status = BIO_get_ktls_send(wbio);
+    int rx_status = BIO_get_ktls_recv(rbio);
+
+    GGL_LOGD("kTLS TX status: %d, RX status: %d", tx_status, rx_status);
+
+    if (BIO_get_ktls_send(wbio) < 1) {
+        GGL_LOGW("kTLS Tx is not fully active.");
+        return GGL_ERR_FAILURE;
+    }
+
+    if (BIO_get_ktls_recv(rbio) < 1) {
+        GGL_LOGW("kTLS Rx is not fully active.");
+        return GGL_ERR_FAILURE;
+    }
+
+    GGL_LOGI("kTLS is active.");
+    return GGL_ERR_OK;
+}
+
+static GglError enable_ktls(SSL_CTX *ssl_ctx) {
+    if (!is_ktls_supported()) {
+        GGL_LOGD(
+            "kTLS not supported on this system. Using back to regular TLS mode."
+        );
+        return GGL_ERR_INVALID;
+    }
+
+    // Force TLS 1.2 for better kTLS support
+    SSL_CTX_set_max_proto_version(ssl_ctx, TLS1_2_VERSION);
+
+    // Enable kTLS on the ctx
+    SSL_CTX_set_options(ssl_ctx, SSL_OP_ENABLE_KTLS);
+    if (!(SSL_CTX_get_options(ssl_ctx) & SSL_OP_ENABLE_KTLS)) {
+        GGL_LOGW("Failed to enable kTLS option on SSL ctx.");
+        return GGL_ERR_FAILURE;
+    }
+
+    GGL_LOGI("kTLS enabled successfully.");
+    return GGL_ERR_OK;
+}
+
 static void cleanup_ssl_ctx(SSL_CTX **ctx) {
     if (*ctx != NULL) {
         SSL_CTX_free(*ctx);
@@ -160,6 +237,12 @@ static GglError create_tls_context(
         return GGL_ERR_CONFIG;
     }
 
+    GglError ret = enable_ktls(new_ssl_ctx);
+    if (ret != GGL_ERR_OK) {
+        GGL_LOGD("Unable to set up kTLS option, continuing with standard TLS..."
+        );
+    }
+
     ctx_cleanup = NULL;
     *ssl_ctx = new_ssl_ctx;
     return GGL_ERR_OK;
@@ -186,6 +269,11 @@ static GglError do_handshake(char *host, BIO *bio) {
     if (SSL_get_verify_result(ssl) != X509_V_OK) {
         GGL_LOGE("Failed TLS server certificate verification.");
         return GGL_ERR_FAILURE;
+    }
+
+    GglError ret = check_ktls_status(ssl);
+    if (ret != GGL_ERR_OK) {
+        GGL_LOGD("kTLS not active, continuing without kTLS optimization...");
     }
 
     return GGL_ERR_OK;


### PR DESCRIPTION
*Description of changes:*
We now support connecting to AWS IoT Core using MQTT over TLS with kTLS optimization. If kTLS is not supported, we also allow to fall back to regular TLS mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
