### PR TITLE
Fleet provisioning CFN template refinement

### DIFF
--- a/docs/fleet_provisioning/fleet-provisioning-cfn.yaml
+++ b/docs/fleet_provisioning/fleet-provisioning-cfn.yaml
@@ -36,8 +36,6 @@ Resources:
             Principal:
               Service: credentials.iot.amazonaws.com
             Action: sts:AssumeRole
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
       Policies:
         - PolicyName: GreengrassTokenExchangeAccess
           PolicyDocument:
@@ -45,12 +43,23 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - "s3:*"
-                  - "s3-object-lambda:*"
-                  - "logs:CreateLogStream"
-                  - "logs:PutLogEvents"
-                  - "logs:CreateLogGroup"
-                  - "logs:DescribeLogStreams"
+                  - logs:CreateLogGroup
+                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:greengrass/systemLogs:*
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Join
+                    - ""
+                    - - "arn:aws:logs:"
+                      - !Ref AWS::Region
+                      - ":"
+                      - !Ref AWS::AccountId
+                      - ":log-group:greengrass/systemLogs:log-stream:${credentials-iot:ThingName}"
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
                 Resource: "*"
 
   # IAM Role for Fleet Provisioning
@@ -107,10 +116,14 @@ Resources:
             Action:
               - "iot:Publish"
               - "iot:Receive"
-            Resource: "*"
+            Resource:
+              - !Sub arn:aws:iot:${AWS::Region}:${AWS::AccountId}:topic/$aws/certificates/create-from-csr/*
+              - !Sub arn:aws:iot:${AWS::Region}:${AWS::AccountId}:topic/$aws/provisioning-templates/${ProvisioningTemplateName}/provision/*
           - Effect: Allow
             Action: "iot:Subscribe"
-            Resource: "*"
+            Resource:
+              - !Sub arn:aws:iot:${AWS::Region}:${AWS::AccountId}:topicfilter/$aws/certificates/create-from-csr/*
+              - !Sub arn:aws:iot:${AWS::Region}:${AWS::AccountId}:topicfilter/$aws/provisioning-templates/${ProvisioningTemplateName}/provision/*
 
   # IoT Policy for Greengrass Core Devices
   GreengrassV2IoTThingPolicy:
@@ -123,6 +136,16 @@ Resources:
           - Effect: Allow
             Action:
               - "iot:Connect"
+            Resource:
+              - !Join
+                - ""
+                - - "arn:aws:iot:"
+                  - !Ref AWS::Region
+                  - ":"
+                  - !Ref AWS::AccountId
+                  - ":client/${iot:Connection.Thing.ThingName}*"
+          - Effect: Allow
+            Action:
               - "iot:Publish"
               - "iot:Subscribe"
               - "iot:Receive"
@@ -154,21 +177,6 @@ Resources:
             Action: sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-      Policies:
-        - PolicyName: MacValidationPolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "logs:CreateLogGroup"
-                  - "logs:CreateLogStream"
-                  - "logs:PutLogEvents"
-                Resource: "*"
-              - Effect: Allow
-                Action:
-                  - "iot:*"
-                Resource: "*"
 
   # Lambda Function for MAC Address Validation
   MacValidationLambda:
@@ -242,7 +250,8 @@ Resources:
                 "CertificateId": {
                   "Ref": "AWS::IoT::Certificate::Id"
                 },
-                "Status": "ACTIVE"
+                "Status": "ACTIVE",
+                "ThingPrincipalType": "EXCLUSIVE_THING"
               }
             },
             "thing": {


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

1. Minimize token exchange role access. Just the minimum for system log forwarder, and pulling artifacts from S3.
2. Use the least-privilege fleet provisioning IoT policy as documented here: https://docs.aws.amazon.com/iot/latest/developerguide/provision-wo-cert.html#claim-based
3. Use least-privilege iot:Connect resource in the provisioned IoT policy. The other actions remain as wildcards since we don't know what topics they might use.
4. Remove unused actions and resource from the MAC Validation Lambda role.
5. Fleet prov template: provision with exclusive thing association since it's a best practice.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
