### PR TITLE
Add reset-failed on Nucleus and component restart

### DIFF
--- a/modules/gghealthd/src/bus_client.c
+++ b/modules/gghealthd/src/bus_client.c
@@ -12,6 +12,7 @@
 #include <pthread.h>
 #include <string.h>
 #include <sys/types.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 static pthread_mutex_t bump_alloc_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -55,4 +56,26 @@ GglError verify_component_exists(GglBuffer component_name) {
         component_version.data
     );
     return GGL_ERR_OK;
+}
+
+GglError get_root_component_list(GglArena *alloc, GglList *component_names) {
+    return ggl_gg_config_list(
+        GGL_BUF_LIST(GGL_STR("services")), alloc, component_names
+    );
+}
+
+bool is_nucleus_component_type(GglBuffer component_name) {
+    GglArena alloc = ggl_arena_init(GGL_BUF((uint8_t[32]) { 0 }));
+    GglBuffer component_type;
+    GglError ret = ggl_gg_config_read_str(
+        GGL_BUF_LIST(
+            GGL_STR("services"), component_name, GGL_STR("componentType")
+        ),
+        &alloc,
+        &component_type
+    );
+    if (ret != GGL_ERR_OK) {
+        return false;
+    }
+    return ggl_buffer_eq(GGL_STR("NUCLEUS"), component_type);
 }

--- a/modules/gghealthd/src/bus_client.h
+++ b/modules/gghealthd/src/bus_client.h
@@ -6,14 +6,20 @@
 #define GGHEALTHD_BUS_H
 
 #include <ggl/arena.h>
+#include <ggl/attr.h>
 #include <ggl/buffer.h>
 #include <ggl/error.h>
 #include <ggl/object.h>
+#include <stdbool.h>
 
-// use ggconfigd to verify a component's existence
+/// use ggconfigd to verify a component's existence
 GglError verify_component_exists(GglBuffer component_name);
 
-// use ggconfigd to list root components
-GglError get_root_component_list(GglArena *alloc, GglList *component_list);
+/// use ggconfigd to list root components
+NONNULL(1, 2)
+GglError get_root_component_list(GglArena *alloc, GglList *component_names);
+
+/// queries ggconfigd for a component's type and returns true if it is "NUCLEUS"
+bool is_nucleus_component_type(GglBuffer component_name);
 
 #endif

--- a/modules/gghealthd/src/sd_bus.h
+++ b/modules/gghealthd/src/sd_bus.h
@@ -1,6 +1,7 @@
 #ifndef GGHEALTHD_SD_BUS_H
 #define GGHEALTHD_SD_BUS_H
 
+#include <ggl/attr.h>
 #include <ggl/buffer.h>
 #include <ggl/error.h>
 #include <ggl/nucleus/constants.h>
@@ -33,6 +34,10 @@ GglError get_unit_path(
     const char **unit_path
 );
 
+// equivalent to systemd reset-failed <service-name>
+NONNULL(2)
+void reset_restart_counters(sd_bus *bus, const char *qualified_name);
+
 GglError open_bus(sd_bus **bus);
 
 GglError get_service_name(GglBuffer component_name, GglBuffer *qualified_name);
@@ -40,6 +45,9 @@ GglError get_service_name(GglBuffer component_name, GglBuffer *qualified_name);
 GglError get_lifecycle_state(
     sd_bus *bus, const char *unit_path, GglBuffer *state
 );
+
+NONNULL(2)
+GglError restart_component(sd_bus *bus, const char *qualified_name);
 
 void *event_loop_thread(void *ctx);
 


### PR DESCRIPTION
*Issue #, if available:*
* If components are restarted for any reason, this increments the restart counter towards its burst limit.

*Description of changes:*
* Add global reset-failed on gghealthd startup
* Add reset-failed of a single component on RestartComponent IPC

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
