### PR TITLE
Update Nix installer URL to Lix

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -9,7 +9,7 @@ Using Nix will allow you to use a reproducible development environment matching
 CI as well as run the CI checks locally.
 
 Use the following Nix installer which enables used features automatically:
-﻿https://github.com/DeterminateSystems/nix-installer
+https://git.lix.systems/lix-project/lix-installer
 
 If using a Nix environment for building, you will need to pass
 `CMAKE_INSTALL_PREFIX` when running CMake.


### PR DESCRIPTION
The DeterminateSystems Nix installer will no longer support upstream Nix in the future.

*Issue #, if available:*

*Description of changes:*
* Change Nix installer link to point to Lix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
