### PR TITLE
Fix: Set minimum protocol TLS version for kTLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ corebus. This table identifies the corebus component that does the work.
 | CreateLocalDeployment          | ggdeploymentd                |
 | ValidateAuthorizationToken     | ggipcd                       |
 | RestartComponent               | gghealthd                    |
+| UpdateState                    | gghealthd                    |
 
 Additional IPC commands will be supported in future releases.
 

--- a/modules/iotcored/src/tls.c
+++ b/modules/iotcored/src/tls.c
@@ -123,16 +123,6 @@ static GglError proxy_get_info(
 }
 
 static void check_ktls_status(SSL *ssl) {
-    // Check the current TLS version
-    if (SSL_version(ssl) == TLS1_2_VERSION) {
-        GGL_LOGD("TLS 1.2 connection established — kTLS is eligible.");
-    } else {
-        GGL_LOGD(
-            "kTLS may not be active because the TLS version is %s, not 1.2.",
-            SSL_get_version(ssl)
-        );
-    }
-
     BIO *wbio = SSL_get_wbio(ssl);
     BIO *rbio = SSL_get_rbio(ssl);
     // Suppress unused warnings - _FORTIFY_SOURCE may optimize away variable
@@ -164,8 +154,7 @@ static void try_enable_ktls(SSL_CTX *ssl_ctx) {
         GGL_LOGW("Failed to enable kTLS option on SSL ctx.");
     }
 
-    GGL_LOGD("kTLS option set on SSL context (actual use depends on the TLS "
-             "version).");
+    GGL_LOGD("kTLS option set on SSL context.");
 }
 
 static void cleanup_ssl_ctx(SSL_CTX **ctx) {


### PR DESCRIPTION
*Issue #, if available:*
- TLS handshake fails when using TLS 1.3.
- kTLS cannot be activated (both Tx and Rx show 0).

*Description of changes:*
- Set TLS 1.2 as the minimum protocol version instead of the maximum.
- Check both Tx and Rx kTLS activation status after the handshake completes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
