### PR TITLE
Fix credentials path on TPM_SUPPORT.md

### DIFF
--- a/docs/TPM_SUPPORT.md
+++ b/docs/TPM_SUPPORT.md
@@ -200,9 +200,9 @@ sudo usermod -a -G tss ggcore
 ### 7.4 Set up Credentials Directory
 
 ```bash
-sudo mkdir -p /var/lib/greengrass/credentials
-sudo cp device.pem AmazonRootCA1.pem /var/lib/greengrass/credentials/
-sudo chown -R ggcore:ggcore /var/lib/greengrass/credentials
+sudo mkdir -p /etc/greengrass/ggcredentials/
+sudo cp device.pem AmazonRootCA1.pem /etc/greengrass/ggcredentials/
+sudo chown -R ggcore:ggcore /etc/greengrass/ggcredentials/
 ```
 
 **Note**: Since we're using persistent TPM keys, no private key file needs to be


### PR DESCRIPTION
There was a mismatch between the created credentials folder and the one we use on the config.

*Description of changes:*
Updated created directory with the one we use on the config.
Since `Step 7.5` creates `/var/lib/greengrass` I assumed you wanted to create `/etc/greengrass/ggcredentials/` on `7.4`.
