### PR TITLE
Fix: python_testing branch not found

### DIFF
--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -30,7 +30,7 @@ jobs:
           repository:
             ${{ github.event.inputs.testing_repo ||
             'aws-greengrass/aws-greengrass-testing' }}
-          ref: ${{ github.event.inputs.testing_repo_ref || 'python_testing' }}
+          ref: ${{ github.event.inputs.testing_repo_ref || 'main' }}
           path: aws-greengrass-testing
 
       - name: List all tests
@@ -78,7 +78,7 @@ jobs:
           repository:
             ${{ github.event.inputs.testing_repo ||
             'aws-greengrass/aws-greengrass-testing' }}
-          ref: ${{ github.event.inputs.testing_repo_ref || 'python_testing' }}
+          ref: ${{ github.event.inputs.testing_repo_ref || 'main' }}
           path: aws-greengrass-testing
 
       - name: Get temporary AWS credentials


### PR DESCRIPTION
## Description

The list-tests job failed because the python_testing branch is no longer used in aws-greengrass/aws-greengrass-testing.

## Related Issue

Fixes #(issue number) or N/A if not applicable

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
