### PR TITLE
Replace faulty assert statement with standard error handling

### DIFF
--- a/modules/ggl-recipe/src/recipe.c
+++ b/modules/ggl-recipe/src/recipe.c
@@ -276,7 +276,11 @@ GgError fetch_script_section(
 static GgError lifecycle_selection(
     GgList selection, GgMap recipe_map, GgObject **selected_lifecycle_object
 ) {
-    assert(gg_list_type_check(selection, GG_TYPE_BUF));
+    GgError ret = gg_list_type_check(selection, GG_TYPE_BUF);
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("Selection is not a list of buffers");
+        return ret;
+    }
     GG_LIST_FOREACH (i, selection) {
         GgBuffer elem = gg_obj_into_buf(*i);
         if (gg_buffer_eq(elem, GG_STR("all"))


### PR DESCRIPTION
## Description

Replace faulty assert statement with standard error handling

## Related Issue

N/A

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
