### PR TITLE
Fix update_job attempting to retry canceled job updates

### DIFF
--- a/modules/ggdeploymentd/src/iot_jobs_listener.c
+++ b/modules/ggdeploymentd/src/iot_jobs_listener.c
@@ -205,7 +205,8 @@ static GgError update_job(
     }
 
     int64_t local_version = atomic_load_explicit(version, memory_order_acquire);
-    while (true) {
+    int stale_version_count = 0;
+    while (stale_version_count < 3) {
         uint8_t version_buf[16] = { 0 };
         int len = snprintf(
             (char *) version_buf, sizeof(version_buf), "%" PRIi64, local_version
@@ -307,6 +308,7 @@ static GgError update_job(
             memory_order_release
         );
         local_version = gg_obj_into_i64(*remote_version);
+        ++stale_version_count;
 
         (void) gg_sleep(1);
     }


### PR DESCRIPTION
## Description

Check job status reported by the MQTT broker when updating job

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

This bug would have been caught by unit testing. Mocking core-bus seems like a good next step.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
