### PR TITLE
Fix: libcurl TPM support for cloud deployment

### DIFF
--- a/modules/fleet-provisioning/src/entry.c
+++ b/modules/fleet-provisioning/src/entry.c
@@ -276,7 +276,7 @@ GgError run_fleet_prov(FleetProvArgs *args) {
     // Output dir
     GgBuffer output_dir_path = args->output_dir
         ? gg_buffer_from_null_term(args->output_dir)
-        : GG_STR("/var/lib/greengrass/credentials/");
+        : GG_STR("/var/lib/greengrass/credentials");
 
     int output_dir;
     ret = gg_dir_open(output_dir_path, O_PATH, true, &output_dir);

--- a/modules/ggl-http/src/gghttp_util.h
+++ b/modules/ggl-http/src/gghttp_util.h
@@ -10,9 +10,15 @@
 #include <gg/error.h>
 #include <ggl/http.h>
 
+typedef struct TpmCallbackData {
+    const char *key_path;
+    const char *cert_path;
+} TpmCallbackData;
+
 typedef struct CurlData {
     CURL *curl;
     struct curl_slist *headers_list;
+    TpmCallbackData tpm_data;
 } CurlData;
 
 /**


### PR DESCRIPTION
## Description
- Add TPM key support to ggl-http using OpenSSL `OSSL_STORE` API rather than using libcurl `CURLOPT_SSLKEY` and `CURLOPT_SSLENGINE`
- Detect TPM handles and use SSL context callback to load certificate and TPM key directly into SSL context
- Avoid race condition by moving TPM callback data from static variable to per-handle storage in CurlData struct
- Nit fix: remove the slash for config paths update

<img width="1305" height="644" alt="Screenshot 2026-01-27 at 10 18 34 AM" src="https://github.com/user-attachments/assets/c1ea3090-e648-4abd-9d13-13d9cfa1f429" />


## Related Issue

Fixes #(issue number) or N/A if not applicable

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [x] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [x] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
