### PR TITLE
Fix Misra Dir 4.13: ensure DIR from fdopendir is closed

### DIFF
--- a/modules/ggdeploymentd/src/stale_component.c
+++ b/modules/ggdeploymentd/src/stale_component.c
@@ -8,6 +8,7 @@
 #include <ftw.h>
 #include <gg/arena.h>
 #include <gg/buffer.h>
+#include <gg/cleanup.h>
 #include <gg/error.h>
 #include <gg/file.h>
 #include <gg/log.h>


### PR DESCRIPTION
## Description
Checking MISRA C-2012 Directive 4.13, got the violation: Resource "dir" is not freed or pointed-to in "iterate_over_components"

## Related Issue

Fixes #(issue number) or N/A if not applicable

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
