### PR TITLE
Fix fd leaks in deployment handler

### DIFF
--- a/modules/ggdeploymentd/src/bootstrap_manager.c
+++ b/modules/ggdeploymentd/src/bootstrap_manager.c
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 #include <gg/arena.h>
 #include <gg/buffer.h>
+#include <gg/cleanup.h>
 #include <gg/error.h>
 #include <gg/file.h>
 #include <gg/flags.h>
@@ -479,6 +480,7 @@ GgError process_bootstrap_phase(
                     component_name.data
                 );
             } else { // relevant bootstrap service file exists
+                GG_CLEANUP(cleanup_close, fd);
                 ret = disable_and_unlink_service(&component_name, BOOTSTRAP);
                 if (ret != GG_ERR_OK) {
                     return ret;

--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -671,6 +671,7 @@ static GgError unarchive_artifact(
         GG_LOGE("Failed to open unarchived artifact location.");
         return err;
     }
+    GG_CLEANUP(cleanup_close, output_dir_fd);
 
     // Unarchive the zip
     return ggl_zip_unarchive(component_store_fd, zip_file, output_dir_fd, mode);
@@ -2480,6 +2481,7 @@ static void handle_deployment(
         GG_LOGE("Failed to open artifact store");
         return;
     }
+    GG_CLEANUP(cleanup_close, artifact_store_fd);
 
     int artifact_archive_fd = -1;
     ret = gg_dir_openat(
@@ -2493,6 +2495,7 @@ static void handle_deployment(
         GG_LOGE("Failed to open archive store.");
         return;
     }
+    GG_CLEANUP(cleanup_close, artifact_archive_fd);
 
     GglDigest digest_context = ggl_new_digest(&ret);
     if (ret != GG_ERR_OK) {
@@ -2564,6 +2567,7 @@ static void handle_deployment(
             GG_LOGE("Failed to open artifact directory.");
             return;
         }
+        GG_CLEANUP(cleanup_close, component_artifacts_fd);
         int component_archive_dir_fd = -1;
         ret = open_component_artifacts_dir(
             artifact_archive_fd,
@@ -2575,6 +2579,7 @@ static void handle_deployment(
             GG_LOGE("Failed to open unarchived artifacts directory.");
             return;
         }
+        GG_CLEANUP(cleanup_close, component_archive_dir_fd);
         GgObject recipe_obj;
         static uint8_t recipe_mem[GGL_COMPONENT_RECIPE_MAX_LEN] = { 0 };
         GgArena alloc = gg_arena_init(GG_BUF(recipe_mem));
@@ -3016,6 +3021,7 @@ static void handle_deployment(
                         component_name.data
                     );
                 } else { // relevant install service file exists
+                    GG_CLEANUP(cleanup_close, fd);
                     (void) disable_and_unlink_service(&component_name, INSTALL);
                     // add relevant component name into the vector
                     ret = gg_buf_vec_push(
@@ -3178,6 +3184,7 @@ static void handle_deployment(
                         component_name.data
                     );
                 } else {
+                    GG_CLEANUP(cleanup_close, fd);
                     (void
                     ) disable_and_unlink_service(&component_name, RUN_STARTUP);
                     // run link command


### PR DESCRIPTION
## Description

Fix various fd leaks in deploymentd. Previously running ~500+ deployments would max out fds and future deployments would fail.

## Related Issue

Fixes #(issue number) or N/A if not applicable

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
