### PR TITLE
Remove expectedVersion from IoT Jobs updates

### DIFF
--- a/modules/ggdeploymentd/src/bootstrap_manager.c
+++ b/modules/ggdeploymentd/src/bootstrap_manager.c
@@ -19,7 +19,6 @@
 #include <gg/object.h>
 #include <gg/vector.h>
 #include <ggl/core_bus/gg_config.h>
-#include <inttypes.h>
 #include <limits.h>
 #include <string.h>
 #include <stdbool.h>
@@ -141,29 +140,6 @@ GgError save_iot_jobs_id(GgBuffer jobs_id) {
     return GG_ERR_OK;
 }
 
-GgError save_iot_jobs_version(int64_t jobs_version) {
-    GG_LOGD(
-        "Saving IoT Jobs version %" PRIi64 " in case of bootstrap.",
-        jobs_version
-    );
-
-    GgError ret = ggl_gg_config_write(
-        GG_BUF_LIST(
-            GG_STR("services"),
-            GG_STR("DeploymentService"),
-            GG_STR("deploymentState"),
-            GG_STR("jobsVersion")
-        ),
-        gg_obj_i64(jobs_version),
-        &(int64_t) { 3 }
-    );
-    if (ret != GG_ERR_OK) {
-        GG_LOGE("Failed to write IoT Jobs Version to config.");
-        return ret;
-    }
-    return GG_ERR_OK;
-}
-
 GgError save_deployment_info(GglDeployment *deployment) {
     GG_LOGD(
         "Encountered component requiring bootstrap. Saving deployment state to config."
@@ -231,7 +207,7 @@ GgError save_deployment_info(GglDeployment *deployment) {
 }
 
 GgError retrieve_in_progress_deployment(
-    GglDeployment *deployment, GgBuffer *jobs_id, int64_t *jobs_version
+    GglDeployment *deployment, GgBuffer *jobs_id
 ) {
     GG_LOGD("Searching config for any in progress deployment.");
 
@@ -275,19 +251,6 @@ GgError retrieve_in_progress_deployment(
         gg_obj_into_buf(*jobs_id_obj).data,
         gg_obj_into_buf(*jobs_id_obj).len
     );
-
-    GgObject *jobs_version_obj;
-    ret = gg_map_validate(
-        gg_obj_into_map(deployment_config),
-        GG_MAP_SCHEMA({ GG_STR("jobsVersion"),
-                        GG_REQUIRED,
-                        GG_TYPE_I64,
-                        &jobs_version_obj })
-    );
-    if (ret != GG_ERR_OK) {
-        return ret;
-    }
-    *jobs_version = gg_obj_into_i64(*jobs_version_obj);
 
     GgObject *deployment_type;
     ret = gg_map_validate(

--- a/modules/ggdeploymentd/src/bootstrap_manager.h
+++ b/modules/ggdeploymentd/src/bootstrap_manager.h
@@ -11,7 +11,6 @@
 #include <gg/object.h>
 #include <gg/vector.h>
 #include <stdbool.h>
-#include <stdint.h>
 
 /*
   deployment info will be saved to config in the following format:
@@ -27,7 +26,6 @@
           deploymentType: local/IoT Jobs
           deploymentDoc:
           jobsID:
-          jobsVersion:
 */
 
 bool component_bootstrap_phase_completed(GgBuffer component_name);
@@ -40,10 +38,9 @@ GgError save_component_info(
 );
 
 GgError save_iot_jobs_id(GgBuffer jobs_id);
-GgError save_iot_jobs_version(int64_t jobs_version);
 GgError save_deployment_info(GglDeployment *deployment);
 GgError retrieve_in_progress_deployment(
-    GglDeployment *deployment, GgBuffer *jobs_id, int64_t *jobs_version
+    GglDeployment *deployment, GgBuffer *jobs_id
 );
 GgError delete_saved_deployment_from_config(void);
 GgError process_bootstrap_phase(

--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -3478,11 +3478,9 @@ static GgError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
     GglDeployment bootstrap_deployment = { 0 };
     uint8_t jobs_id_resp_mem[64] = { 0 };
     GgBuffer jobs_id = GG_BUF(jobs_id_resp_mem);
-    int64_t jobs_version = 0;
 
-    GgError ret = retrieve_in_progress_deployment(
-        &bootstrap_deployment, &jobs_id, &jobs_version
-    );
+    GgError ret
+        = retrieve_in_progress_deployment(&bootstrap_deployment, &jobs_id);
     if (ret != GG_ERR_OK) {
         GG_LOGD("No deployments previously in progress detected.");
     } else {
@@ -3495,7 +3493,7 @@ static GgError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
         bool send_deployment_update
             = (GG_ERR_OK
                == set_jobs_deployment_for_bootstrap(
-                   jobs_id, bootstrap_deployment.deployment_id, jobs_version
+                   jobs_id, bootstrap_deployment.deployment_id
                ));
 
         bool bootstrap_deployment_succeeded = false;

--- a/modules/ggdeploymentd/src/iot_jobs_listener.h
+++ b/modules/ggdeploymentd/src/iot_jobs_listener.h
@@ -7,13 +7,12 @@
 
 #include <gg/buffer.h>
 #include <gg/error.h>
-#include <stdint.h>
 
 void *job_listener_thread(void *ctx);
 
 GgError update_current_jobs_deployment(GgBuffer deployment_id, GgBuffer status);
 GgError set_jobs_deployment_for_bootstrap(
-    GgBuffer job_id, GgBuffer deployment_id, int64_t version
+    GgBuffer job_id, GgBuffer deployment_id
 );
 
 #endif


### PR DESCRIPTION
Remove the expectedVersion field from UpdateJobExecution MQTT calls. This field is optional per the IoT Jobs API and was causing ~5% of deployment status updates to fail with VersionMismatch errors due to a race condition between MQTT reconnect and job completion.

The race occurs when an MQTT reconnect triggers a DescribeNextJob response during deployment processing, causing the locally tracked version to become stale by the time the SUCCEEDED update is sent. The existing retry logic for this case also contained a bug where the sent version was overwritten before comparison, making the retry path unreachable (dead code).

aws-greengrass-nucleus (Java) does not send expectedVersion and does not experience this issue. Since only one ggdeploymentd instance updates a given job execution, optimistic locking provides no benefit.

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number) or N/A if not applicable

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
