### PR TITLE
Add MQTT connectivity check for endpoint switch

### DIFF
--- a/misc/dictionary.txt
+++ b/misc/dictionary.txt
@@ -70,6 +70,7 @@ HEALTHD
 htobe
 INET
 iotcored
+iotcoreddeploy
 iotcoredfleet
 iwyu
 journalctl

--- a/misc/iwyu_mappings.yml
+++ b/misc/iwyu_mappings.yml
@@ -21,6 +21,7 @@
 - symbol: ["pthread_condattr_t", "private", "<sys/types.h>", "public"]
 - symbol: ["pthread_mutex_t", "private", "<sys/types.h>", "public"]
 - symbol: ["pthread_mutexattr_t", "private", "<sys/types.h>", "public"]
+- symbol: ["pthread_once_t", "private", "<sys/types.h>", "public"]
 - symbol: ["pthread_t", "private", "<sys/types.h>", "public"]
 - symbol: ["si_status", "private", "<signal.h>", "public"]
 - symbol: ["va_end", "private", "<stdarg.h>", "public"]

--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -9,6 +9,7 @@
 #include "deployment_model.h"
 #include "deployment_queue.h"
 #include "iot_jobs_listener.h"
+#include "iotcored_instance.h"
 #include "priv_io.h"
 #include "stale_component.h"
 #include <assert.h>
@@ -55,6 +56,7 @@
 #define MAX_DECODE_BUF_LEN 4096
 #define DEPLOYMENT_TARGET_NAME_MAX_CHARS 128
 #define MAX_DEPLOYMENT_TARGETS 100
+#define MQTT_CONNECTIVITY_CHECK_TIMEOUT_SECONDS 60
 
 static struct DeploymentConfiguration {
     char data_endpoint[128];
@@ -2378,7 +2380,7 @@ static GgError wait_for_deployment_status(GgMap resolved_components) {
     return GG_ERR_OK;
 }
 
-static GgError validate_iot_endpoint(
+static GgError validate_iot_endpoint_format(
     GgBuffer endpoint, GgBuffer name, GgBuffer device_region
 ) {
     if (endpoint.len == 0) {
@@ -2469,7 +2471,59 @@ static GgError get_nucleus_merge_map(
     return GG_ERR_OK;
 }
 
-static GgError validate_endpoint_switch_deployment(GgMap components) {
+/// Verify MQTT connectivity to the target endpoint by spawning a separate
+/// iotcored process, since the running iotcored is connected to the current
+/// endpoint.
+static GgError check_mqtt_connectivity(
+    GgBuffer target_endpoint, const char *bin_path
+) {
+    static char iotcored_path_buf[PATH_MAX];
+    GgByteVec iotcored_path = GG_BYTE_VEC(iotcored_path_buf);
+    GgError ret = gg_byte_vec_append(
+        &iotcored_path, gg_buffer_from_null_term((char *) bin_path)
+    );
+    gg_byte_vec_chain_append(&ret, &iotcored_path, GG_STR("iotcored"));
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("Failed to resolve iotcored path.");
+        return ret;
+    }
+
+    GG_LOGI(
+        "Checking MQTT connectivity to %.*s (timeout=%us).",
+        (int) target_endpoint.len,
+        target_endpoint.data,
+        MQTT_CONNECTIVITY_CHECK_TIMEOUT_SECONDS
+    );
+
+    IotcoredInstance instance;
+    ret = iotcored_instance_start(
+        &instance, iotcored_path.buf, target_endpoint
+    );
+    GG_CLEANUP(iotcored_instance_stop, instance);
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+
+    ret = iotcored_await_connection(MQTT_CONNECTIVITY_CHECK_TIMEOUT_SECONDS);
+    if (ret != GG_ERR_OK) {
+        GG_LOGE(
+            "MQTT connectivity check failed for %.*s.",
+            (int) target_endpoint.len,
+            target_endpoint.data
+        );
+    } else {
+        GG_LOGI(
+            "MQTT connectivity check passed for %.*s.",
+            (int) target_endpoint.len,
+            target_endpoint.data
+        );
+    }
+    return ret;
+}
+
+static GgError validate_endpoint_switch_deployment(
+    GgMap components, const char *bin_path
+) {
     GgMap merge = { 0 };
     bool found = false;
     GgError ret = get_nucleus_merge_map(components, &merge, &found);
@@ -2539,19 +2593,22 @@ static GgError validate_endpoint_switch_deployment(GgMap components) {
         );
     }
 
-    if (effective_data_ep.len > 0) {
-        ret = validate_iot_endpoint(
-            effective_data_ep, GG_STR("iotDataEndpoint"), effective_region
-        );
-        if (ret != GG_ERR_OK) {
-            return ret;
-        }
+    ret = validate_iot_endpoint_format(
+        effective_data_ep, GG_STR("iotDataEndpoint"), effective_region
+    );
+    if (ret != GG_ERR_OK) {
+        return ret;
     }
 
-    if (effective_cred_ep.len > 0) {
-        ret = validate_iot_endpoint(
-            effective_cred_ep, GG_STR("iotCredEndpoint"), effective_region
-        );
+    ret = validate_iot_endpoint_format(
+        effective_cred_ep, GG_STR("iotCredEndpoint"), effective_region
+    );
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+
+    if (data_ep_obj != NULL) {
+        ret = check_mqtt_connectivity(effective_data_ep, bin_path);
         if (ret != GG_ERR_OK) {
             return ret;
         }
@@ -2569,7 +2626,9 @@ static void handle_deployment(
     int root_path_fd = args->root_path_fd;
 
     // Validate IoT endpoint deployment before any state changes
-    GgError ret = validate_endpoint_switch_deployment(deployment->components);
+    GgError ret = validate_endpoint_switch_deployment(
+        deployment->components, args->bin_path
+    );
     if (ret != GG_ERR_OK) {
         GG_LOGE("Deployment rejected: IoT endpoint validation failed.");
         return;

--- a/modules/ggdeploymentd/src/iotcored_instance.c
+++ b/modules/ggdeploymentd/src/iotcored_instance.c
@@ -1,0 +1,218 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iotcored_instance.h"
+#include <assert.h>
+#include <errno.h>
+#include <gg/arena.h>
+#include <gg/buffer.h>
+#include <gg/cleanup.h>
+#include <gg/error.h>
+#include <gg/log.h>
+#include <gg/utils.h>
+#include <ggl/core_bus/aws_iot_mqtt.h>
+#include <ggl/core_bus/gg_config.h>
+#include <ggl/exec.h>
+#include <limits.h>
+#include <pthread.h>
+#include <string.h>
+#include <sys/types.h>
+#include <time.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+// TODO: Remove retry by pre-creating the socket before spawn (socket
+// activation).
+#define SUBSCRIBE_RETRY_INTERVAL_MS 500
+#define IOTCORED_INSTANCE_NAME "iotcoreddeploy"
+#define MAX_ENDPOINT_LEN 128
+#define MAX_THING_NAME_LEN 128
+// MQTT client ID: thingName + suffix. Must match IoT policy pattern thingName*
+// and stay within 128-byte MQTT client ID limit.
+// TODO: Use a dynamic suffix if multiple iotcored instances are needed
+// concurrently.
+#define MAX_CLIENT_ID_LEN 128
+#define CLIENT_ID_SUFFIX "#endpoint-switch"
+
+typedef struct {
+    pthread_mutex_t mtx;
+    pthread_cond_t cond;
+    bool connected;
+} ConnectionCtx;
+
+static GgError connection_status_callback(
+    void *ctx, uint32_t handle, GgObject data
+) {
+    (void) handle;
+    ConnectionCtx *conn_ctx = ctx;
+
+    bool connected = false;
+    GgError ret = ggl_aws_iot_mqtt_connection_status_parse(data, &connected);
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+
+    if (connected) {
+        GG_MTX_SCOPE_GUARD(&conn_ctx->mtx);
+        conn_ctx->connected = true;
+        pthread_cond_signal(&conn_ctx->cond);
+    }
+
+    return GG_ERR_OK;
+}
+
+GgError iotcored_instance_start(
+    IotcoredInstance *ctx, GgBuffer iotcored_path, GgBuffer endpoint
+) {
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->pid = -1;
+
+    static uint8_t thing_name_mem[MAX_THING_NAME_LEN + 1];
+    GgArena alloc = gg_arena_init(
+        gg_buffer_substr(GG_BUF(thing_name_mem), 0, MAX_THING_NAME_LEN)
+    );
+    GgBuffer thing_name = { 0 };
+    GgError ret = ggl_gg_config_read_str(
+        GG_BUF_LIST(GG_STR("system"), GG_STR("thingName")), &alloc, &thing_name
+    );
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("Failed to read thingName.");
+        return ret;
+    }
+    char client_id[MAX_CLIENT_ID_LEN + 1];
+    int client_id_len = snprintf(
+        client_id,
+        sizeof(client_id),
+        "%.*s" CLIENT_ID_SUFFIX,
+        (int) thing_name.len,
+        thing_name.data
+    );
+    if (client_id_len >= (int) sizeof(client_id)) {
+        GG_LOGE(
+            "MQTT client ID %.*s" CLIENT_ID_SUFFIX " exceeds 128-byte limit.",
+            (int) thing_name.len,
+            thing_name.data
+        );
+        return GG_ERR_RANGE;
+    }
+
+    char endpoint_buf[MAX_ENDPOINT_LEN + 1];
+    if (endpoint.len >= sizeof(endpoint_buf)) {
+        GG_LOGE("Endpoint too long: %.*s.", (int) endpoint.len, endpoint.data);
+        return GG_ERR_RANGE;
+    }
+    memcpy(endpoint_buf, endpoint.data, endpoint.len);
+    endpoint_buf[endpoint.len] = '\0';
+
+    char path_buf[PATH_MAX];
+    if (iotcored_path.len >= sizeof(path_buf)) {
+        GG_LOGE(
+            "iotcored path too long: %.*s.",
+            (int) iotcored_path.len,
+            iotcored_path.data
+        );
+        return GG_ERR_RANGE;
+    }
+    memcpy(path_buf, iotcored_path.data, iotcored_path.len);
+    path_buf[iotcored_path.len] = '\0';
+
+    const char *args[] = {
+        path_buf,  "-n", IOTCORED_INSTANCE_NAME, "-e", endpoint_buf, "-i",
+        client_id, NULL,
+    };
+
+    ret = ggl_exec_command_async(args, &ctx->pid);
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("Failed to spawn iotcored instance.");
+        ctx->pid = -1;
+        return ret;
+    }
+
+    GG_LOGD("Spawned iotcored instance (pid=%d).", ctx->pid);
+    return GG_ERR_OK;
+}
+
+static void cleanup_pthread_cond(pthread_cond_t **cond) {
+    if (*cond != NULL) {
+        pthread_cond_destroy(*cond);
+    }
+}
+
+GgError iotcored_await_connection(uint32_t timeout_s) {
+    pthread_condattr_t attr;
+    pthread_condattr_init(&attr);
+    pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+    pthread_cond_t cond;
+    pthread_cond_init(&cond, &attr);
+    pthread_condattr_destroy(&attr);
+    GG_CLEANUP(cleanup_pthread_cond, &cond);
+
+    pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
+
+    ConnectionCtx ctx = {
+        .mtx = mtx,
+        .cond = cond,
+        .connected = false,
+    };
+
+    struct timespec deadline;
+    clock_gettime(CLOCK_MONOTONIC, &deadline);
+    deadline.tv_sec += timeout_s;
+
+    uint32_t sub_handle = 0;
+    GG_CLEANUP(cleanup_ggl_client_sub_close, sub_handle);
+
+    while (true) {
+        struct timespec now;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        if ((now.tv_sec > deadline.tv_sec)
+            || ((now.tv_sec == deadline.tv_sec)
+                && (now.tv_nsec >= deadline.tv_nsec))) {
+            return GG_ERR_FAILURE;
+        }
+
+        GgError ret = ggl_aws_iot_mqtt_connection_status(
+            GG_STR(IOTCORED_INSTANCE_NAME),
+            connection_status_callback,
+            NULL,
+            &ctx,
+            &sub_handle
+        );
+        if (ret == GG_ERR_OK) {
+            break;
+        }
+
+        (void) gg_sleep_ms(SUBSCRIBE_RETRY_INTERVAL_MS);
+    }
+
+    bool timed_out = false;
+    {
+        GG_MTX_SCOPE_GUARD(&ctx.mtx);
+
+        while (!ctx.connected) {
+            int cond_ret
+                = pthread_cond_timedwait(&ctx.cond, &ctx.mtx, &deadline);
+            if ((cond_ret != 0) && (cond_ret != EINTR)) {
+                assert(cond_ret == ETIMEDOUT);
+                timed_out = true;
+                break;
+            }
+        }
+    }
+
+    if (timed_out) {
+        return GG_ERR_FAILURE;
+    }
+
+    return GG_ERR_OK;
+}
+
+void iotcored_instance_stop(IotcoredInstance *ctx) {
+    if (ctx->pid > 0) {
+        GG_LOGD("Stopping iotcored instance (pid=%d).", ctx->pid);
+        (void) ggl_exec_kill_process(ctx->pid);
+        ctx->pid = -1;
+    }
+}

--- a/modules/ggdeploymentd/src/iotcored_instance.h
+++ b/modules/ggdeploymentd/src/iotcored_instance.h
@@ -1,0 +1,31 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GGDEPLOYMENTD_IOTCORED_INSTANCE_H
+#define GGDEPLOYMENTD_IOTCORED_INSTANCE_H
+
+#include <gg/error.h>
+#include <gg/types.h>
+#include <sys/types.h>
+#include <stdint.h>
+
+typedef struct {
+    pid_t pid;
+} IotcoredInstance;
+
+/// Spawn an iotcored process pointed at the given endpoint. The spawned
+/// process reads cert/key/rootca from ggconfigd — only the endpoint is
+/// overridden.
+GgError iotcored_instance_start(
+    IotcoredInstance *ctx, GgBuffer iotcored_path, GgBuffer endpoint
+);
+
+/// Block until the spawned iotcored reports connected=true or timeout expires.
+/// Operates on the module-level instance — only one instance at a time.
+GgError iotcored_await_connection(uint32_t timeout_s);
+
+/// Kill the spawned iotcored process. Can be used directly with GG_CLEANUP.
+void iotcored_instance_stop(IotcoredInstance *ctx);
+
+#endif


### PR DESCRIPTION


## Description

Verify the device can reach the new IoT data endpoint before applying configuration changes, preventing device bricking from unreachable endpoints.

A separate iotcored process is spawned to test connectivity since the running iotcored is connected to the current endpoint. On timeout, the deployment reports FAILED with no state changes.

Also renames `validate_iot_endpoint` to `validate_iot_endpoint_format `to distinguish format checks from live connectivity checks.
## Related Issue

Fixes #(issue number) or N/A if not applicable

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

1. Unreachable endpoint (cert not registered in target account):
```
I[ggdeploymentd] Checking MQTT connectivity to <endpoint> (timeout=120s).
D[ggdeploymentd] Spawned iotcored instance (pid=79).
E[iotcored] Connection failed: MQTTRecvFailed
  ... retries for 120s ...
E[ggdeploymentd] MQTT connectivity check failed for <endpoint>.
D[ggdeploymentd] Stopping iotcored instance (pid=79).
D[ggl-exec] Process 79 was terminated by signal 15.
W[ggdeploymentd] Completed deployment processing and reporting job as FAILED.
```

2. Reachable endpoint (cert registered in target account):

```
I[ggdeploymentd] Checking MQTT connectivity to <endpoint> (timeout=120s).
D[ggdeploymentd] Spawned iotcored instance (pid=193).
I[iotcored] TLS connection established.
I[core_mqtt] MQTT connection established with the broker.
I[iotcored] Connected to IoT core.
I[ggdeploymentd] MQTT connectivity check passed for <endpoint>.
D[ggdeploymentd] Stopping iotcored instance (pid=193).
D[ggl-exec] Process 193 was terminated by signal 15.
```

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
