### PR TITLE
Add health daemon config interface

### DIFF
--- a/misc/dictionary.txt
+++ b/misc/dictionary.txt
@@ -11,6 +11,7 @@ cgexec
 clangd
 clientfd
 clientv
+collectionIntervalSec
 coremqtt
 coreutils
 corge
@@ -23,6 +24,7 @@ dbus
 DCMAKE
 dearmor
 depl
+devtmpfs
 DFETCHCONTENT
 DGGL
 DIOTCORED
@@ -38,6 +40,8 @@ evbuffer
 eventfd
 evhttp
 evkeyvalq
+excludeInterfaces
+excludeMounts
 execvp
 execvpe
 FDNAMES
@@ -46,6 +50,8 @@ FIXEDTPM
 FOWNER
 Fssd
 fstrict
+fstype
+fstypes
 gencb
 getent
 ggconfig
@@ -88,6 +94,7 @@ LOGE
 LOGI
 LOGT
 LOGW
+meminfo
 mqtt
 mqttproxy
 mtls
@@ -102,6 +109,8 @@ NOPASSWD
 nproc
 OSSL
 ostree
+outputDirectory
+outputMode
 parentid
 pidfd
 pkcs
@@ -109,6 +118,7 @@ pkgs
 pname
 posix
 postrm
+procPath
 ptid
 PTRACE
 Pypi
@@ -133,13 +143,17 @@ stdenv
 subscribetocomponentupdates
 svcuid
 svcuids
+sysfs
+sysPath
 sysv
 tabrmd
 tcti
 tesd
 tesddeploy
+thingName
 tlog
 tmpfiles
+tmpfs
 TPMA
 TPMI
 TPML

--- a/modules/gg-lite-health-daemon/CMakeLists.txt
+++ b/modules/gg-lite-health-daemon/CMakeLists.txt
@@ -1,0 +1,6 @@
+# aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+ggl_init_module(gg-lite-health-daemon LIBS gg-sdk ggl-common core-bus
+                                           core-bus-gg-config)

--- a/modules/gg-lite-health-daemon/include/gg-lite-health-daemon/config.h
+++ b/modules/gg-lite-health-daemon/include/gg-lite-health-daemon/config.h
@@ -1,0 +1,45 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GG_LITE_HEALTH_DAEMON_CONFIG_H
+#define GG_LITE_HEALTH_DAEMON_CONFIG_H
+
+//! Health daemon configuration
+
+#include <gg/error.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define MAX_EXCLUDE_ENTRIES 16
+#define MAX_EXCLUDE_ENTRY_LEN 64
+#define MAX_PATH_LEN 256
+#define MAX_LABEL_LEN 16
+
+/// Health daemon configuration values.
+typedef struct {
+    /// Output format; currently only "emf" is supported.
+    char output_mode[MAX_LABEL_LEN];
+    /// Directory where EMF metric files are written.
+    char output_directory[MAX_PATH_LEN];
+    /// Seconds between collection cycles.
+    uint32_t collection_interval_sec;
+    /// Path to /proc (overridable for containers).
+    char proc_path[MAX_PATH_LEN];
+    /// Path to /sys (overridable for containers).
+    char sys_path[MAX_PATH_LEN];
+    /// Filesystem types to skip in disk collection (e.g. "tmpfs").
+    char exclude_fstypes[MAX_EXCLUDE_ENTRIES][MAX_EXCLUDE_ENTRY_LEN];
+    size_t exclude_fstype_count;
+    /// Network interfaces to skip (e.g. "lo").
+    char exclude_interfaces[MAX_EXCLUDE_ENTRIES][MAX_EXCLUDE_ENTRY_LEN];
+    size_t exclude_interface_count;
+} HealthDaemonConfig;
+
+/// Initialize config with defaults.
+GgError config_init(HealthDaemonConfig *config);
+
+/// Load config from nucleus core-bus.
+GgError config_load(HealthDaemonConfig *config);
+
+#endif

--- a/modules/gg-lite-health-daemon/src/config.c
+++ b/modules/gg-lite-health-daemon/src/config.c
@@ -1,0 +1,124 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gg-lite-health-daemon/config.h"
+#include <gg/arena.h>
+#include <gg/buffer.h>
+#include <gg/error.h>
+#include <gg/list.h>
+#include <gg/log.h>
+#include <gg/object.h>
+#include <gg/types.h>
+#include <ggl/core_bus/gg_config.h>
+#include <string.h>
+#include <stdint.h>
+
+static const HealthDaemonConfig DEFAULT_CONFIG = {
+    .output_mode = "emf",
+    .output_directory = "/var/log/gg-metrics/system-health/",
+    .collection_interval_sec = 60,
+    .proc_path = "/proc",
+    .sys_path = "/sys",
+    .exclude_fstypes = { "tmpfs", "proc", "sysfs", "devtmpfs" },
+    .exclude_fstype_count = 4,
+    .exclude_interfaces = { "lo" },
+    .exclude_interface_count = 1,
+};
+
+GgError config_init(HealthDaemonConfig *config) {
+    *config = DEFAULT_CONFIG;
+    return GG_ERR_OK;
+}
+
+static void copy_buf(GgBuffer src, char *dest, size_t max_len) {
+    if (max_len == 0) {
+        return;
+    }
+    size_t len = (src.len < max_len - 1) ? src.len : max_len - 1;
+    memcpy(dest, src.data, len);
+    dest[len] = '\0';
+}
+
+static GgError read_config_field(
+    const char *field, GgArena *alloc, GgObject *obj
+) {
+    return ggl_gg_config_read(
+        GG_BUF_LIST(
+            GG_STR("services"),
+            GG_STR("aws.greengrass.NucleusLite"),
+            GG_STR("configuration"),
+            GG_STR("healthDaemon"),
+            gg_buffer_from_null_term((char *) field)
+        ),
+        alloc,
+        obj
+    );
+}
+
+static void load_str(const char *field, char *dest, size_t max_len) {
+    uint8_t mem[256];
+    GgArena alloc = gg_arena_init(GG_BUF(mem));
+    GgObject obj;
+    if (read_config_field(field, &alloc, &obj) == GG_ERR_OK
+        && gg_obj_type(obj) == GG_TYPE_BUF) {
+        copy_buf(gg_obj_into_buf(obj), dest, max_len);
+    }
+}
+
+static void load_u32(const char *field, uint32_t *dest) {
+    uint8_t mem[64];
+    GgArena alloc = gg_arena_init(GG_BUF(mem));
+    GgObject obj;
+    if (read_config_field(field, &alloc, &obj) == GG_ERR_OK
+        && gg_obj_type(obj) == GG_TYPE_I64) {
+        int64_t val = gg_obj_into_i64(obj);
+        // Reject zero and negative; only positive values override defaults.
+        if (val > 0 && val <= UINT32_MAX) {
+            *dest = (uint32_t) val;
+        }
+    }
+}
+
+static void load_str_list(
+    const char *field, char dest[][MAX_EXCLUDE_ENTRY_LEN], size_t *count
+) {
+    uint8_t mem[2048];
+    GgArena alloc = gg_arena_init(GG_BUF(mem));
+    GgObject obj;
+    if (read_config_field(field, &alloc, &obj) != GG_ERR_OK
+        || gg_obj_type(obj) != GG_TYPE_LIST) {
+        return;
+    }
+    GgList obj_list = gg_obj_into_list(obj);
+    size_t n = 0;
+    GG_LIST_FOREACH (item, obj_list) {
+        if (n >= MAX_EXCLUDE_ENTRIES) {
+            GG_LOGW("Exclude list full, dropping entry");
+            break;
+        }
+        if (gg_obj_type(*item) == GG_TYPE_BUF) {
+            copy_buf(gg_obj_into_buf(*item), dest[n], MAX_EXCLUDE_ENTRY_LEN);
+            n++;
+        }
+    }
+    *count = n;
+}
+
+GgError config_load(HealthDaemonConfig *config) {
+    load_str("outputMode", config->output_mode, MAX_LABEL_LEN);
+    load_str("outputDirectory", config->output_directory, MAX_PATH_LEN);
+    load_u32("collectionIntervalSec", &config->collection_interval_sec);
+    load_str("procPath", config->proc_path, MAX_PATH_LEN);
+    load_str("sysPath", config->sys_path, MAX_PATH_LEN);
+    load_str_list(
+        "excludeMounts", config->exclude_fstypes, &config->exclude_fstype_count
+    );
+    load_str_list(
+        "excludeInterfaces",
+        config->exclude_interfaces,
+        &config->exclude_interface_count
+    );
+
+    return GG_ERR_OK;
+}

--- a/modules/gg-lite-health-daemon/test/test_config.c
+++ b/modules/gg-lite-health-daemon/test/test_config.c
@@ -1,0 +1,39 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// config_load requires a running nucleus (core-bus). Only config_init
+// defaults are tested here. Integration tests cover config_load.
+
+#include "gg-lite-health-daemon/config.h"
+#include <assert.h>
+#include <gg/error.h>
+#include <string.h>
+
+static void test_config_init_defaults(void) {
+    HealthDaemonConfig config;
+    assert(config_init(&config) == GG_ERR_OK);
+
+    assert(strcmp(config.output_mode, "emf") == 0);
+    assert(
+        strcmp(config.output_directory, "/var/log/gg-metrics/system-health/")
+        == 0
+    );
+    assert(config.collection_interval_sec == 60);
+    assert(strcmp(config.proc_path, "/proc") == 0);
+    assert(strcmp(config.sys_path, "/sys") == 0);
+
+    assert(config.exclude_fstype_count == 4);
+    assert(strcmp(config.exclude_fstypes[0], "tmpfs") == 0);
+    assert(strcmp(config.exclude_fstypes[1], "proc") == 0);
+    assert(strcmp(config.exclude_fstypes[2], "sysfs") == 0);
+    assert(strcmp(config.exclude_fstypes[3], "devtmpfs") == 0);
+
+    assert(config.exclude_interface_count == 1);
+    assert(strcmp(config.exclude_interfaces[0], "lo") == 0);
+}
+
+int main(void) {
+    test_config_init_defaults();
+    return 0;
+}


### PR DESCRIPTION
## Description

Add configuration module for gg-lite-health-daemon. Reads config from nucleus
core-bus via `ggl_gg_config_read`, following the same pattern as `gg-fleet-statusd`.

- `CMakeLists.txt` — Module registration with `core-bus-gg-config` dependency
- `config.h` — `HealthDaemonConfig` struct with all daemon settings
- `config.c` — Core-bus config loading with `read_config_field` helper. Missing fields keep defaults, only `thingName` failure is fatal.
- `test_config.c` — Verifies all 11 default values

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [x] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [x] New functionality is covered by tests

## Additional Notes

First PR in a series of 6 for the gg-lite-health-daemon module. This PR adds
only the config interface. Subsequent PRs add the daemon skeleton, metric
collectors (CPU, memory, disk, network), and EMF file output.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._