### PR TITLE
Pr/health daemon skeleton

### DIFF
--- a/misc/dictionary.txt
+++ b/misc/dictionary.txt
@@ -11,6 +11,7 @@ cgexec
 clangd
 clientfd
 clientv
+collectionIntervalSec
 coremqtt
 coreutils
 corge
@@ -23,6 +24,7 @@ dbus
 DCMAKE
 dearmor
 depl
+devtmpfs
 DFETCHCONTENT
 DGGL
 DIOTCORED
@@ -38,6 +40,8 @@ evbuffer
 eventfd
 evhttp
 evkeyvalq
+excludeInterfaces
+excludeMounts
 execvp
 execvpe
 FDNAMES
@@ -46,6 +50,8 @@ FIXEDTPM
 FOWNER
 Fssd
 fstrict
+fstype
+fstypes
 gencb
 getent
 ggconfig
@@ -88,6 +94,7 @@ LOGE
 LOGI
 LOGT
 LOGW
+meminfo
 mqtt
 mqttproxy
 mtls
@@ -102,6 +109,8 @@ NOPASSWD
 nproc
 OSSL
 ostree
+outputDirectory
+outputMode
 parentid
 pidfd
 pkcs
@@ -109,6 +118,7 @@ pkgs
 pname
 posix
 postrm
+procPath
 ptid
 PTRACE
 Pypi
@@ -133,13 +143,17 @@ stdenv
 subscribetocomponentupdates
 svcuid
 svcuids
+sysfs
+sysPath
 sysv
 tabrmd
 tcti
 tesd
 tesddeploy
+thingName
 tlog
 tmpfiles
+tmpfs
 TPMA
 TPMI
 TPML

--- a/modules/gg-lite-health-daemon/CMakeLists.txt
+++ b/modules/gg-lite-health-daemon/CMakeLists.txt
@@ -1,0 +1,6 @@
+# aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+ggl_init_module(gg-lite-health-daemon LIBS gg-sdk ggl-common core-bus
+                                           core-bus-gg-config)

--- a/modules/gg-lite-health-daemon/bin/gg-lite-health-daemon.c
+++ b/modules/gg-lite-health-daemon/bin/gg-lite-health-daemon.c
@@ -1,0 +1,19 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gg/error.h>
+#include <gg_lite_health_daemon.h>
+#include <ggl/nucleus/init.h>
+
+int main(int argc, char **argv) {
+    (void) argc;
+    (void) argv;
+
+    ggl_nucleus_init();
+
+    GgError ret = run_gg_lite_health_daemon();
+    if (ret != GG_ERR_OK) {
+        return 1;
+    }
+}

--- a/modules/gg-lite-health-daemon/include/gg-lite-health-daemon/config.h
+++ b/modules/gg-lite-health-daemon/include/gg-lite-health-daemon/config.h
@@ -1,0 +1,45 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GG_LITE_HEALTH_DAEMON_CONFIG_H
+#define GG_LITE_HEALTH_DAEMON_CONFIG_H
+
+//! Health daemon configuration
+
+#include <gg/error.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define MAX_EXCLUDE_ENTRIES 16
+#define MAX_EXCLUDE_ENTRY_LEN 64
+#define MAX_PATH_LEN 256
+#define MAX_LABEL_LEN 16
+
+/// Health daemon configuration values.
+typedef struct {
+    /// Output format; currently only "emf" is supported.
+    char output_mode[MAX_LABEL_LEN];
+    /// Directory where EMF metric files are written.
+    char output_directory[MAX_PATH_LEN];
+    /// Seconds between collection cycles.
+    uint32_t collection_interval_sec;
+    /// Path to /proc (overridable for containers).
+    char proc_path[MAX_PATH_LEN];
+    /// Path to /sys (overridable for containers).
+    char sys_path[MAX_PATH_LEN];
+    /// Filesystem types to skip in disk collection (e.g. "tmpfs").
+    char exclude_fstypes[MAX_EXCLUDE_ENTRIES][MAX_EXCLUDE_ENTRY_LEN];
+    size_t exclude_fstype_count;
+    /// Network interfaces to skip (e.g. "lo").
+    char exclude_interfaces[MAX_EXCLUDE_ENTRIES][MAX_EXCLUDE_ENTRY_LEN];
+    size_t exclude_interface_count;
+} HealthDaemonConfig;
+
+/// Initialize config with defaults.
+GgError config_init(HealthDaemonConfig *config);
+
+/// Load config from nucleus core-bus.
+GgError config_load(HealthDaemonConfig *config);
+
+#endif

--- a/modules/gg-lite-health-daemon/include/gg_lite_health_daemon.h
+++ b/modules/gg-lite-health-daemon/include/gg_lite_health_daemon.h
@@ -1,0 +1,15 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GG_LITE_HEALTH_DAEMON_H
+#define GG_LITE_HEALTH_DAEMON_H
+
+//! gg-lite-health-daemon entry point
+
+#include <gg/error.h>
+
+/// Run the health daemon main loop.
+GgError run_gg_lite_health_daemon(void);
+
+#endif

--- a/modules/gg-lite-health-daemon/src/config.c
+++ b/modules/gg-lite-health-daemon/src/config.c
@@ -1,0 +1,124 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gg-lite-health-daemon/config.h"
+#include <gg/arena.h>
+#include <gg/buffer.h>
+#include <gg/error.h>
+#include <gg/list.h>
+#include <gg/log.h>
+#include <gg/object.h>
+#include <gg/types.h>
+#include <ggl/core_bus/gg_config.h>
+#include <string.h>
+#include <stdint.h>
+
+static const HealthDaemonConfig DEFAULT_CONFIG = {
+    .output_mode = "emf",
+    .output_directory = "/var/log/gg-metrics/system-health/",
+    .collection_interval_sec = 60,
+    .proc_path = "/proc",
+    .sys_path = "/sys",
+    .exclude_fstypes = { "tmpfs", "proc", "sysfs", "devtmpfs" },
+    .exclude_fstype_count = 4,
+    .exclude_interfaces = { "lo" },
+    .exclude_interface_count = 1,
+};
+
+GgError config_init(HealthDaemonConfig *config) {
+    *config = DEFAULT_CONFIG;
+    return GG_ERR_OK;
+}
+
+static void copy_buf(GgBuffer src, char *dest, size_t max_len) {
+    if (max_len == 0) {
+        return;
+    }
+    size_t len = (src.len < max_len - 1) ? src.len : max_len - 1;
+    memcpy(dest, src.data, len);
+    dest[len] = '\0';
+}
+
+static GgError read_config_field(
+    const char *field, GgArena *alloc, GgObject *obj
+) {
+    return ggl_gg_config_read(
+        GG_BUF_LIST(
+            GG_STR("services"),
+            GG_STR("aws.greengrass.NucleusLite"),
+            GG_STR("configuration"),
+            GG_STR("healthDaemon"),
+            gg_buffer_from_null_term((char *) field)
+        ),
+        alloc,
+        obj
+    );
+}
+
+static void load_str(const char *field, char *dest, size_t max_len) {
+    uint8_t mem[256];
+    GgArena alloc = gg_arena_init(GG_BUF(mem));
+    GgObject obj;
+    if (read_config_field(field, &alloc, &obj) == GG_ERR_OK
+        && gg_obj_type(obj) == GG_TYPE_BUF) {
+        copy_buf(gg_obj_into_buf(obj), dest, max_len);
+    }
+}
+
+static void load_u32(const char *field, uint32_t *dest) {
+    uint8_t mem[64];
+    GgArena alloc = gg_arena_init(GG_BUF(mem));
+    GgObject obj;
+    if (read_config_field(field, &alloc, &obj) == GG_ERR_OK
+        && gg_obj_type(obj) == GG_TYPE_I64) {
+        int64_t val = gg_obj_into_i64(obj);
+        // Reject zero and negative; only positive values override defaults.
+        if (val > 0 && val <= UINT32_MAX) {
+            *dest = (uint32_t) val;
+        }
+    }
+}
+
+static void load_str_list(
+    const char *field, char dest[][MAX_EXCLUDE_ENTRY_LEN], size_t *count
+) {
+    uint8_t mem[2048];
+    GgArena alloc = gg_arena_init(GG_BUF(mem));
+    GgObject obj;
+    if (read_config_field(field, &alloc, &obj) != GG_ERR_OK
+        || gg_obj_type(obj) != GG_TYPE_LIST) {
+        return;
+    }
+    GgList obj_list = gg_obj_into_list(obj);
+    size_t n = 0;
+    GG_LIST_FOREACH (item, obj_list) {
+        if (n >= MAX_EXCLUDE_ENTRIES) {
+            GG_LOGW("Exclude list full, dropping entry");
+            break;
+        }
+        if (gg_obj_type(*item) == GG_TYPE_BUF) {
+            copy_buf(gg_obj_into_buf(*item), dest[n], MAX_EXCLUDE_ENTRY_LEN);
+            n++;
+        }
+    }
+    *count = n;
+}
+
+GgError config_load(HealthDaemonConfig *config) {
+    load_str("outputMode", config->output_mode, MAX_LABEL_LEN);
+    load_str("outputDirectory", config->output_directory, MAX_PATH_LEN);
+    load_u32("collectionIntervalSec", &config->collection_interval_sec);
+    load_str("procPath", config->proc_path, MAX_PATH_LEN);
+    load_str("sysPath", config->sys_path, MAX_PATH_LEN);
+    load_str_list(
+        "excludeMounts", config->exclude_fstypes, &config->exclude_fstype_count
+    );
+    load_str_list(
+        "excludeInterfaces",
+        config->exclude_interfaces,
+        &config->exclude_interface_count
+    );
+
+    return GG_ERR_OK;
+}

--- a/modules/gg-lite-health-daemon/src/entry.c
+++ b/modules/gg-lite-health-daemon/src/entry.c
@@ -1,0 +1,44 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gg-lite-health-daemon/config.h"
+#include <gg/error.h>
+#include <gg/log.h>
+#include <gg/utils.h>
+#include <gg_lite_health_daemon.h>
+#include <signal.h>
+#include <stddef.h>
+
+static volatile sig_atomic_t running = 1;
+
+static void handle_signal(int sig) {
+    (void) sig;
+    running = 0;
+}
+
+GgError run_gg_lite_health_daemon(void) {
+    GG_LOGI("Started gg-lite-health-daemon.");
+
+    HealthDaemonConfig config;
+    GgError ret = config_init(&config);
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+
+    ret = config_load(&config);
+    if (ret != GG_ERR_OK) {
+        GG_LOGW("Failed to load config, using defaults.");
+    }
+
+    struct sigaction act = { .sa_handler = handle_signal };
+    sigaction(SIGTERM, &act, NULL);
+    sigaction(SIGINT, &act, NULL);
+
+    while (running) {
+        (void) gg_sleep(config.collection_interval_sec);
+    }
+
+    GG_LOGI("Shutting down gg-lite-health-daemon.");
+    return GG_ERR_OK;
+}

--- a/modules/gg-lite-health-daemon/test/test_config.c
+++ b/modules/gg-lite-health-daemon/test/test_config.c
@@ -1,0 +1,39 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// config_load requires a running nucleus (core-bus). Only config_init
+// defaults are tested here. Integration tests cover config_load.
+
+#include "gg-lite-health-daemon/config.h"
+#include <assert.h>
+#include <gg/error.h>
+#include <string.h>
+
+static void test_config_init_defaults(void) {
+    HealthDaemonConfig config;
+    assert(config_init(&config) == GG_ERR_OK);
+
+    assert(strcmp(config.output_mode, "emf") == 0);
+    assert(
+        strcmp(config.output_directory, "/var/log/gg-metrics/system-health/")
+        == 0
+    );
+    assert(config.collection_interval_sec == 60);
+    assert(strcmp(config.proc_path, "/proc") == 0);
+    assert(strcmp(config.sys_path, "/sys") == 0);
+
+    assert(config.exclude_fstype_count == 4);
+    assert(strcmp(config.exclude_fstypes[0], "tmpfs") == 0);
+    assert(strcmp(config.exclude_fstypes[1], "proc") == 0);
+    assert(strcmp(config.exclude_fstypes[2], "sysfs") == 0);
+    assert(strcmp(config.exclude_fstypes[3], "devtmpfs") == 0);
+
+    assert(config.exclude_interface_count == 1);
+    assert(strcmp(config.exclude_interfaces[0], "lo") == 0);
+}
+
+int main(void) {
+    test_config_init_defaults();
+    return 0;
+}

--- a/modules/gg-lite-health-daemon/test/test_main.c
+++ b/modules/gg-lite-health-daemon/test/test_main.c
@@ -1,0 +1,22 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Verify the daemon entry point compiles and links.
+
+#include "gg-lite-health-daemon/config.h"
+#include <assert.h>
+#include <gg/error.h>
+#include <stdio.h>
+
+static void test_config_linkage(void) {
+    HealthDaemonConfig config;
+    assert(config_init(&config) == GG_ERR_OK);
+    assert(config.collection_interval_sec == 60);
+}
+
+int main(void) {
+    test_config_linkage();
+    printf("test_main: all tests passed\n");
+    return 0;
+}

--- a/modules/gg-lite-health-daemon/unit/ggl.core.gg-lite-health-daemon.service.in
+++ b/modules/gg-lite-health-daemon/unit/ggl.core.gg-lite-health-daemon.service.in
@@ -1,0 +1,21 @@
+[Unit]
+StartLimitInterval=20
+StartLimitBurst=10
+PartOf=greengrass-lite.target
+
+[Install]
+WantedBy=greengrass-lite.target
+
+[Service]
+Type=idle
+ExecStart=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/@name@
+Restart=always
+RestartSec=1
+CapabilityBoundingSet=~CAP_SYS_ADMIN ~CAP_SYS_PTRACE
+User=@GGL_SYSTEMD_SYSTEM_USER@
+Group=@GGL_SYSTEMD_SYSTEM_GROUP@
+WorkingDirectory=/var/lib/greengrass
+
+[Unit]
+Description=Core-bus daemon. Collects system health metrics and writes EMF output.
+After=ggl.core.ggconfigd.service


### PR DESCRIPTION
## Description

Add daemon skeleton for gg-lite-health-daemon. Thin main() wrapper calls
`run_gg_lite_health_daemon()` which loads config from NucleusLite core-bus,
sets up SIGTERM/SIGINT handlers, and runs a collection loop sleeping for
`collection_interval_sec` (default 60s).

Follows the fleet-statusd daemon pattern.

- `gg_lite_health_daemon.h` — Public entry point prototype
- `bin/gg-lite-health-daemon.c` — main() with ggl_nucleus_init()
- `src/entry.c` — Config load (non-fatal on failure), signal handling, loop
- `unit/*.service.in` — Systemd service (after ggconfigd, Restart=always)
- `test/test_main.c` — Linkage verification

Depends on #1094 (config interface).

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [x] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [x] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [x] New functionality is covered by tests

## Additional Notes

Second PR in a series for gg-lite-health-daemon. Daemon starts, loads config
from NucleusLite core-bus, and sleeps in a collection loop. Collectors and
EMF output come in subsequent PRs. Tested: builds with GCC in Linux container,
binary runs and logs startup/shutdown correctly.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._