### PR TITLE
Fix subscription leak in iotcored_await_connection

### DIFF
--- a/modules/ggdeploymentd/src/iotcored_instance.c
+++ b/modules/ggdeploymentd/src/iotcored_instance.c
@@ -12,6 +12,7 @@
 #include <gg/log.h>
 #include <gg/utils.h>
 #include <ggl/core_bus/aws_iot_mqtt.h>
+#include <ggl/core_bus/client.h>
 #include <ggl/core_bus/gg_config.h>
 #include <ggl/process.h>
 #include <limits.h>
@@ -162,7 +163,6 @@ GgError iotcored_await_connection(GgBuffer socket_name, uint32_t timeout_s) {
     deadline.tv_sec += timeout_s;
 
     uint32_t sub_handle = 0;
-    GG_CLEANUP(cleanup_ggl_client_sub_close, sub_handle);
 
     while (true) {
         struct timespec now;
@@ -197,6 +197,8 @@ GgError iotcored_await_connection(GgBuffer socket_name, uint32_t timeout_s) {
             }
         }
     }
+
+    ggl_client_sub_close(sub_handle);
 
     if (timed_out) {
         return GG_ERR_FAILURE;


### PR DESCRIPTION
## Description

Consecutive IoT endpoint switch deployments hang on the second switch. The device successfully switches endpoints (HEALTHY in target region), but `ggdeploymentd` never reports terminal status back to the source account — the IoT Job stays `IN_PROGRESS` indefinitely.

The root cause is a subscription leak in `iotcored_await_connection()`. `GG_CLEANUP` captures the initial value of `sub_handle` (0) into a separate cleanup variable. The real handle assigned later via output parameter is never cleaned up. Leaked subscriptions receive events on subsequent endpoint switches, and their callbacks execute with stale stack pointers under `pool->mtx`, causing undefined behavior that permanently locks the mutex.

**Fix:** Remove the broken `GG_CLEANUP` and explicitly call `ggl_client_sub_close(sub_handle)` after the condvar wait, before returning. This closes the subscription with the actual handle value on both success and timeout paths.

## Related Issue

N/A

## Type of Change

   - [x] Bug fix
   - [ ] New feature
   - [ ] Breaking change
   - [ ] Documentation update
   - [ ] Performance improvement
   - [ ] Code refactoring

## Checklist

   - [x] Code passes all the quality test. Can try `nix flake check -L` locally
   - [ ] **Documentation updated** (if applicable)
   - [ ] **Tests added/updated in [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)** (if applicable)

## Documentation Updates

   - [ ] Updated README.md if needed
   - [ ] Updated relevant documentation in `docs/` folder
   - [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

   - [x] Existing tests pass
   - [ ] Added tests to [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
   - [x] New functionality is covered by tests

## Additional Notes

Verified with 4 consecutive endpoint switches (us-east-1 → us-west-2 → us-east-1 → us-west-2 → us-east-1) — all reported `SUCCEEDED` to the source account. Before the fix, the second switch consistently hung with the IoT Job stuck at `IN_PROGRESS`.

   _By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._