### PR TITLE
Avoid overwriting deployment source ARN of non-root components

### DIFF
--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -3274,17 +3274,30 @@ static void handle_deployment(
             return;
         }
 
-        ret = add_arn_list_to_config(
-            gg_kv_key(*pair), deployment->configuration_arn
-        );
-
-        if (ret != GG_ERR_OK) {
-            GG_LOGE(
-                "Failed to write configuration arn of %.*s to ggconfigd.",
-                (int) gg_kv_key(*pair).len,
-                gg_kv_key(*pair).data
+        // Only tag the component with this deployment's configuration ARN if
+        // it is a root component of the current deployment (i.e. explicitly
+        // listed in deployment->components). Components pulled in from other
+        // thing groups or as transitive dependencies retain their original
+        // deployment source ARN, preventing this deployment from clobbering
+        // another deployment's ownership record.
+        GgObject *component_in_deployment;
+        if (gg_map_get(
+                deployment->components,
+                gg_kv_key(*pair),
+                &component_in_deployment
+            )) {
+            ret = add_arn_list_to_config(
+                gg_kv_key(*pair), deployment->configuration_arn
             );
-            return;
+
+            if (ret != GG_ERR_OK) {
+                GG_LOGE(
+                    "Failed to write configuration arn of %.*s to ggconfigd.",
+                    (int) gg_kv_key(*pair).len,
+                    gg_kv_key(*pair).data
+                );
+                return;
+            }
         }
 
         ret = apply_configurations(


### PR DESCRIPTION
- handle_deployment called add_arn_list_to_config for every resolved component, overwriting the source ARN of components owned by other deployments (cross-group or transitive dependencies).

- Guard the call so only root components of the current deployment get their ARN list updated.

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #1092 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [x] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
