### PR TITLE
Suppress ggconfigd subscriber notifications on unchanged writes

### DIFF
--- a/modules/ggconfigd/src/db_interface.c
+++ b/modules/ggconfigd/src/db_interface.c
@@ -39,6 +39,10 @@ static inline void cleanup_sqlite3_finalize(sqlite3_stmt **p) {
 static bool config_initialized = false;
 static sqlite3 *config_database;
 static const char *config_database_name = "config.db";
+
+static GgError read_value_at_key(
+    int64_t key_id, GgObject *value, GgArena *alloc
+);
 static const char *config_backup_name = "config.db.backup";
 
 static void sqlite_logger(void *ctx, int err_code, const char *str) {
@@ -842,6 +846,24 @@ GgError ggconfig_write_value_at_key(
         return GG_ERR_OK;
     }
 
+    // Check if the stored value is byte-identical to the incoming one.
+    // Both are JSON-encoded, so buffer compare is sufficient. The update still
+    // proceeds (to refresh the timestamp), but notifications are suppressed
+    // when the value didn't actually change.
+    bool value_unchanged = false;
+    {
+        GgObject existing_value;
+        uint8_t existing_mem[GGCONFIGD_MAX_OBJECT_DECODE_BYTES];
+        GgArena existing_alloc = gg_arena_init(GG_BUF(existing_mem));
+        if (read_value_at_key(last_key_id, &existing_value, &existing_alloc)
+                == GG_ERR_OK
+            && gg_obj_type(existing_value) == GG_TYPE_BUF) {
+            if (gg_buffer_eq(gg_obj_into_buf(existing_value), *value)) {
+                value_unchanged = true;
+            }
+        }
+    }
+
     err = value_update(last_key_id, value, timestamp);
     if (err != GG_ERR_OK) {
         GG_LOGE(
@@ -855,6 +877,14 @@ GgError ggconfig_write_value_at_key(
         return err;
     }
     sqlite3_exec(config_database, "END TRANSACTION", NULL, NULL, NULL);
+
+    if (value_unchanged) {
+        GG_LOGD(
+            "key %s value unchanged; skipping subscriber notification",
+            print_key_path(key_path)
+        );
+        return GG_ERR_OK;
+    }
 
     err = notify_nested_key(key_path, ids);
     if (err != GG_ERR_OK) {


### PR DESCRIPTION
ggconfig_write_value_at_key notified subscribers on every write, even when the new value was byte-identical to the stored one, producing redundant IPC traffic.

Compare the stored buffer to the incoming one with gg_buffer_eq before notifying. Both are JSON-encoded, so a bytewise compare covers all value types. The update still proceeds to refresh the timestamp; only notify_nested_key is skipped.

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #1017

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
