### PR TITLE
Suppress ggconfigd subscriber notifications on unchanged writes

### DIFF
--- a/docs/design/ggconfigd.md
+++ b/docs/design/ggconfigd.md
@@ -206,8 +206,10 @@ Some options for implementing notification grouping are:
 If a value is written to the config, but its value doesn't change (although the
 timestamp may be updated), there is no reason that a subscriber cares about this
 event. Removing notifications for these events helps prevent unnecessary
-notifications and reactions to unnecessary notifications. Currently we don't
-have this suppression functionality, but it could be added in the future.
+notifications and reactions to unnecessary notifications. Writes compare the
+stored value against the incoming one and skip the notification when they match.
+The timestamp still gets refreshed. Since values are stored as JSON-encoded
+bytes, a byte compare is enough.
 
 This also applies to the `restore` operation, which currently notifies all
 active subscribers regardless of whether their key's value actually changed

--- a/modules/ggconfigd/src/db_interface.c
+++ b/modules/ggconfigd/src/db_interface.c
@@ -842,6 +842,51 @@ GgError ggconfig_write_value_at_key(
         return GG_ERR_OK;
     }
 
+    // Check if the stored value is byte-identical to the incoming one.
+    // Both are JSON-encoded, so buffer compare is sufficient. The update still
+    // proceeds (to refresh the timestamp), but notifications are suppressed
+    // when the value didn't actually change. The pointer returned by
+    // sqlite3_column_text is owned by sqlite and remains valid until the
+    // statement is finalized, which GG_CLEANUP handles at scope exit, so
+    // comparing against it in place avoids an arena allocation and memcpy.
+    bool value_unchanged = false;
+    {
+        sqlite3_stmt *stmt = NULL;
+        int rc = sqlite3_prepare_v2(
+            config_database, GGL_SQL_READ_VALUE, -1, &stmt, NULL
+        );
+        if (rc != SQLITE_OK) {
+            GG_LOGE(
+                "Failed to prepare read-value statement for key id %" PRId64
+                " with rc %d and error %s",
+                last_key_id,
+                rc,
+                sqlite3_errmsg(config_database)
+            );
+        } else {
+            // Register cleanup immediately so the statement is finalized
+            // on any exit path below.
+            GG_CLEANUP(cleanup_sqlite3_finalize, stmt);
+            sqlite3_bind_int64(stmt, 1, last_key_id);
+            rc = sqlite3_step(stmt);
+            if (rc != SQLITE_ROW) {
+                GG_LOGE(
+                    "Failed to read existing value for key id %" PRId64
+                    " with rc %d and error %s",
+                    last_key_id,
+                    rc,
+                    sqlite3_errmsg(config_database)
+                );
+            } else {
+                GgBuffer existing = {
+                    .data = (uint8_t *) sqlite3_column_text(stmt, 0),
+                    .len = (size_t) sqlite3_column_bytes(stmt, 0),
+                };
+                value_unchanged = gg_buffer_eq(existing, *value);
+            }
+        }
+    }
+
     err = value_update(last_key_id, value, timestamp);
     if (err != GG_ERR_OK) {
         GG_LOGE(
@@ -855,6 +900,14 @@ GgError ggconfig_write_value_at_key(
         return err;
     }
     sqlite3_exec(config_database, "END TRANSACTION", NULL, NULL, NULL);
+
+    if (value_unchanged) {
+        GG_LOGD(
+            "key %s value unchanged; skipping subscriber notification",
+            print_key_path(key_path)
+        );
+        return GG_ERR_OK;
+    }
 
     err = notify_nested_key(key_path, ids);
     if (err != GG_ERR_OK) {


### PR DESCRIPTION
- ggconfig_write_value_at_key notified subscribers on every write, even when the new value was byte-identical to the stored one, producing redundant IPC traffic.

- Compare the stored buffer to the incoming one with gg_buffer_eq before notifying. Both are JSON-encoded, so a bytewise compare covers all value types. The update still proceeds to refresh the timestamp; only notify_nested_key is skipped.

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #1017 #961

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] Code passes all the quality test. Can try `nix flake check -L` locally
- [x] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [x] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [x] Existing tests pass
- [x] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
 - https://github.com/aws-greengrass/aws-greengrass-testing/pull/304
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
