### PR TITLE
Fix HTTP error retry and fd offset after truncate

### DIFF
--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -437,7 +437,8 @@ static GgError retry_download_wrapper(void *ctx) {
     if (http_response_code == (uint16_t) 403) {
         GgError err = retry_ctx->retry_cleanup_fn(retry_ctx->response_data);
         GG_LOGE(
-            "Artifact download attempt failed with 403. Retrying with backoff."
+            "Artifact download attempt failed with HTTP %d. Retrying with backoff.",
+            http_response_code
         );
         if (err != GG_ERR_OK) {
             retry_ctx->err = err;
@@ -446,10 +447,7 @@ static GgError retry_download_wrapper(void *ctx) {
         return GG_ERR_FAILURE;
     }
     if (ret != GG_ERR_OK) {
-        GG_LOGE(
-            "Artifact download attempt failed due to error: %d", ret
-
-        );
+        GG_LOGE("Artifact download attempt failed due to error: %d", ret);
         retry_ctx->err = ret;
         return GG_ERR_OK;
     }
@@ -458,8 +456,8 @@ static GgError retry_download_wrapper(void *ctx) {
     return GG_ERR_OK;
 }
 
-// TODO: Refactor to delete the file and get the new fd instead of truncating
-// the file
+// TODO: Consider refactoring to close and reopen the file instead of
+// truncating in place.
 static GgError truncate_s3_file_on_failure(void *response_data) {
     int fd = *(int *) response_data;
 
@@ -470,6 +468,10 @@ static GgError truncate_s3_file_on_failure(void *response_data) {
 
     if (ret == -1) {
         GG_LOGE("Failed to truncate fd for write (errno=%d).", errno);
+        return GG_ERR_FAILURE;
+    }
+    if (lseek(fd, 0, SEEK_SET) == -1) {
+        GG_LOGE("Failed to seek fd to beginning (errno=%d).", errno);
         return GG_ERR_FAILURE;
     }
     return GG_ERR_OK;

--- a/modules/ggl-http/src/gghttp_util.c
+++ b/modules/ggl-http/src/gghttp_util.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 #define MAX_HEADER_LENGTH 8192
@@ -63,8 +64,9 @@ static GgError translate_curl_code(CURLcode code) {
 
 static bool can_retry(CURLcode code, CurlData *data) {
     switch (code) {
-    // If OK, then inspect HTTP status code.
+    // If OK or FAILONERROR fired, inspect HTTP status code.
     case CURLE_OK:
+    case CURLE_HTTP_RETURNED_ERROR:
         break;
 
     case CURLE_OPERATION_TIMEDOUT:
@@ -129,6 +131,10 @@ static GgError truncate_file(void *response_data) {
 
     if (ret == -1) {
         GG_LOGE("Failed to truncate fd for write (errno=%d).", errno);
+        return GG_ERR_FAILURE;
+    }
+    if (lseek(fd, 0, SEEK_SET) == -1) {
+        GG_LOGE("Failed to seek fd to beginning (errno=%d).", errno);
         return GG_ERR_FAILURE;
     }
     return GG_ERR_OK;


### PR DESCRIPTION
- Fix can_retry to handle CURLE_HTTP_RETURNED_ERROR from FAILONERROR, allowing existing HTTP status code retry logic (5xx, 429, etc.) to actually execute. Previously this was dead code.
- Fix ftruncate without lseek in both truncate helpers, preventing corrupt artifacts when retrying after partial writes.
- Improve 403 retry log message to include the HTTP status code.

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number) or N/A if not applicable

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
