### PR TITLE
Rewrite design overview to match current code

### DIFF
--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -1,38 +1,88 @@
 # Greengrass Nucleus Lite Design Overview
 
-Greengrass Nucleus Lite is designed as a group of daemons with each daemon
-providing specific functionality. Daemons are intended to be small single
-purpose executables that enable a system to be composable by daemon selection.
+Greengrass nucleus lite is a collection of small systemd-managed daemons that
+implement the AWS IoT Greengrass v2 runtime for resource-constrained Linux
+devices. Daemons are intended to be small single-purpose executables that enable
+a system to be composable by daemon selection.
 
 ## Daemon List
 
-GG Daemons are small programs that run to provide a specific functionality to
-greengrass.
+Each daemon is a standalone binary under `modules/<name>/bin/`. Daemons that
+serve a core-bus interface listen on a Unix socket at
+`/run/greengrass/<interface>`.
 
-| Daemon           | Provided functionality                                                                                   |
-| ---------------- | -------------------------------------------------------------------------------------------------------- |
-| gghealthd        | Collect GG daemon health information from the Platform and provide the information to the GG system      |
-| ggconfigd        | Provide an interface to the configuration system that is accessable to all other GG components           |
-| ggdeploymentd    | Executes a deployment that has been submitted to the deployment queue                                    |
-| ggipcd           | Provides the legacy IPC interface to generic components and routes the IPC commands to suitable handlers |
-| ggpubsubd        | Provides the local publish/subscribe interface between components                                        |
-| iotcored         | Provides the MQTT interface to IoT Core                                                                  |
-| gg-fleet-statusd | Produces status reports about all running GG components and sends the reports to IoT Core.               |
-
-Please review the daemons specific documentation for more information on each
-daemon.
+| Daemon               | Core-bus interface | Purpose                                                                                                     |
+| -------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `ggconfigd`          | `gg_config`        | SQLite-backed hierarchical configuration store                                                              |
+| `iotcored`           | `aws_iot_mqtt`     | MQTT connection to AWS IoT Core (coreMQTT-based)                                                            |
+| `tesd`               | `aws_iot_tes`      | Token Exchange Service — fetches temporary AWS credentials via IoT credential provider                      |
+| `tes-serverd`        | N/A                | Container-credentials HTTP endpoint for AWS SDKs inside components                                          |
+| `ggdeploymentd`      | `gg_deployment`    | Deployment engine — processes cloud and local deployments                                                   |
+| `gghealthd`          | `gg_health`        | Component lifecycle and health status via systemd sd-bus                                                    |
+| `ggpubsubd`          | `gg_pubsub`        | Local publish/subscribe message bus between components                                                      |
+| `gg-fleet-statusd`   | `gg_fleet_status`  | Publishes fleet status reports to IoT Core                                                                  |
+| `ggipcd`             | N/A                | Translates GGv2 IPC protocol from components into core-bus calls                                            |
+| `fleet-provisioning` | N/A                | Runs AWS Fleet Provisioning flow to register a device, then exits                                           |
+| `recipe-runner`      | N/A                | Per-component helper invoked by systemd; expands recipe-script placeholders and execs the component process |
+| `ggl-cli`            | N/A                | User-facing CLI for local deployments and management                                                        |
 
 ## Libraries List
 
-GG libraries are functions that get linked with daemons to provide the common
-behaviors needed by all GG daemons. One example is interfacing the the GG
-coreBus.
+Libraries are non-daemon modules linked into daemons to provide shared
+functionality.
 
-| Library     | Provided functionality                                                                           |
-| ----------- | ------------------------------------------------------------------------------------------------ |
-| ggl-lib     | General datatypes and the corebus interface for communications between GGL components            |
-| ggl-json    | A basic JSON interface for conversion to/from JSON & corebus datatypes                           |
-| ggl-process | A Linux interface library for process lifecycle management: spawning, waiting, and killing.      |
-| ggl-http    | A library to use HTTP to fetch a token and download a file. Suitable for S3 downloads.           |
-| ggl-yaml    | A basic YAML interface for conversion to/from YAML and corebus datatypes                         |
-| ggl-file    | A library for basic file operations needed for component installation and deployment operations. |
+### Core infrastructure
+
+| Module              | Purpose                                                                   |
+| ------------------- | ------------------------------------------------------------------------- |
+| `ggl-common`        | Nucleus initialization (`ggl_nucleus_init`), version logging              |
+| `ggl-constants`     | Nucleus-wide compile-time constants                                       |
+| `core-bus`          | Core-bus client and server: RPC call, notify, subscribe over Unix sockets |
+| `ggl-socket-server` | Unix socket pool with generational indices; systemd socket activation     |
+| `ggipc-auth`        | GG-IPC peer authentication — maps systemd unit PID to component name      |
+
+### Core-bus interface wrappers
+
+Thin client libraries for each daemon's RPC surface.
+
+| Module                  | Purpose                                                                                     |
+| ----------------------- | ------------------------------------------------------------------------------------------- |
+| `core-bus-gg-config`    | Client wrapper for `gg_config` RPCs (read, write, list, delete, subscribe, backup, restore) |
+| `core-bus-aws-iot-mqtt` | Client wrapper for `aws_iot_mqtt` RPCs (publish, subscribe, connection_status)              |
+| `core-bus-gghealthd`    | Client wrapper for `gg_health` RPCs                                                         |
+| `core-bus-sub-response` | Utility: subscribe and collect the first response synchronously                             |
+
+### Data and serialization
+
+| Module       | Purpose                                                  |
+| ------------ | -------------------------------------------------------- |
+| `ggl-json`   | JSON Pointer (RFC 6901) parsing into config key paths    |
+| `ggl-yaml`   | YAML (libyaml) to `GgObject` conversion                  |
+| `ggl-zip`    | libzip wrapper for unpacking component artifact archives |
+| `ggl-uri`    | Generic URI parsing and Docker image URI parsing         |
+| `ggl-semver` | Semver version comparison and requirement matching       |
+
+### System and process integration
+
+| Module                  | Purpose                                                                |
+| ----------------------- | ---------------------------------------------------------------------- |
+| `ggl-process`           | Process spawn, call, wait, and kill helpers                            |
+| `ggl-binpath`           | Derive sibling binary path from `argv[0]`                              |
+| `ggl-proxy-environment` | Reads `networkProxy` config and sets `https_proxy`/`no_proxy` env vars |
+
+### AWS integration
+
+| Module              | Purpose                                                                                 |
+| ------------------- | --------------------------------------------------------------------------------------- |
+| `ggl-http`          | libcurl wrapper for token fetch, S3 SigV4 download, generic download, ECR auth          |
+| `aws-iot-call`      | MQTT request/response pattern with `clientToken` correlation                            |
+| `aws-sigv4`         | Wrapper around the AWS SigV4 SDK                                                        |
+| `core_mqtt`         | Wrapper around FreeRTOS coreMQTT with project config                                    |
+| `ggl-docker-client` | Docker CLI wrapper for pulling, managing, and authenticating Docker-artifact components |
+
+### Recipe handling
+
+| Module        | Purpose                                                                     |
+| ------------- | --------------------------------------------------------------------------- |
+| `ggl-recipe`  | Parse GG component recipes (YAML to structured map with platform selectors) |
+| `recipe2unit` | Generate systemd unit files from component recipes                          |


### PR DESCRIPTION
The previous docs/design/overview.md dated from an early iteration of the codebase: it listed only 7 daemons and 6 libraries, with several library names that no longer exist (ggl-lib, ggl-file).

Rewrite as an as-built description:

- Daemon table now covers all 12 binaries under modules/*/bin/, each with its core-bus interface name (or standalone/HTTP/client label) verified against ggl_listen() call sites.
- Library table groups the 24 non-daemon modules by role (core infrastructure, core-bus wrappers, data/serialization, system/process integration, AWS integration, recipe handling).

Component-interaction diagrams and systemd orchestration details are deferred to the architecture-level doc rather than repeated in this overview.

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number) or N/A if not applicable

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
