### PR TITLE
Use lowercase 'nucleus lite' in prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ feature gap.
 ## Getting started
 
 See the [build guide](docs/BUILD.md) for instructions to build and install
-Greengrass Nucleus Lite from source.
+Greengrass nucleus lite from source.
 
-To configure and run Greengrass Nucleus Lite, see the
+To configure and run Greengrass nucleus lite, see the
 [setup guide](docs/SETUP.md).
 
 For setting up as a Greengrass developer, also see the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,7 @@ This release contains the following bug fixes:
 
 # Release Notes v2.5.0
 
-- Use of AWS Greengrass Nucleus Lite with HSMs using PKCS#11 is now supported.
+- Use of AWS Greengrass nucleus lite with HSMs using PKCS#11 is now supported.
   PKCS#11 backed key/cert handles can now be used and will be passed to OpenSSL
   to allow handling by system configured OpenSSL Providers.
 - TPM backed keys can now be used with fleet provisioning.
@@ -138,7 +138,7 @@ https://docs.aws.amazon.com/greengrass/v2/developerguide/run-docker-container.ht
 
 # Release Notes v2.1.0
 
-This release includes HTTP proxy support for the AWS Greengrass Nucleus Lite
+This release includes HTTP proxy support for the AWS Greengrass nucleus lite
 runtime.
 
 ## New with this release

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Greengrass Nucleus Lite Developer setup
 
-This guide is for developers working on the Greengrass Nucleus Lite codebase to
+This guide is for developers working on the Greengrass nucleus lite codebase to
 set up.
 
 ## Using Nix

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,6 +1,6 @@
 # Setting up Greengrass nucleus lite
 
-See the [build guide](BUILD.md) to compile and install Greengrass Nucleus Lite.
+See the [build guide](BUILD.md) to compile and install Greengrass nucleus lite.
 If running locally for evaluation, you can use the provided container to install
 in its own environment.
 
@@ -94,7 +94,7 @@ cp ./config.yaml /etc/greengrass/config.yaml
 
 ## Running the nucleus
 
-To enable and run all the Greengrass Nucleus Lite core services for testing, run
+To enable and run all the Greengrass nucleus lite core services for testing, run
 the `run_nucleus` script available in the source directory.
 
 ```sh
@@ -108,11 +108,11 @@ Entire system logs can be viewed with `journalctl -a`. Individual service logs
 can be viewed with `journalctl -a -t <service-name>` (e.g.
 `journalctl -a -t ggdeploymentd` to view deployment logs).
 
-To stop Greengrass Nucleus Lite run `systemctl stop greengrass-lite.target`
+To stop Greengrass nucleus lite run `systemctl stop greengrass-lite.target`
 
 ## Performing a local deployment
 
-To do a local deployment with the Greengrass Nucleus Lite CLI, you will need a
+To do a local deployment with the Greengrass nucleus lite CLI, you will need a
 directory with the component's recipe and a directory with the component's
 artifacts. See the Greengrass component documentation for writing your own
 Greengrass component.

--- a/docs/design/iotcored.md
+++ b/docs/design/iotcored.md
@@ -29,4 +29,4 @@ The daemon requires configuration for connecting to AWS IoT Core, including the
 endpoint and device credentials.
 
 These may be passed as command line parameters; if they are not the values will
-be pulled from the Greengrass Nucleus Lite config library.
+be pulled from the Greengrass nucleus lite config library.

--- a/docs/design/tes-http-serverd/tes-http-serverd.md
+++ b/docs/design/tes-http-serverd/tes-http-serverd.md
@@ -8,7 +8,7 @@
 ## Overview
 
 The `tes-http-serverd` service daemon is a light-weight generic HTTP server for
-Greengrass Nucleus Lite which main purpose is to host a credential provider
+Greengrass nucleus lite which main purpose is to host a credential provider
 endpoint (on the provided or default server port) for other processes and the
 AWS SDK to make an HTTP request to. If the incoming HTTP request is
 authenticated and accepted, the TES HTTP server will provide a temporary session
@@ -66,7 +66,7 @@ can make a request to this endpoint.
 #### Authorization
 
 Requests made to the `tes-http-serverd` service requires the authorization token
-which is generated at startup of the Greengrass Nucleus Lite host orchestration.
+which is generated at startup of the Greengrass nucleus lite host orchestration.
 The environment variable `AWS_CONTAINER_AUTHORIZATION_TOKEN` will be exported to
 the system and enable the AWS SDK Client and other processes to connected to the
 HTTP server successfully. Connections with an invalid authorization token will

--- a/docs/spec/executable/teshttpserverd.md
+++ b/docs/spec/executable/teshttpserverd.md
@@ -30,7 +30,7 @@ The following is the current daemon implementation flow:
 ### AWS_CONTAINER_AUTHORIZATION_TOKEN
 
 - Authorization token which is used to connected to the Token Exchange Service
-  server hosted on `AWS_CONTAINER_CREDENTIALS_FULL_URI`. Greengrass Nucleus Lite
+  server hosted on `AWS_CONTAINER_CREDENTIALS_FULL_URI`. Greengrass nucleus lite
   will export this variable for example the AWS SDK to use.
 
 ### AWS_CONTAINER_CREDENTIALS_FULL_URI

--- a/modules/ggconfigd/bin/ggconfigd.c
+++ b/modules/ggconfigd/bin/ggconfigd.c
@@ -9,7 +9,7 @@
 #include <ggl/nucleus/init.h>
 #include <stdlib.h>
 
-static char doc[] = "ggconfigd -- Greengrass Nucleus Lite configuration daemon";
+static char doc[] = "ggconfigd -- Greengrass nucleus lite configuration daemon";
 
 static struct argp_option opts[] = {
     { "config-file", 'c', "path", 0, "Configuration file to use", 0 },

--- a/modules/ggdeploymentd/bin/ggdeploymentd.c
+++ b/modules/ggdeploymentd/bin/ggdeploymentd.c
@@ -13,7 +13,7 @@
 #include <stdbool.h>
 
 static char doc[]
-    = "ggdeploymentd -- Greengrass Nucleus Lite deployment daemon";
+    = "ggdeploymentd -- Greengrass nucleus lite deployment daemon";
 
 static struct argp_option opts[] = {
     { 0 },

--- a/modules/ggdeploymentd/unit/ggl.core.ggdeploymentd.service.in
+++ b/modules/ggdeploymentd/unit/ggl.core.ggdeploymentd.service.in
@@ -18,5 +18,5 @@ CapabilityBoundingSet=~CAP_SYS_PTRACE
 WorkingDirectory=/var/lib/greengrass
 
 [Unit]
-Description=Greengrass Nucleus Lite deployment queue and processor
+Description=Greengrass nucleus lite deployment queue and processor
 After=ggl.core.ggconfigd.service


### PR DESCRIPTION
Align the product name casing in prose with the design overview doc. Keep H1 headings in Title Case.

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number) or N/A if not applicable

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
