### PR TITLE
Redeploy components on config change

### DIFF
--- a/modules/ggdeploymentd/src/component_config.c
+++ b/modules/ggdeploymentd/src/component_config.c
@@ -15,6 +15,7 @@
 #include <gg/vector.h>
 #include <ggl/core_bus/gg_config.h>
 #include <ggl/json_pointer.h>
+#include <stdbool.h>
 #include <stddef.h>
 
 static GgError apply_reset_config(
@@ -239,4 +240,26 @@ GgError apply_configurations(
     }
 
     return GG_ERR_OK;
+}
+
+bool is_component_config_updated(
+    GglDeployment *deployment, GgBuffer component_name
+) {
+    GgObject *doc_component_info;
+    if (!gg_map_get(
+            deployment->components, component_name, &doc_component_info
+        )) {
+        return false;
+    }
+    if (gg_obj_type(*doc_component_info) != GG_TYPE_MAP) {
+        return false;
+    }
+    if (!gg_map_get(
+            gg_obj_into_map(*doc_component_info),
+            GG_STR("configurationUpdate"),
+            NULL
+        )) {
+        return false;
+    }
+    return true;
 }

--- a/modules/ggdeploymentd/src/component_config.h
+++ b/modules/ggdeploymentd/src/component_config.h
@@ -8,9 +8,14 @@
 #include "deployment_model.h"
 #include <gg/error.h>
 #include <gg/types.h>
+#include <stdbool.h>
 
 GgError apply_configurations(
     GglDeployment *deployment, GgBuffer component_name, GgBuffer operation
+);
+
+bool is_component_config_updated(
+    GglDeployment *deployment, GgBuffer component_name
 );
 
 #endif

--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -3463,7 +3463,8 @@ static void handle_deployment(
             return;
         }
 
-        if (component_updated) {
+        if (component_updated
+            || is_component_config_updated(deployment, gg_kv_key(*pair))) {
             ret = gg_kv_vec_push(
                 &components_to_deploy, gg_kv(gg_kv_key(*pair), *gg_kv_val(pair))
             );


### PR DESCRIPTION
## Description

Restarting components on deployment configuration update provides a mechanism to keep simple components (ones that don't use IPC) to receive those updates. This new restart pattern matches current V2 behavior.

## Related Issue

Fixes #769

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [x] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
