### PR TITLE
Derive FSS messageType from trigger

### DIFF
--- a/docs/spec/executable/gg-fleet-statusd.md
+++ b/docs/spec/executable/gg-fleet-statusd.md
@@ -15,6 +15,9 @@ See docs at
   reconnection.
 - [fss-6] The service reads periodic update interval from configuration.
 - [fss-7] The service initializes default configuration values at startup.
+- [fss-8] The `messageType` field of published updates is derived from the
+  trigger: `NUCLEUS_LAUNCH`, `CADENCE`, and `NETWORK_RECONFIGURE` produce
+  `COMPLETE`; the remaining listed triggers produce `PARTIAL`.
 
 ## CLI parameters
 
@@ -56,8 +59,12 @@ to send a fleet status update to IoT Core.
     - `THING_GROUP_DEPLOYMENT`
     - `COMPONENT_STATUS_CHANGE`
     - `RECONNECT`
-    - `LAUNCH`
+    - `NUCLEUS_LAUNCH`
+    - `CADENCE`
     - `NETWORK_RECONFIGURE`
+  - [gg-fleet-statusd-send_fleet_status_update-1.3] Trigger values outside the
+    listed set are rejected; the call returns an error and no update is
+    published.
 - [gg-fleet-statusd-send_fleet_status_update-2] `deployment_info` is a required
   parameter of type map
   - [gg-fleet-statusd-send_fleet_status_update-2.1] `deployment_info` includes a

--- a/modules/gg-fleet-statusd/src/fleet_status_service.c
+++ b/modules/gg-fleet-statusd/src/fleet_status_service.c
@@ -52,11 +52,38 @@ static const GgBuffer ARCHITECTURE =
     { 0 };
 #endif
 
+static GgError derive_message_type(
+    GgBuffer trigger, GgBuffer *out_message_type
+) {
+    if (gg_buffer_eq(trigger, GG_STR("NUCLEUS_LAUNCH"))
+        || gg_buffer_eq(trigger, GG_STR("CADENCE"))
+        || gg_buffer_eq(trigger, GG_STR("NETWORK_RECONFIGURE"))) {
+        *out_message_type = GG_STR("COMPLETE");
+        return GG_ERR_OK;
+    }
+    if (gg_buffer_eq(trigger, GG_STR("RECONNECT"))
+        || gg_buffer_eq(trigger, GG_STR("LOCAL_DEPLOYMENT"))
+        || gg_buffer_eq(trigger, GG_STR("THING_DEPLOYMENT"))
+        || gg_buffer_eq(trigger, GG_STR("THING_GROUP_DEPLOYMENT"))
+        || gg_buffer_eq(trigger, GG_STR("COMPONENT_STATUS_CHANGE"))) {
+        *out_message_type = GG_STR("PARTIAL");
+        return GG_ERR_OK;
+    }
+    GG_LOGE("Invalid FSS trigger '%.*s'", (int) trigger.len, trigger.data);
+    return GG_ERR_INVALID;
+}
+
 // TODO: Split this function up
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 GgError publish_fleet_status_update(
     GgBuffer thing_name, GgBuffer trigger, GgMap deployment_info
 ) {
+    GgBuffer message_type;
+    GgError ret = derive_message_type(trigger, &message_type);
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+
     static pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
     GG_MTX_SCOPE_GUARD(&mtx);
 
@@ -70,7 +97,7 @@ GgError publish_fleet_status_update(
 
     // retrieve running components from services config
     GgList components;
-    GgError ret = ggl_gg_config_list(
+    ret = ggl_gg_config_list(
         GG_BUF_LIST(GG_STR("services")), &alloc, &components
     );
     if (ret != GG_ERR_OK) {
@@ -279,7 +306,7 @@ GgError publish_fleet_status_update(
         gg_kv(GG_STR("thing"), gg_obj_buf(thing_name)),
         gg_kv(GG_STR("sequenceNumber"), gg_obj_i64(sequence)),
         gg_kv(GG_STR("timestamp"), gg_obj_i64(timestamp)),
-        gg_kv(GG_STR("messageType"), gg_obj_buf(GG_STR("COMPLETE"))),
+        gg_kv(GG_STR("messageType"), gg_obj_buf(message_type)),
         gg_kv(GG_STR("trigger"), gg_obj_buf(trigger)),
         gg_kv(GG_STR("overallDeviceStatus"), gg_obj_buf(overall_device_status)),
         gg_kv(GG_STR("components"), gg_obj_list(component_statuses.list)),


### PR DESCRIPTION
The Fleet Status Service was hardcoding messageType to "COMPLETE" for all published updates. The cloud-side service uses messageType to distinguish full state snapshots from event-driven updates, and specifically only emits EventBridge events for "PARTIAL" messages. This means lite messages were silently routed as full-snapshot updates, blocking any EventBridge consumers from triggering on lite-side deployment terminals or reconnects.

Derive messageType from the trigger via the same lookup nucleus uses:
- NUCLEUS_LAUNCH, CADENCE, NETWORK_RECONFIGURE -> COMPLETE
- RECONNECT, LOCAL_DEPLOYMENT, THING_DEPLOYMENT, THING_GROUP_DEPLOYMENT, COMPONENT_STATUS_CHANGE -> PARTIAL

Unrecognized trigger values cause the publish to fail with GG_ERR_INVALID and an error log, matching nucleus's "throw on unknown" behavior.

Also update the gg-fleet-statusd spec:
- fix LAUNCH (never matched the code) to NUCLEUS_LAUNCH and add CADENCE to the trigger list
- document messageType derivation (fss-8)
- document that unrecognized trigger values are rejected (1.3)

Changes were tested by setting up a Greengrass V2 Effective Deployment Status Change EventBridge rule, sending a deployment to a device, and observing that the deployment triggered the rule. When testing on main without these changes, the rule was not triggered.

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number) or N/A if not applicable

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
