### PR TITLE
Fix IoT Job ID overwrite on concurrent notify-next

### DIFF
--- a/modules/ggdeploymentd/src/bus_server.c
+++ b/modules/ggdeploymentd/src/bus_server.c
@@ -26,7 +26,9 @@ static GgError create_local_deployment(
 
     GgByteVec id = GG_BYTE_VEC((uint8_t[36]) { 0 });
 
-    GgError ret = ggl_deployment_enqueue(params, &id, LOCAL_DEPLOYMENT);
+    GgError ret = ggl_deployment_enqueue(
+        params, &id, (GgBuffer) { 0 }, LOCAL_DEPLOYMENT
+    );
     if (ret != GG_ERR_OK) {
         return ret;
     }

--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -2748,8 +2748,11 @@ static void report_endpoint_switch_status_to_source(
     PublishToSourceCtx pub_ctx = { .deployment_id = deployment_id };
     ret = gg_backoff(1000, 60000, 8, report_success_to_source, &pub_ctx);
     if (ret != GG_ERR_OK) {
-        GG_LOGW("Failed to report SUCCEEDED to source account; "
-                "source IoT Job will time out.");
+        GG_LOGW(
+            "Failed to report SUCCEEDED to source account (%s); "
+            "source IoT Job will time out.",
+            gg_strerror(ret)
+        );
     } else {
         GG_LOGI("Reported SUCCEEDED to source account.");
     }
@@ -4053,6 +4056,8 @@ static GgError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
         if (ret != GG_ERR_OK) {
             return ret;
         }
+
+        set_current_job(deployment->iot_job_id, deployment->deployment_id);
 
         GG_LOGI("Processing incoming deployment.");
 

--- a/modules/ggdeploymentd/src/deployment_model.h
+++ b/modules/ggdeploymentd/src/deployment_model.h
@@ -28,6 +28,7 @@ typedef enum {
 
 typedef struct {
     GgBuffer deployment_id;
+    GgBuffer iot_job_id;
     GgBuffer recipe_directory_path;
     GgBuffer artifacts_directory_path;
     GgBuffer configuration_arn;

--- a/modules/ggdeploymentd/src/deployment_queue.c
+++ b/modules/ggdeploymentd/src/deployment_queue.c
@@ -81,6 +81,15 @@ GgError deep_copy_deployment(GglDeployment *deployment, GgArena *alloc) {
     }
     deployment->deployment_id = gg_obj_into_buf(obj);
 
+    if (deployment->iot_job_id.len > 0) {
+        obj = gg_obj_buf(deployment->iot_job_id);
+        ret = gg_arena_claim_obj(&obj, alloc);
+        if (ret != GG_ERR_OK) {
+            return ret;
+        }
+        deployment->iot_job_id = gg_obj_into_buf(obj);
+    }
+
     ret = null_terminate_buffer(&deployment->recipe_directory_path, alloc);
     if (ret != GG_ERR_OK) {
         return ret;
@@ -439,7 +448,10 @@ static GgError parse_deployment_obj(
 }
 
 GgError ggl_deployment_enqueue(
-    GgMap deployment_doc, GgByteVec *id, GglDeploymentType type
+    GgMap deployment_doc,
+    GgByteVec *id,
+    GgBuffer iot_job_id,
+    GglDeploymentType type
 ) {
     GG_MTX_SCOPE_GUARD(&queue_mtx);
 
@@ -461,6 +473,7 @@ GgError ggl_deployment_enqueue(
     }
 
     new.type = type;
+    new.iot_job_id = iot_job_id;
 
     if (id != NULL) {
         ret = gg_byte_vec_append(id, new.deployment_id);

--- a/modules/ggdeploymentd/src/deployment_queue.h
+++ b/modules/ggdeploymentd/src/deployment_queue.h
@@ -19,7 +19,10 @@
 /// replaceable state. Otherwise, do not add the deployment to the queue and
 /// return an error.
 GgError ggl_deployment_enqueue(
-    GgMap deployment_doc, GgByteVec *id, GglDeploymentType type
+    GgMap deployment_doc,
+    GgByteVec *id,
+    GgBuffer iot_job_id,
+    GglDeploymentType type
 );
 
 /// Get the deployment queue for the next deployment.

--- a/modules/ggdeploymentd/src/iot_jobs_listener.c
+++ b/modules/ggdeploymentd/src/iot_jobs_listener.c
@@ -6,6 +6,7 @@
 #include "bootstrap_manager.h"
 #include "deployment_model.h"
 #include "deployment_queue.h"
+#include <assert.h>
 #include <gg/arena.h>
 #include <gg/backoff.h>
 #include <gg/buffer.h>
@@ -278,28 +279,21 @@ static GgError enqueue_job(GgMap deployment_doc, GgBuffer job_id) {
             GG_LOGI("Duplicate job document received. Skipping.");
             return GG_ERR_OK;
         }
+    }
 
-        current_job_id = GG_BYTE_VEC(current_job_id_buf);
-        ret = gg_byte_vec_append(&current_job_id, job_id);
-        if (ret != GG_ERR_OK) {
-            GG_LOGE("Job ID too long.");
-            return ret;
-        }
+    GgByteVec deployment_id_vec = GG_BYTE_VEC((uint8_t[64]) { 0 });
 
-        current_deployment_id = GG_BYTE_VEC(current_deployment_id_buf);
-
-        // TODO: backoff algorithm
-        int64_t retries = 1;
-        while (
-            (ret = ggl_deployment_enqueue(
-                 deployment_doc, &current_deployment_id, THING_GROUP_DEPLOYMENT
-             ))
-            == GG_ERR_BUSY
-        ) {
-            int64_t sleep_for = 1 << MIN(7, retries);
-            (void) gg_sleep(sleep_for);
-            ++retries;
-        }
+    // TODO: backoff algorithm
+    int64_t retries = 1;
+    while (
+        (ret = ggl_deployment_enqueue(
+             deployment_doc, &deployment_id_vec, job_id, THING_GROUP_DEPLOYMENT
+         ))
+        == GG_ERR_BUSY
+    ) {
+        int64_t sleep_for = 1 << MIN(7, retries);
+        (void) gg_sleep(sleep_for);
+        ++retries;
     }
 
     if (ret != GG_ERR_OK) {
@@ -504,10 +498,12 @@ GgError update_current_jobs_deployment_to(
         if (!gg_buffer_eq(deployment_id, current_deployment_id.buf)) {
             return GG_ERR_NOENTRY;
         }
-        memcpy(
-            job_id.data, current_job_id.buf.data, current_deployment_id.buf.len
-        );
-        job_id.len = current_deployment_id.buf.len;
+        if (current_job_id.buf.len == 0) {
+            // Local deployments have no IoT Job — nothing to publish.
+            return GG_ERR_OK;
+        }
+        memcpy(job_id.data, current_job_id.buf.data, current_job_id.buf.len);
+        job_id.len = current_job_id.buf.len;
     }
 
     return update_job_to(job_id, status, socket_name);
@@ -544,4 +540,16 @@ GgError set_jobs_deployment_for_bootstrap(
         }
     }
     return GG_ERR_OK;
+}
+
+void set_current_job(GgBuffer job_id, GgBuffer deployment_id) {
+    GG_MTX_SCOPE_GUARD(&current_job_id_mutex);
+    current_job_id = GG_BYTE_VEC(current_job_id_buf);
+    if (job_id.len > 0) {
+        GgError ret = gg_byte_vec_append(&current_job_id, job_id);
+        assert(ret == GG_ERR_OK);
+    }
+    current_deployment_id = GG_BYTE_VEC(current_deployment_id_buf);
+    GgError ret = gg_byte_vec_append(&current_deployment_id, deployment_id);
+    assert(ret == GG_ERR_OK);
 }

--- a/modules/ggdeploymentd/src/iot_jobs_listener.h
+++ b/modules/ggdeploymentd/src/iot_jobs_listener.h
@@ -22,4 +22,8 @@ GgError set_jobs_deployment_for_bootstrap(
     GgBuffer job_id, GgBuffer deployment_id
 );
 
+/// Set the current job/deployment IDs for status reporting. Called at dequeue
+/// time so the IDs reflect the job being actively processed.
+void set_current_job(GgBuffer job_id, GgBuffer deployment_id);
+
 #endif


### PR DESCRIPTION
## Problem

When a device receives a new deployment notification (`notify-next`) while it is still
reporting the final status of the current deployment, the internal tracking of which
job is being processed gets overwritten. The status report then fails because the
device no longer recognizes the deployment it just completed — the IoT Job stays stuck
at IN_PROGRESS.

The most common trigger is cross-account endpoint switch: the device switches its MQTT
connection to a new account, which immediately delivers a pending deployment
notification that overwrites the tracking state. But the bug can occur in any scenario
where a new `notify-next` arrives before the current job's terminal status is published.

## Root Cause

`current_job_id` / `current_deployment_id` in `iot_jobs_listener.c` were written at
**enqueue time** (listener thread) rather than **dequeue time** (handler thread). Since
the listener can enqueue new jobs while the handler is still processing the previous
one, the globals get clobbered. The subsequent call to `update_current_jobs_deployment`
returns `GG_ERR_NOENTRY` because the deployment ID no longer matches.

## Fix

- Add `iot_job_id` field to `GglDeployment` and thread it through the deployment queue
- Remove `current_job_id` / `current_deployment_id` writes from `enqueue_job` — keep
  only the duplicate check (read-only under mutex)
- Set `current_job_id` / `current_deployment_id` in the deployment handler immediately
  after `ggl_deployment_dequeue` via new `set_current_job()` function
- Add early return in `update_current_jobs_deployment_to` for local deployments (empty
  job ID — no IoT Job to report to)
- Fix pre-existing memcpy length bug (was using `current_deployment_id.buf.len` to copy
  from `current_job_id.buf.data`)

## Files Changed

| File | Change |
|------|--------|
| `deployment_model.h` | Add `iot_job_id` field to `GglDeployment` |
| `deployment_queue.h/c` | Accept + deep-copy `iot_job_id` in enqueue |
| `iot_jobs_listener.h/c` | Add `set_current_job()`; remove global writes from `enqueue_job`; fix memcpy + add empty job ID guard |
| `deployment_handler.c` | Call `set_current_job()` after dequeue; add error logging in source report |
| `bus_server.c` | Pass empty `iot_job_id` for local deployments |

## Testing

Tested with containerized Greengrass Lite devices performing cross-account endpoint
switches:

1. Provisioned a device in a source account/region
2. Created a deployment targeted at the device in the destination account (ensures
   `notify-next` fires immediately when the device reconnects after the switch)
3. **Switch 1 (source → target):** Source IoT Job reported `SUCCEEDED` ✅
4. **Switch 2 (target → source):** Target IoT Job reported `SUCCEEDED` ✅

Before the fix, Switch 1 consistently failed — the source IoT Job was stuck at
`IN_PROGRESS` while the device was HEALTHY in the target. Device logs showed 8
consecutive `GG_ERR_NOENTRY` (error 12) failures in `report_success_to_source`.