### PR TITLE
Add event based FSS

### DIFF
--- a/docs/design/gghealthd-design.md
+++ b/docs/design/gghealthd-design.md
@@ -26,6 +26,12 @@ behalf.
   `ggdeploymentd`. In response, gghealthd shall connect to the core device
   orchestrator and await Greengrass component completions or failures,
   forwarding the overall result back to ggdeploymentd.
+- `gghealthd` shall offer a broadcast subscription
+  (`subscribe_to_all_component_state_changes`) that streams every Greengrass
+  component's terminal lifecycle state changes, driven by a single global
+  systemd `PropertiesChanged` match. `ggdeploymentd` uses this to report
+  component status changes to the cloud via `gg-fleet-statusd`. See the
+  [component status updates design](../../../component-udpates-design.md).
 - On request by `gg-fleet-statusd`, `gghealthd` shall report individual
   component lifecycle states. This will be used to report the overall device
   health as well as what components are installed on the device.

--- a/docs/spec/executable/gg-fleet-statusd.md
+++ b/docs/spec/executable/gg-fleet-statusd.md
@@ -18,6 +18,11 @@ See docs at
 - [fss-8] The `messageType` field of published updates is derived from the
   trigger: `NUCLEUS_LAUNCH`, `CADENCE`, and `NETWORK_RECONFIGURE` produce
   `COMPLETE`; the remaining listed triggers produce `PARTIAL`.
+- [fss-9] A `COMPONENT_STATUS_CHANGE` update is triggered by `ggdeploymentd`
+  when a component's lifecycle state changes outside of a deployment. These
+  changes are detected by `gghealthd`'s event loop and forwarded by
+  `ggdeploymentd` (which suppresses them while a deployment is in progress, as
+  the deployment path reports status itself).
 
 ## CLI parameters
 

--- a/docs/spec/executable/gghealthd.md
+++ b/docs/spec/executable/gghealthd.md
@@ -194,3 +194,37 @@ becoming available.
 - [gghealthd-bus-deployment-updates-error-3] `GGL_ERR_FATAL` shall be returned
   in the event that `gghealthd` is not permitted to view a root component's
   status.
+
+### subscribe_to_all_component_state_changes
+
+A broadcast subscription that streams lifecycle state changes for every
+Greengrass (`ggl.*`) component. It is intended for `ggdeploymentd`, which
+forwards changes to `gg-fleet-statusd` so the cloud reflects component status as
+it changes (outside of deployments). A single global systemd `PropertiesChanged`
+match drives this subscription.
+
+#### Parameters
+
+- [gghealthd-bus-all-state-changes-1] All parameters shall be ignored.
+
+#### Response
+
+- [gghealthd-bus-all-state-changes-resp-1] Each response shall be a map with the
+  following schema:
+  - [gghealthd-bus-all-state-changes-resp-1.1] Required key `component_name`
+    shall be present with value type Buffer, containing the bare component name
+    (the systemd unit's `ggl.` prefix and `.service` suffix removed).
+  - [gghealthd-bus-all-state-changes-resp-1.2] Required key `lifecycle_state`
+    shall be present with value type Buffer.
+- [gghealthd-bus-all-state-changes-resp-2] A response shall be sent only when a
+  component's systemd `ActiveState` actually changes and the resulting
+  Greengrass lifecycle state is terminal (`RUNNING`, `FINISHED`, or `BROKEN`).
+- [gghealthd-bus-all-state-changes-resp-3] Only Greengrass (`ggl.*`) component
+  units shall be reported; all other units shall be ignored.
+  - [gghealthd-bus-all-state-changes-resp-3.1] All internal units (`ggl.core.*`)
+    shall be ignored.
+
+#### Errors
+
+- [gghealthd-bus-all-state-changes-error-1] `GGL_ERR_NOMEM` shall be returned if
+  the subscription cannot be accepted.

--- a/modules/core-bus-gghealthd/include/ggl/core_bus/gg_healthd.h
+++ b/modules/core-bus-gghealthd/include/ggl/core_bus/gg_healthd.h
@@ -10,9 +10,23 @@
 #include <gg/arena.h>
 #include <gg/error.h>
 #include <gg/types.h>
+#include <ggl/core_bus/client.h>
+#include <stdint.h>
 
 GgError ggl_gghealthd_retrieve_component_status(
     GgBuffer component, GgArena *alloc, GgBuffer *component_status
+);
+
+/// Subscribe to lifecycle state changes of every Greengrass (`ggl.*`)
+/// component. `on_response` receives a map with `component_name` and
+/// `lifecycle_state` buffers for each terminal-state change. Wraps the
+/// `gg_health` `subscribe_to_all_component_state_changes` core-bus method.
+GgError ggl_gghealthd_subscribe_to_all_component_state_changes(
+    GglSubscribeCallback on_response,
+    GglSubscribeCloseCallback on_close,
+    void *ctx,
+    GgError *remote_error,
+    uint32_t *handle
 );
 
 #endif

--- a/modules/core-bus-gghealthd/src/gg_healthd.c
+++ b/modules/core-bus-gghealthd/src/gg_healthd.c
@@ -65,3 +65,22 @@ GgError ggl_gghealthd_retrieve_component_status(
 
     return GG_ERR_OK;
 }
+
+GgError ggl_gghealthd_subscribe_to_all_component_state_changes(
+    GglSubscribeCallback on_response,
+    GglSubscribeCloseCallback on_close,
+    void *ctx,
+    GgError *remote_error,
+    uint32_t *handle
+) {
+    return ggl_subscribe(
+        GG_STR("gg_health"),
+        GG_STR("subscribe_to_all_component_state_changes"),
+        GG_MAP(),
+        on_response,
+        on_close,
+        ctx,
+        remote_error,
+        handle
+    );
+}

--- a/modules/ggdeploymentd/src/component_status_listener.c
+++ b/modules/ggdeploymentd/src/component_status_listener.c
@@ -1,0 +1,174 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "component_status_listener.h"
+#include "deployment_handler.h"
+#include <gg/arena.h>
+#include <gg/buffer.h>
+#include <gg/error.h>
+#include <gg/flags.h>
+#include <gg/log.h>
+#include <gg/map.h>
+#include <gg/object.h>
+#include <gg/types.h>
+#include <gg/utils.h>
+#include <ggl/core_bus/client.h>
+#include <ggl/core_bus/gg_healthd.h>
+#include <inttypes.h>
+#include <pthread.h>
+#include <sys/types.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stddef.h>
+// Seconds to wait before (re)attempting a subscription, and the poll interval
+// used to notice that the subscription dropped.
+#define RESUBSCRIBE_BACKOFF_SECONDS 5
+
+// Set by the subscription close callback (on the core-bus subscription thread)
+// and observed by the supervisor thread to trigger a re-subscribe.
+static atomic_bool subscription_closed;
+
+// Forwards a component status change to the fleet status service. FSS gathers
+// the full component list itself; we only need to trigger a PARTIAL update.
+static void forward_to_fleet_status(void) {
+    static uint8_t resp_mem[128];
+    GgArena alloc = gg_arena_init(GG_BUF(resp_mem));
+    GgObject result;
+
+    GgMap args = GG_MAP(
+        gg_kv(GG_STR("trigger"), gg_obj_buf(GG_STR("COMPONENT_STATUS_CHANGE"))),
+        gg_kv(GG_STR("deployment_info"), gg_obj_map(GG_MAP()))
+    );
+
+    GgError ret = ggl_call(
+        GG_STR("gg_fleet_status"),
+        GG_STR("send_fleet_status_update"),
+        args,
+        NULL,
+        &alloc,
+        &result
+    );
+    if (ret != GG_ERR_OK) {
+        GG_LOGE(
+            "Failed to forward component status change to fleet status "
+            "service (ret=%d).",
+            (int) ret
+        );
+    }
+}
+
+// Runs on the core-bus subscription thread for each broadcast notification.
+// Always returns GG_ERR_OK: returning an error would tear down the
+// subscription, and a single failed forward should not do that.
+static GgError on_state_change(void *ctx, uint32_t handle, GgObject data) {
+    (void) ctx;
+    (void) handle;
+
+    if (gg_obj_type(data) != GG_TYPE_MAP) {
+        GG_LOGW("Component state change notification is not a map.");
+        return GG_ERR_OK;
+    }
+
+    GgObject *component_name_obj = NULL;
+    GgObject *state_obj = NULL;
+    GgError ret = gg_map_validate(
+        gg_obj_into_map(data),
+        GG_MAP_SCHEMA(
+            { GG_STR("component_name"),
+              GG_REQUIRED,
+              GG_TYPE_BUF,
+              &component_name_obj },
+            { GG_STR("lifecycle_state"), GG_REQUIRED, GG_TYPE_BUF, &state_obj }
+        )
+    );
+    if (ret != GG_ERR_OK) {
+        GG_LOGW("Component state change notification missing fields.");
+        return GG_ERR_OK;
+    }
+
+    GgBuffer component_name = gg_obj_into_buf(*component_name_obj);
+    GgBuffer status = gg_obj_into_buf(*state_obj);
+
+    if (ggl_deployment_in_progress()) {
+        GG_LOGD(
+            "Deployment in progress; not forwarding %.*s -> %.*s.",
+            (int) component_name.len,
+            component_name.data,
+            (int) status.len,
+            status.data
+        );
+        return GG_ERR_OK;
+    }
+
+    GG_LOGD(
+        "Forwarding component state change to fleet status service: "
+        "%.*s -> %.*s.",
+        (int) component_name.len,
+        component_name.data,
+        (int) status.len,
+        status.data
+    );
+    forward_to_fleet_status();
+    return GG_ERR_OK;
+}
+
+static void on_close(void *ctx, uint32_t handle) {
+    (void) ctx;
+    (void) handle;
+    atomic_store(&subscription_closed, true);
+}
+
+static void *listener_thread(void *ctx) {
+    (void) ctx;
+
+    while (true) {
+        atomic_store(&subscription_closed, false);
+
+        uint32_t handle = 0;
+        GgError remote_err = GG_ERR_OK;
+        GgError ret = ggl_gghealthd_subscribe_to_all_component_state_changes(
+            on_state_change, on_close, NULL, &remote_err, &handle
+        );
+        if (ret != GG_ERR_OK) {
+            GG_LOGW(
+                "Failed to subscribe to gghealthd component state changes "
+                "(ret=%d, remote=%d). Retrying in %ds.",
+                (int) ret,
+                (int) remote_err,
+                RESUBSCRIBE_BACKOFF_SECONDS
+            );
+            (void) gg_sleep(RESUBSCRIBE_BACKOFF_SECONDS);
+            continue;
+        }
+
+        GG_LOGI(
+            "Subscribed to gghealthd component state changes (handle=%" PRIu32
+            ").",
+            handle
+        );
+
+        while (!atomic_load(&subscription_closed)) {
+            (void) gg_sleep(RESUBSCRIBE_BACKOFF_SECONDS);
+        }
+
+        GG_LOGW("gghealthd component state change subscription closed; "
+                "resubscribing.");
+        (void) gg_sleep(RESUBSCRIBE_BACKOFF_SECONDS);
+    }
+
+    return NULL;
+}
+
+void ggl_start_component_status_listener(void) {
+    pthread_t ptid;
+    int sys_ret = pthread_create(&ptid, NULL, listener_thread, NULL);
+    if (sys_ret != 0) {
+        GG_LOGE(
+            "Failed to start component status listener thread: %d.", sys_ret
+        );
+        return;
+    }
+    pthread_detach(ptid);
+    GG_LOGI("Started component status listener.");
+}

--- a/modules/ggdeploymentd/src/component_status_listener.h
+++ b/modules/ggdeploymentd/src/component_status_listener.h
@@ -1,0 +1,14 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GGDEPLOYMENTD_COMPONENT_STATUS_LISTENER_H
+#define GGDEPLOYMENTD_COMPONENT_STATUS_LISTENER_H
+
+/// Starts a detached supervisor thread that subscribes to gghealthd component
+/// lifecycle state changes and forwards them to the fleet status service (as a
+/// COMPONENT_STATUS_CHANGE trigger) whenever no deployment is in progress. The
+/// supervisor re-subscribes if the subscription drops (e.g. gghealthd restart).
+void ggl_start_component_status_listener(void);
+
+#endif

--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -54,6 +54,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -72,6 +73,16 @@ static struct DeploymentConfiguration {
     char region[24];
     char port[16];
 } config;
+
+// Set while a deployment is actively being processed by the handler thread.
+// Read from the component-status listener (running on a different thread) to
+// suppress per-component cloud status updates during a deployment, since the
+// deployment path already reports to the fleet status service itself.
+static atomic_bool deployment_in_progress;
+
+bool ggl_deployment_in_progress(void) {
+    return atomic_load(&deployment_in_progress);
+}
 
 typedef struct TesCredentials {
     GgBuffer aws_region;
@@ -3994,12 +4005,16 @@ static GgError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
                ));
 
         bool bootstrap_deployment_succeeded = false;
+        atomic_store(&deployment_in_progress, true);
+        GG_LOGD("Deployment in progress (resuming bootstrap deployment).");
         handle_deployment(
             &bootstrap_deployment,
             args,
             &bootstrap_ctx,
             &bootstrap_deployment_succeeded
         );
+        atomic_store(&deployment_in_progress, false);
+        GG_LOGD("Bootstrap deployment processing complete.");
 
         if (bootstrap_ctx.source_iot_data_endpoint.len > 0
             && !bootstrap_deployment_succeeded) {
@@ -4047,7 +4062,11 @@ static GgError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
 
         bool deployment_succeeded = false;
         DeploymentContext ctx = { 0 };
+        atomic_store(&deployment_in_progress, true);
+        GG_LOGD("Deployment in progress.");
         handle_deployment(deployment, args, &ctx, &deployment_succeeded);
+        atomic_store(&deployment_in_progress, false);
+        GG_LOGD("Deployment processing complete.");
 
         if (ctx.source_iot_data_endpoint.len > 0 && !deployment_succeeded) {
             rollback_config(deployment->deployment_id);

--- a/modules/ggdeploymentd/src/deployment_handler.h
+++ b/modules/ggdeploymentd/src/deployment_handler.h
@@ -6,6 +6,7 @@
 #define GGDEPLOYMENTD_DEPLOYMENT_HANDLER_H
 
 #include <gg/types.h>
+#include <stdbool.h>
 
 typedef struct {
     int root_path_fd;
@@ -14,5 +15,9 @@ typedef struct {
 } GglDeploymentHandlerThreadArgs;
 
 void *ggl_deployment_handler_thread(void *ctx);
+
+/// Returns true while the handler thread is actively processing a deployment.
+/// Thread-safe.
+bool ggl_deployment_in_progress(void);
 
 #endif

--- a/modules/ggdeploymentd/src/entry.c
+++ b/modules/ggdeploymentd/src/entry.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "bus_server.h"
+#include "component_status_listener.h"
 #include "deployment_handler.h"
 #include "iot_jobs_listener.h"
 #include <errno.h>
@@ -73,6 +74,10 @@ GgError run_ggdeploymentd(const char *bin_path) {
     pthread_t ptid_handler;
     pthread_create(&ptid_handler, NULL, &ggl_deployment_handler_thread, &args);
     pthread_detach(ptid_handler);
+
+    // Forward gghealthd component lifecycle state changes to the fleet status
+    // service when no deployment is in progress.
+    ggl_start_component_status_listener();
 
     ggdeploymentd_start_server();
 

--- a/modules/gghealthd/src/bus_server.c
+++ b/modules/gghealthd/src/bus_server.c
@@ -176,6 +176,14 @@ static GgError subscribe_to_lifecycle_completion(
     return GG_ERR_OK;
 }
 
+static GgError subscribe_to_all_component_state_changes(
+    void *ctx, GgMap params, uint32_t handle
+) {
+    (void) ctx;
+    (void) params;
+    return gghealthd_register_all_component_state_changes_subscription(handle);
+}
+
 static GgError restart_component(void *ctx, GgMap params, uint32_t handle) {
     (void) ctx;
     GgObject *component_name_obj;
@@ -222,6 +230,10 @@ GgError run_gghealthd(void) {
             { GG_STR("subscribe_to_lifecycle_completion"),
               true,
               subscribe_to_lifecycle_completion,
+              NULL },
+            { GG_STR("subscribe_to_all_component_state_changes"),
+              true,
+              subscribe_to_all_component_state_changes,
               NULL } };
     static const size_t HANDLERS_LEN = sizeof(handlers) / sizeof(handlers[0]);
 

--- a/modules/gghealthd/src/sd_bus.c
+++ b/modules/gghealthd/src/sd_bus.c
@@ -165,6 +165,47 @@ GgError get_service_name(GgBuffer component_name, GgBuffer *qualified_name) {
     return ret;
 }
 
+GgError get_component_name_from_unit(
+    sd_bus *bus, const char *unit_path, GgBuffer *component_name
+) {
+    assert(
+        (bus != NULL) && (unit_path != NULL) && (component_name != NULL)
+        && (component_name->data != NULL)
+    );
+
+    char *unit_id = NULL;
+    sd_bus_error error = SD_BUS_ERROR_NULL;
+    int ret = sd_bus_get_property_string(
+        bus,
+        DEFAULT_DESTINATION,
+        unit_path,
+        UNIT_INTERFACE,
+        "Id",
+        &error,
+        &unit_id
+    );
+    GG_CLEANUP(sd_bus_error_free, error);
+    GG_CLEANUP(cleanup_free, unit_id);
+    if (ret < 0) {
+        return translate_dbus_call_error(ret);
+    }
+
+    GgBuffer id = gg_buffer_from_null_term(unit_id);
+    // only Greengrass component units (ggl.<name>.service)
+    if ((id.len <= SERVICE_PREFIX_LEN + SERVICE_SUFFIX_LEN)
+        || !gg_buffer_has_prefix(id, GG_STR(SERVICE_PREFIX))
+        || !gg_buffer_has_suffix(id, GG_STR(SERVICE_SUFFIX))) {
+        return GG_ERR_NOENTRY;
+    }
+
+    GgBuffer name
+        = gg_buffer_substr(id, SERVICE_PREFIX_LEN, id.len - SERVICE_SUFFIX_LEN);
+    assert(name.len != 0);
+
+    GgByteVec component_name_vec = gg_byte_vec_init(*component_name);
+    return gg_byte_vec_append(&component_name_vec, name);
+}
+
 static GgError get_component_result(
     sd_bus *bus, const char *unit_path, GgBuffer *state
 ) {

--- a/modules/gghealthd/src/sd_bus.h
+++ b/modules/gghealthd/src/sd_bus.h
@@ -42,6 +42,14 @@ GgError open_bus(sd_bus **bus);
 
 GgError get_service_name(GgBuffer component_name, GgBuffer *qualified_name);
 
+// Reads the systemd unit `Id` for `unit_path`; if it is a Greengrass
+// (`ggl.*.service`) unit, writes the bare component name into `component_name`
+// (`component_name->data` must have capacity `component_name->len`). Returns
+// GG_ERR_NOENTRY for non-Greengrass units.
+GgError get_component_name_from_unit(
+    sd_bus *bus, const char *unit_path, GgBuffer *component_name
+);
+
 GgError get_lifecycle_state(
     sd_bus *bus, const char *unit_path, GgBuffer *state
 );

--- a/modules/gghealthd/src/subscriptions.c
+++ b/modules/gghealthd/src/subscriptions.c
@@ -38,6 +38,14 @@ static uint8_t component_names[GGHEALTHD_MAX_SUBSCRIPTIONS]
 
 static sd_bus *global_bus;
 
+// Handle subscribed to all-component lifecycle state changes (broadcast topic).
+// The design has a single consumer (ggdeploymentd) and the core-bus server
+// already bounds the total number of client connections, so a single handle is
+// sufficient; there is no per-subscriber systemd resource here (one global
+// match feeds every subscriber). Accessed only from the socket-server thread
+// (core-bus handlers and the sd_event callback), so no locking is needed.
+static uint32_t broadcast_handle;
+
 static GgBuffer component_name_buf(int index) {
     assert((index >= 0) && (index < GGHEALTHD_MAX_SUBSCRIPTIONS));
     return gg_buffer_substr(
@@ -46,6 +54,28 @@ static GgBuffer component_name_buf(int index) {
 }
 
 // Event loop thread functions //
+
+// Greengrass lifecycle states that gghealthd reports as "settled" to
+// subscribers. Shared by the per-component and broadcast handlers.
+static bool is_terminal_state(GgBuffer status) {
+    return gg_buffer_eq(GG_STR("BROKEN"), status)
+        || gg_buffer_eq(GG_STR("FINISHED"), status)
+        || gg_buffer_eq(GG_STR("RUNNING"), status);
+}
+
+// Build the standard {component_name, lifecycle_state} response and send it to
+// a subscriber. Shared by the per-component and broadcast handlers.
+static void respond_state_change(
+    uint32_t handle, GgBuffer component_name, GgBuffer status
+) {
+    ggl_sub_respond(
+        handle,
+        gg_obj_map(GG_MAP(
+            gg_kv(GG_STR("component_name"), gg_obj_buf(component_name)),
+            gg_kv(GG_STR("lifecycle_state"), gg_obj_buf(status))
+        ))
+    );
+}
 
 static int properties_changed_handler(
     sd_bus_message *m, void *user_data, sd_bus_error *ret_error
@@ -87,9 +117,7 @@ static int properties_changed_handler(
     }
 
     // RUNNING, FINISHED, BROKEN,  terminal states
-    if (gg_buffer_eq(GG_STR("BROKEN"), status)
-        || gg_buffer_eq(GG_STR("FINISHED"), status)
-        || gg_buffer_eq(GG_STR("RUNNING"), status)) {
+    if (is_terminal_state(status)) {
         GG_LOGI(
             "%.*s finished their lifecycle (status=%.*s)",
             (int) component_name.len,
@@ -97,13 +125,7 @@ static int properties_changed_handler(
             (int) status.len,
             status.data
         );
-        ggl_sub_respond(
-            handle,
-            gg_obj_map(GG_MAP(
-                gg_kv(GG_STR("component_name"), gg_obj_buf(component_name)),
-                gg_kv(GG_STR("lifecycle_state"), gg_obj_buf(status))
-            ))
-        );
+        respond_state_change(handle, component_name, status);
     } else {
         GG_LOGD("Signalled for non-terminal state. ");
     }
@@ -173,6 +195,137 @@ static void event_handle_callback(void) {
     GG_LOGD("Event loop returned %d.", ret);
 }
 
+// Returns true if the PropertiesChanged message body indicates that the
+// systemd `ActiveState` property actually changed. systemd only lists a
+// property in the changed/invalidated set when its value transitions, so this
+// is the "filter on actual change" that dedupes redundant signals. Consumes
+// the message body, which the caller does not otherwise read.
+static bool active_state_changed(sd_bus_message *m) {
+    // PropertiesChanged signature: s a{sv} as
+    //   (interface_name, changed_properties, invalidated_properties)
+    const char *iface = NULL;
+    if (sd_bus_message_read_basic(m, 's', &iface) < 0) {
+        return false;
+    }
+
+    bool found = false;
+
+    if (sd_bus_message_enter_container(m, 'a', "{sv}") < 0) {
+        return false;
+    }
+    while (sd_bus_message_enter_container(m, 'e', "sv") > 0) {
+        const char *key = NULL;
+        if (sd_bus_message_read_basic(m, 's', &key) < 0) {
+            break;
+        }
+        if ((key != NULL) && (strcmp(key, "ActiveState") == 0)) {
+            found = true;
+        }
+        // skip the variant value to advance to the next dict entry
+        if (sd_bus_message_skip(m, "v") < 0) {
+            break;
+        }
+        sd_bus_message_exit_container(m);
+    }
+    sd_bus_message_exit_container(m);
+
+    // also treat ActiveState being invalidated as a change
+    if (sd_bus_message_enter_container(m, 'a', "s") >= 0) {
+        const char *invalidated = NULL;
+        while (sd_bus_message_read_basic(m, 's', &invalidated) > 0) {
+            if ((invalidated != NULL)
+                && (strcmp(invalidated, "ActiveState") == 0)) {
+                found = true;
+            }
+        }
+        sd_bus_message_exit_container(m);
+    }
+
+    return found;
+}
+
+// Kept referenced for the lifetime of the process so the match stays installed.
+static sd_bus_slot *broadcast_match_slot;
+
+// Single global PropertiesChanged handler feeding the broadcast subscription.
+// Filters to Greengrass component units whose ActiveState actually changed,
+// maps to a terminal Greengrass lifecycle state, and fans the result out to
+// the broadcast subscriber.
+static int global_properties_changed_handler(
+    sd_bus_message *m, void *user_data, sd_bus_error *ret_error
+) {
+    (void) user_data;
+    (void) ret_error;
+
+    if (broadcast_handle == 0) {
+        // no subscriber; nothing to fan out to
+        return 0;
+    }
+
+    const char *unit_path = sd_bus_message_get_path(m);
+    if (unit_path == NULL) {
+        return 0;
+    }
+
+    // filter on actual ActiveState change
+    if (!active_state_changed(m)) {
+        return 0;
+    }
+
+    sd_bus *bus = sd_bus_message_get_bus(m);
+    if (bus == NULL) {
+        GG_LOGW("No bus connection on signal.");
+        return 0;
+    }
+
+    // resolve and filter to ggl.* component units
+    uint8_t name_bytes[GGL_COMPONENT_NAME_MAX_LEN];
+    GgBuffer component_name = GG_BUF(name_bytes);
+    GgError ret = get_component_name_from_unit(bus, unit_path, &component_name);
+    if (ret != GG_ERR_OK) {
+        // not a Greengrass component unit (or unreadable); ignore
+        return 0;
+    }
+
+    // Ignore core nucleus services (ggl.core.*.service -> core.*); these are
+    // internal daemons and can be skipped
+    if (gg_buffer_has_prefix(component_name, GG_STR("core."))) {
+        GG_LOGD(
+            "Ignoring core service %.*s state change.",
+            (int) component_name.len,
+            component_name.data
+        );
+        return 0;
+    }
+
+    GgBuffer status = GG_STR("");
+    ret = get_lifecycle_state(bus, unit_path, &status);
+    if (ret != GG_ERR_OK) {
+        return 0;
+    }
+
+    if (!is_terminal_state(status)) {
+        GG_LOGD(
+            "%.*s changed to non-terminal state %.*s; not broadcasting.",
+            (int) component_name.len,
+            component_name.data,
+            (int) status.len,
+            status.data
+        );
+        return 0;
+    }
+
+    GG_LOGI(
+        "Broadcasting component state change: %.*s -> %.*s",
+        (int) component_name.len,
+        component_name.data,
+        (int) status.len,
+        status.data
+    );
+    respond_state_change(broadcast_handle, component_name, status);
+    return 0;
+}
+
 void init_health_events(void) {
     while (true) {
         GgError ret = open_bus(&global_bus);
@@ -221,6 +374,28 @@ void init_health_events(void) {
     int sd_ret = sd_bus_attach_event(global_bus, e, 0);
     if (sd_ret < 0) {
         GG_LOGE("Failed to attach bus event %p", (void *) global_bus);
+    }
+
+    // Single global match for every systemd unit's PropertiesChanged. The
+    // handler filters to Greengrass component units and terminal states and
+    // fans out to the broadcast subscriber. `sender` is restricted to systemd
+    // and `path` is NULL (all units), so this one match replaces per-unit
+    // matches for the broadcast use case.
+    sd_ret = sd_bus_match_signal(
+        global_bus,
+        &broadcast_match_slot,
+        DEFAULT_DESTINATION,
+        NULL,
+        "org.freedesktop.DBus.Properties",
+        "PropertiesChanged",
+        global_properties_changed_handler,
+        NULL
+    );
+    if (sd_ret < 0) {
+        GG_LOGE(
+            "Failed to register global PropertiesChanged match (errno=%d).",
+            -sd_ret
+        );
     }
 
     // TODO: replace with setting up a larger epoll
@@ -272,5 +447,52 @@ void gghealthd_unregister_lifecycle_subscription(void *ctx, uint32_t handle) {
             GG_LOGT("Found handle (index=%d).", index);
             unregister_dbus_signal(index);
         }
+    }
+}
+
+GgError gghealthd_register_all_component_state_changes_subscription(
+    uint32_t handle
+) {
+    GG_LOGT(
+        "Registering all-component state-change watch (handle=%" PRIu32 ")",
+        handle
+    );
+    if (broadcast_handle != 0) {
+        GG_LOGW(
+            "Replacing existing all-component state-change subscriber "
+            "(old handle=%" PRIu32 ", new handle=%" PRIu32 ").",
+            broadcast_handle,
+            handle
+        );
+    }
+    broadcast_handle = handle;
+    ggl_sub_accept(
+        handle,
+        gghealthd_unregister_all_component_state_changes_subscription,
+        NULL
+    );
+    GG_LOGD(
+        "Accepted all-component state-change subscription (handle=%" PRIu32
+        ").",
+        handle
+    );
+    return GG_ERR_OK;
+}
+
+void gghealthd_unregister_all_component_state_changes_subscription(
+    void *ctx, uint32_t handle
+) {
+    (void) ctx;
+    GG_LOGT(
+        "Unregistering all-component state-change watch (handle=%" PRIu32 ")",
+        handle
+    );
+    if (broadcast_handle == handle) {
+        broadcast_handle = 0;
+        GG_LOGD(
+            "Unregistered all-component state-change subscription "
+            "(handle=%" PRIu32 ").",
+            handle
+        );
     }
 }

--- a/modules/gghealthd/src/subscriptions.h
+++ b/modules/gghealthd/src/subscriptions.h
@@ -15,6 +15,16 @@ GgError gghealthd_register_lifecycle_subscription(
 
 void gghealthd_unregister_lifecycle_subscription(void *ctx, uint32_t handle);
 
+// Register a broadcast subscription that receives the lifecycle state changes
+// of every Greengrass (`ggl.*`) component. Accepts the subscription on success.
+GgError gghealthd_register_all_component_state_changes_subscription(
+    uint32_t handle
+);
+
+void gghealthd_unregister_all_component_state_changes_subscription(
+    void *ctx, uint32_t handle
+);
+
 void init_health_events(void);
 
 #endif


### PR DESCRIPTION
## Description

This PR adds a event loop under `healthd` that will monitor and receive event based update on any/all deployed component.

## Related Issue

Fixes #(issue number) or N/A if not applicable

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [x] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [x] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [x] Existing tests pass
- [x] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
    - https://github.com/aws-greengrass/aws-greengrass-testing/pull/307
- [ ] New functionality is covered by tests
- [x] Tested Manually

## Additional Notes

Validated manually by following the steps:
- Deploy a component and wait for the deployment to finish
- use `systemctl stop` to stop a component (only after a successful deployment)
- Wait upto 10 seconds to see the change in cloud

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
