### PR TITLE
Report stale components as UNINSTALLED so that the cloud can stop tracking them

### DIFF
--- a/docs/spec/executable/gg-fleet-statusd.md
+++ b/docs/spec/executable/gg-fleet-statusd.md
@@ -74,3 +74,19 @@ to send a fleet status update to IoT Core.
   parameter of type map
   - [gg-fleet-statusd-send_fleet_status_update-2.1] `deployment_info` includes a
     map of deployment information to send to cloud after a deployment
+- [gg-fleet-statusd-send_fleet_status_update-3] `removed_components` is an
+  optional parameter of type list
+  - [gg-fleet-statusd-send_fleet_status_update-3.1] Each entry shall be of type
+    Buffer holding a component name. Calls with non-buffer entries shall be
+    rejected with an error and no update is published.
+  - [gg-fleet-statusd-send_fleet_status_update-3.2] An absent or empty list
+    means no components were uninstalled by the triggering event.
+  - [gg-fleet-statusd-send_fleet_status_update-3.3] Each listed component shall
+    appear in the published payload's `components[]` array with
+    `status: "UNINSTALLED"`, `version: ""`, `fleetConfigArns: []`, and
+    `isRoot: true`. This signals the cloud to prune the component from its
+    inventory even when `messageType` is `PARTIAL`.
+  - [gg-fleet-statusd-send_fleet_status_update-3.4] When the combined number of
+    running and removed components would exceed the configured component cap,
+    extra UNINSTALLED entries are dropped from the current update and a warning
+    is logged.

--- a/docs/spec/executable/ggdeploymentd.md
+++ b/docs/spec/executable/ggdeploymentd.md
@@ -97,6 +97,49 @@ the following requirements.
    - [ggdeploymentd-4.2] Stale components are removed from the device on a new
      deployment handling. A component is considered stale if it was not part of
      the list of resolved component versions.
+     - [ggdeploymentd-4.2.1] The names of components that are fully removed
+       (i.e. not part of any thing group's resolved component set, so their
+       systemd unit, recipe, artifacts, and `services/<name>` config tree are
+       deleted) are recorded for the post-deployment fleet status update so the
+       cloud can prune them from its inventory. See [ggdeploymentd-5.1.4] below.
+5. [ggdeploymentd-5] The deployment service reports outcomes to
+   `gg-fleet-statusd` so the cloud reflects the post-deployment state of the
+   device.
+   - [ggdeploymentd-5.1] After every deployment (including resumed bootstrap
+     deployments), the deployment service shall invoke
+     `gg_fleet_status/send_fleet_status_update`.
+     - [ggdeploymentd-5.1.1] The `trigger` shall be `LOCAL_DEPLOYMENT` for
+       deployments of type LOCAL and `THING_GROUP_DEPLOYMENT` for deployments of
+       type THING_GROUP. Other deployment types are not currently emitted.
+     - [ggdeploymentd-5.1.2] The `deployment_info` map shall include `status`
+       (`SUCCEEDED` or `FAILED`), `fleetConfigurationArnForStatus`,
+       `deploymentId`, `statusDetails.detailedStatus` (`SUCCESSFUL` or
+       `FAILED_ROLLBACK_NOT_REQUESTED`), and `unchangedRootComponents`.
+     - [ggdeploymentd-5.1.3] When the deployment did not fully remove any
+       components, `removed_components` shall be an empty list.
+     - [ggdeploymentd-5.1.4] When stale-component cleanup fully removed one or
+       more components, `removed_components` shall contain each removed
+       component name (deduplicated). This causes `gg-fleet-statusd` to report
+       each name with `status: "UNINSTALLED"` so the cloud prunes them on the
+       same `PARTIAL` update, instead of waiting for the next `COMPLETE` update
+       (`NUCLEUS_LAUNCH`, `CADENCE`, or `NETWORK_RECONFIGURE`).
+     - [ggdeploymentd-5.1.5] When the number of removed components in a single
+       deployment exceeds the per-update component cap
+       (`GGL_MAX_GENERIC_COMPONENTS`), entries beyond the cap may be dropped
+       from the update; the affected components will instead be reconciled by
+       the next `COMPLETE` update.
+   - [ggdeploymentd-5.2] While a deployment is being processed, the deployment
+     service shall suppress event-based fleet status updates so that
+     per-component lifecycle transitions caused by the deployment are not
+     reported separately. The post-deployment update in [ggdeploymentd-5.1]
+     supersedes them.
+   - [ggdeploymentd-5.3] Outside of deployments, the deployment service shall
+     forward Greengrass component lifecycle state changes to `gg-fleet-statusd`
+     with `trigger = COMPONENT_STATUS_CHANGE` so that unexpected restarts,
+     failures (`BROKEN`), and similar events are reflected in the cloud without
+     waiting for the next `CADENCE` update. Lifecycle changes are sourced from
+     `gghealthd`'s broadcast subscription
+     `subscribe_to_all_component_state_changes`.
 
 ### Future-Looking Possibilities
 
@@ -175,6 +218,15 @@ device following a deployment.
 - Remove any components that does not match the exact component name and version
 - Will also support deactivating services related to the component as well as
   unit files, script files, artifacts and recipe files
+- When a component is fully removed (its name is not present in the resolved
+  component set, i.e. its `services/<name>` config tree, systemd units, and
+  recipe/artifact files are deleted), its name is captured and forwarded to
+  `gg-fleet-statusd` via the `removed_components` argument of
+  `send_fleet_status_update`. `gg-fleet-statusd` then includes the component in
+  the published payload with `status: "UNINSTALLED"`, so the cloud prunes it
+  from the device's installed-components inventory on the same update.
+  Components whose only change is a version bump are not reported as removed,
+  even though their old recipe/artifact files on disk are deleted.
 
 - Note: Currently excludes local deployments and might result to removal of all
   those components

--- a/modules/gg-fleet-statusd/src/entry.c
+++ b/modules/gg-fleet-statusd/src/entry.c
@@ -96,7 +96,7 @@ static GgError connection_status_callback(
             connection_trigger.data
         );
         ret = publish_fleet_status_update(
-            thing_name, connection_trigger, GG_MAP()
+            thing_name, connection_trigger, GG_MAP(), GG_LIST()
         );
         if (ret != GG_ERR_OK) {
             GG_LOGE("Failed to publish fleet status update.");
@@ -209,7 +209,7 @@ static void *ggl_fleet_status_service_thread(void *ctx) {
         }
 
         ret = publish_fleet_status_update(
-            thing_name, GG_STR("CADENCE"), GG_MAP()
+            thing_name, GG_STR("CADENCE"), GG_MAP(), GG_LIST()
         );
         if (ret != GG_ERR_OK) {
             GG_LOGE("Failed to publish fleet status update.");
@@ -239,8 +239,35 @@ static GgError send_fleet_status_update(
         return GG_ERR_INVALID;
     }
 
+    // `removed_components` is optional. When present it must be a list of
+    // buffers; we validate the type up front so publish_fleet_status_update
+    // can rely on each item being a GG_TYPE_BUF.
+    GgList removed_components = GG_LIST();
+    GgObject *removed_obj = NULL;
+    found = gg_map_get(params, GG_STR("removed_components"), &removed_obj);
+    if (found) {
+        if (gg_obj_type(*removed_obj) != GG_TYPE_LIST) {
+            GG_LOGE("Optional `removed_components` must be a list.");
+            return GG_ERR_INVALID;
+        }
+        removed_components = gg_obj_into_list(*removed_obj);
+        for (size_t i = 0; i < removed_components.len; i++) {
+            if (gg_obj_type(removed_components.items[i]) != GG_TYPE_BUF) {
+                GG_LOGE(
+                    "`removed_components[%zu]` is not a buffer; rejecting "
+                    "update.",
+                    i
+                );
+                return GG_ERR_INVALID;
+            }
+        }
+    }
+
     GgError ret = publish_fleet_status_update(
-        thing_name, gg_obj_into_buf(*trigger), gg_obj_into_map(*deployment_info)
+        thing_name,
+        gg_obj_into_buf(*trigger),
+        gg_obj_into_map(*deployment_info),
+        removed_components
     );
     if (ret != GG_ERR_OK) {
         GG_LOGE("Failed to publish fleet status update.");

--- a/modules/gg-fleet-statusd/src/fleet_status_service.c
+++ b/modules/gg-fleet-statusd/src/fleet_status_service.c
@@ -76,7 +76,10 @@ static GgError derive_message_type(
 // TODO: Split this function up
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 GgError publish_fleet_status_update(
-    GgBuffer thing_name, GgBuffer trigger, GgMap deployment_info
+    GgBuffer thing_name,
+    GgBuffer trigger,
+    GgMap deployment_info,
+    GgList removed_components
 ) {
     GgBuffer message_type;
     GgError ret = derive_message_type(trigger, &message_type);
@@ -236,6 +239,64 @@ GgError publish_fleet_status_update(
             continue;
         }
 
+        component_count++;
+    }
+    assert(component_count == component_statuses.list.len);
+
+    // Append entries for components that were just uninstalled by a
+    // deployment. The cloud uses status=UNINSTALLED to prune the component
+    // from its inventory even on PARTIAL updates -- without this, a removed
+    // component lingers in the cloud until the next COMPLETE update
+    // (NUCLEUS_LAUNCH / CADENCE / NETWORK_RECONFIGURE).
+    GG_LIST_FOREACH (removed_obj, removed_components) {
+        if (component_count >= GGL_MAX_GENERIC_COMPONENTS) {
+            GG_LOGW(
+                "Reached component cap (%d); dropping remaining UNINSTALLED "
+                "entries from this fleet status update.",
+                GGL_MAX_GENERIC_COMPONENTS
+            );
+            break;
+        }
+        assert(gg_obj_type(*removed_obj) == GG_TYPE_BUF);
+
+        GgBuffer removed = gg_obj_into_buf(*removed_obj);
+
+        // The local services config tree for this component has already been
+        // deleted, so we cannot look up its prior version or configArns.
+        // Report empty values; the cloud only needs the name and the
+        // UNINSTALLED status to drop it from the inventory.
+        GgMap removed_info = GG_MAP(
+            gg_kv(GG_STR("componentName"), gg_obj_buf(removed)),
+            gg_kv(GG_STR("version"), gg_obj_buf(GG_STR(""))),
+            gg_kv(GG_STR("fleetConfigArns"), gg_obj_list(GG_LIST())),
+            gg_kv(GG_STR("isRoot"), gg_obj_bool(true)),
+            gg_kv(GG_STR("status"), gg_obj_buf(GG_STR("UNINSTALLED")))
+        );
+
+        memcpy(
+            component_infos[component_count],
+            removed_info.pairs,
+            sizeof(component_infos[component_count])
+        );
+        removed_info.pairs = component_infos[component_count];
+
+        ret = gg_obj_vec_push(&component_statuses, gg_obj_map(removed_info));
+        if (ret != GG_ERR_OK) {
+            GG_LOGE(
+                "Failed to add UNINSTALLED entry for %.*s to component list "
+                "with error %s.",
+                (int) removed.len,
+                removed.data,
+                gg_strerror(ret)
+            );
+            continue;
+        }
+
+        GG_LOGD(
+            "Reporting %.*s as UNINSTALLED in fleet status update.",
+            (int) removed.len,
+            removed.data
+        );
         component_count++;
     }
     assert(component_count == component_statuses.list.len);

--- a/modules/gg-fleet-statusd/src/fleet_status_service.h
+++ b/modules/gg-fleet-statusd/src/fleet_status_service.h
@@ -10,8 +10,16 @@
 
 #define MAX_THING_NAME_LEN 128
 
+/// Publishes a fleet status update to the cloud. @p removed_components lists
+/// component names (as buffers) that have just been uninstalled by a
+/// deployment, if any; each is reported with status=UNINSTALLED so the cloud
+/// can prune them from its inventory even on PARTIAL updates. Pass an empty
+/// list when there are no removals.
 GgError publish_fleet_status_update(
-    GgBuffer thing_name, GgBuffer trigger, GgMap deployment_info
+    GgBuffer thing_name,
+    GgBuffer trigger,
+    GgMap deployment_info,
+    GgList removed_components
 );
 
 #endif // GG_FLEET_STATUSD_FLEET_STATUS_SERVICE_H

--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -1554,9 +1554,16 @@ static GgError resolve_dependencies(
     GglDeploymentType deployment_type,
     GglDeploymentHandlerThreadArgs *args,
     GgArena *alloc,
-    GgKVVec *resolved_components_kv_vec
+    GgKVVec *resolved_components_kv_vec,
+    bool *out_depends_on_token_exchange_service
 ) {
     GgError ret;
+
+    // Built-in components (e.g. TokenExchangeService) are skipped below and
+    // never enter the resolved set. Report whether the device's merged
+    // dependency closure needs TES so the caller can keep its fleet
+    // configuration ARN in sync for gg-fleet-statusd reporting.
+    *out_depends_on_token_exchange_service = false;
 
     // TODO: Decide on size
     GgKVVec components_to_resolve = GG_KV_VEC((GgKV[64]) { 0 });
@@ -2078,6 +2085,20 @@ static GgError resolve_dependencies(
                     || gg_buffer_eq(
                         gg_kv_key(*dependency), GG_STR("aws.greengrass.Cli")
                     )) {
+                    // TokenExchangeService is a built-in component that is
+                    // never resolved or installed through a deployment, so the
+                    // component-processing loop never tags it with this
+                    // deployment's configuration ARN. Record that the device's
+                    // dependency closure includes TES so the caller can keep
+                    // its fleet configuration ARN in sync; otherwise
+                    // gg-fleet-statusd reports TES with an empty
+                    // fleetConfigArns and the cloud will not display it.
+                    if (gg_buffer_eq(
+                            gg_kv_key(*dependency),
+                            GG_STR("aws.greengrass.TokenExchangeService")
+                        )) {
+                        *out_depends_on_token_exchange_service = true;
+                    }
                     GG_LOGD(
                         "Skipping a dependency during resolution as it is %.*s",
                         (int) gg_kv_key(*dependency).len,
@@ -3049,19 +3070,55 @@ static void handle_deployment(
     static uint8_t resolve_dependencies_mem[8192] = { 0 };
     GgArena resolve_dependencies_alloc
         = gg_arena_init(GG_BUF(resolve_dependencies_mem));
+    bool depends_on_token_exchange_service;
     ret = resolve_dependencies(
         deployment->components,
         deployment->thing_group,
         deployment->type,
         args,
         &resolve_dependencies_alloc,
-        &resolved_components_kv_vec
+        &resolved_components_kv_vec,
+        &depends_on_token_exchange_service
     );
     if (ret != GG_ERR_OK) {
         GG_LOGE(
             "Failed to do dependency resolution for deployment, failing deployment."
         );
         return;
+    }
+
+    // aws.greengrass.TokenExchangeService is a built-in component that is
+    // skipped during dependency resolution, so the component-processing loop
+    // below never tags it with this deployment's configuration ARN. Keep its
+    // fleet configuration ARN in sync here so gg-fleet-statusd reports it (and
+    // the cloud displays it) exactly while some component on the device depends
+    // on it. resolve_dependencies merges every thing group and local deployment
+    // into the resolved set, so depends_on_token_exchange_service is a
+    // device-wide signal: associate TES with this deployment's configuration
+    // ARN when it is needed, and clear the association when nothing depends on
+    // it anymore. Written at timestamp 3 so it overrides the lowest-priority
+    // empty seed written by tes-serverd and persists across restarts. This is
+    // best-effort cloud-reporting metadata, so a failure must not fail the
+    // deployment.
+    GgObject tes_config_arn = gg_obj_buf(deployment->configuration_arn);
+    GgObject tes_config_arn_list = gg_obj_list(GG_LIST());
+    if (depends_on_token_exchange_service) {
+        tes_config_arn_list
+            = gg_obj_list((GgList) { .items = &tes_config_arn, .len = 1 });
+    }
+    GgError tes_arn_ret = ggl_gg_config_write(
+        GG_BUF_LIST(
+            GG_STR("services"),
+            GG_STR("aws.greengrass.TokenExchangeService"),
+            GG_STR("configArn")
+        ),
+        tes_config_arn_list,
+        &(int64_t) { 3 }
+    );
+    if (tes_arn_ret != GG_ERR_OK) {
+        GG_LOGW(
+            "Failed to update aws.greengrass.TokenExchangeService fleet configuration ARN; its console visibility may be stale."
+        );
     }
 
     GgByteVec region = GG_BYTE_VEC(config.region);

--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -2373,7 +2373,9 @@ static GgError add_arn_list_to_config(
 }
 
 static GgError send_fss_update(
-    GglDeployment *deployment, bool deployment_succeeded
+    GglDeployment *deployment,
+    bool deployment_succeeded,
+    GgBufList removed_components
 ) {
     GgBuffer server = GG_STR("gg_fleet_status");
     static uint8_t buffer[10 * sizeof(GgObject)] = { 0 };
@@ -2414,9 +2416,32 @@ static GgError send_fss_update(
         trigger = GG_STR("THING_GROUP_DEPLOYMENT");
     }
 
+    // Project the bufs into GgObjects so we can pass them as a list. The
+    // backing storage for the names is owned by the caller and outlives this
+    // call.
+    GgObject removed_objs[GGL_MAX_GENERIC_COMPONENTS];
+    size_t removed_count = removed_components.len;
+    if (removed_count > GGL_MAX_GENERIC_COMPONENTS) {
+        GG_LOGW(
+            "Truncating removed component list from %zu to %d for fleet "
+            "status update.",
+            removed_count,
+            GGL_MAX_GENERIC_COMPONENTS
+        );
+        removed_count = GGL_MAX_GENERIC_COMPONENTS;
+    }
+    for (size_t i = 0; i < removed_count; i++) {
+        removed_objs[i] = gg_obj_buf(removed_components.bufs[i]);
+    }
+    GgList removed_list
+        = (GgList) { .items = removed_objs, .len = removed_count };
+
+    // Always pass the key so the receiver does not need to special-case its
+    // absence; an empty list is the no-removals signal.
     GgMap args = GG_MAP(
         gg_kv(GG_STR("trigger"), gg_obj_buf(trigger)),
-        gg_kv(GG_STR("deployment_info"), gg_obj_map(deployment_info))
+        gg_kv(GG_STR("deployment_info"), gg_obj_map(deployment_info)),
+        gg_kv(GG_STR("removed_components"), gg_obj_list(removed_list))
     );
 
     GgArena alloc = gg_arena_init(GG_BUF(buffer));
@@ -3995,7 +4020,11 @@ static void handle_deployment(
     }
 
     GG_LOGI("Performing cleanup of stale components");
-    ret = cleanup_stale_versions(resolved_components_kv_vec.map);
+    ret = cleanup_stale_versions(
+        resolved_components_kv_vec.map,
+        ctx->removed_names_storage,
+        ctx->removed_components
+    );
     if (ret != GG_ERR_OK) {
         GG_LOGE("Error while cleaning up stale components after deployment.");
     }
@@ -4044,7 +4073,20 @@ static GgError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
     GglDeployment bootstrap_deployment = { 0 };
     uint8_t jobs_id_resp_mem[64] = { 0 };
     GgBuffer jobs_id = GG_BUF(jobs_id_resp_mem);
-    DeploymentContext bootstrap_ctx = { 0 };
+
+    // Storage for components fully removed during cleanup_stale_versions.
+    // Bytes for each name go into the byte vec; the bufvec holds slices into
+    // those bytes. Both must outlive the FSS call below.
+    static uint8_t bootstrap_removed_names_mem[MAX_COMP_NAME_BUF_SIZE];
+    GgByteVec bootstrap_removed_names_storage
+        = GG_BYTE_VEC(bootstrap_removed_names_mem);
+    static GgBuffer bootstrap_removed_bufs[GGL_MAX_GENERIC_COMPONENTS];
+    GgBufVec bootstrap_removed_components = GG_BUF_VEC(bootstrap_removed_bufs);
+
+    DeploymentContext bootstrap_ctx = {
+        .removed_names_storage = &bootstrap_removed_names_storage,
+        .removed_components = &bootstrap_removed_components,
+    };
 
     GgError ret = retrieve_in_progress_deployment(
         &bootstrap_deployment, &jobs_id, &bootstrap_ctx
@@ -4082,7 +4124,9 @@ static GgError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
         }
 
         (void) send_fss_update(
-            &bootstrap_deployment, bootstrap_deployment_succeeded
+            &bootstrap_deployment,
+            bootstrap_deployment_succeeded,
+            bootstrap_removed_components.buf_list
         );
 
         if (send_deployment_update) {
@@ -4123,7 +4167,18 @@ static GgError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
         );
 
         bool deployment_succeeded = false;
-        DeploymentContext ctx = { 0 };
+
+        // Per-deployment storage for components that get fully removed
+        // during cleanup_stale_versions. Reset for each deployment.
+        static uint8_t removed_names_mem[MAX_COMP_NAME_BUF_SIZE];
+        GgByteVec removed_names_storage = GG_BYTE_VEC(removed_names_mem);
+        static GgBuffer removed_bufs[GGL_MAX_GENERIC_COMPONENTS];
+        GgBufVec removed_components = GG_BUF_VEC(removed_bufs);
+
+        DeploymentContext ctx = {
+            .removed_names_storage = &removed_names_storage,
+            .removed_components = &removed_components,
+        };
         atomic_store(&deployment_in_progress, true);
         GG_LOGD("Deployment in progress.");
         handle_deployment(deployment, args, &ctx, &deployment_succeeded);
@@ -4134,7 +4189,9 @@ static GgError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
             rollback_config(deployment->deployment_id);
         }
 
-        (void) send_fss_update(deployment, deployment_succeeded);
+        (void) send_fss_update(
+            deployment, deployment_succeeded, removed_components.buf_list
+        );
 
         // TODO: need error details from handle_deployment
         report_deployment_status(

--- a/modules/ggdeploymentd/src/deployment_model.h
+++ b/modules/ggdeploymentd/src/deployment_model.h
@@ -6,6 +6,7 @@
 #define GGDEPLOYMENTD_DEPLOYMENT_MODEL_H
 
 #include <gg/types.h>
+#include <gg/vector.h>
 #include <stdbool.h>
 
 #define MAX_COMP_NAME_BUF_SIZE 10000
@@ -45,6 +46,13 @@ typedef struct {
 typedef struct {
     bool is_bootstrap;
     GgBuffer source_iot_data_endpoint;
+    /// Optional output: components that cleanup_stale_versions fully removed
+    /// during this deployment. The caller owns the backing buffers; the
+    /// handler appends names so the post-deployment fleet status update can
+    /// report them as UNINSTALLED. Both pointers must be NULL or both must
+    /// be non-NULL.
+    GgByteVec *removed_names_storage;
+    GgBufVec *removed_components;
 } DeploymentContext;
 
 #endif

--- a/modules/ggdeploymentd/src/stale_component.c
+++ b/modules/ggdeploymentd/src/stale_component.c
@@ -510,7 +510,59 @@ GgError disable_and_unlink_service(
     return GG_ERR_OK;
 }
 
-GgError cleanup_stale_versions(GgMap latest_components_map) {
+// Records @p component_name in @p removed_components_out (with bytes copied
+// into @p removed_names_storage), deduplicating against names already
+// recorded. A no-op if either output pointer is NULL. On overflow of either
+// storage, logs a warning and rolls back the partial byte copy without
+// aborting the surrounding cleanup pass.
+static void record_removed_component(
+    GgBuffer component_name,
+    GgByteVec *removed_names_storage,
+    GgBufVec *removed_components_out
+) {
+    if ((removed_names_storage == NULL) || (removed_components_out == NULL)) {
+        return;
+    }
+
+    for (size_t i = 0; i < removed_components_out->buf_list.len; i++) {
+        if (gg_buffer_eq(
+                component_name, removed_components_out->buf_list.bufs[i]
+            )) {
+            return;
+        }
+    }
+
+    size_t name_offset = removed_names_storage->buf.len;
+    GgError ret = gg_byte_vec_append(removed_names_storage, component_name);
+    if (ret == GG_ERR_OK) {
+        GgBuffer slice
+            = { .data = removed_names_storage->buf.data + name_offset,
+                .len = component_name.len };
+        ret = gg_buf_vec_push(removed_components_out, slice);
+    }
+    if (ret != GG_ERR_OK) {
+        // Roll back the partial copy so the storage offset stays consistent
+        // with the bufvec.
+        removed_names_storage->buf.len = name_offset;
+        GG_LOGW(
+            "Could not record removed component %.*s for fleet status update "
+            "(ret=%d).",
+            (int) component_name.len,
+            component_name.data,
+            (int) ret
+        );
+    }
+}
+
+GgError cleanup_stale_versions(
+    GgMap latest_components_map,
+    GgByteVec *removed_names_storage,
+    GgBufVec *removed_components_out
+) {
+    // Both must be NULL or both must be non-NULL: the bufvec stores slices
+    // into the byte vec, so they share a lifetime.
+    assert((removed_names_storage == NULL) == (removed_components_out == NULL));
+
     int recipe_dir_fd;
     GgError ret = get_recipe_dir_fd(&recipe_dir_fd);
     if (ret != GG_ERR_OK) {
@@ -582,6 +634,16 @@ GgError cleanup_stale_versions(GgMap latest_components_map) {
             // Cannot find this component at all. Delete it!
             (void) delete_component(
                 component_name_buffer_iterator, version_buffer_iterator, true
+            );
+
+            // Record the removal so the caller can report UNINSTALLED to the
+            // cloud. Multiple installed versions of the same removed
+            // component reach this branch once each, so the helper
+            // deduplicates against names already recorded.
+            record_removed_component(
+                component_name_buffer_iterator,
+                removed_names_storage,
+                removed_components_out
             );
 
             // Also stop any running service for this component.

--- a/modules/ggdeploymentd/src/stale_component.h
+++ b/modules/ggdeploymentd/src/stale_component.h
@@ -4,10 +4,27 @@
 #include "deployment_model.h"
 #include <gg/error.h>
 #include <gg/types.h>
+#include <gg/vector.h>
 
 GgError disable_and_unlink_service(
     GgBuffer *component_name, PhaseSelection phase
 );
-GgError cleanup_stale_versions(GgMap latest_components_map);
+
+/// Iterates installed component recipes and removes any whose name+version is
+/// not in @p latest_components_map. Components whose name is missing entirely
+/// from the map are treated as fully removed: their config tree, services and
+/// recipe files are deleted.
+///
+/// If both @p removed_names_storage and @p removed_components_out are
+/// non-NULL, fully-removed component names are also recorded in the output
+/// (deduplicated). Each name is copied into @p removed_names_storage and a
+/// slice referencing those bytes is pushed onto @p removed_components_out.
+/// The slices remain valid as long as @p removed_names_storage's backing
+/// buffer is alive.
+GgError cleanup_stale_versions(
+    GgMap latest_components_map,
+    GgByteVec *removed_names_storage,
+    GgBufVec *removed_components_out
+);
 
 #endif

--- a/modules/tes-serverd/src/http_server.c
+++ b/modules/tes-serverd/src/http_server.c
@@ -276,6 +276,13 @@ GgError http_server(void) {
         return ret;
     }
 
+    // Seed an empty fleet configuration ARN list at the lowest possible
+    // timestamp (0). This guarantees the component always has a list-typed
+    // configArn (so gg-fleet-statusd includes TES in its status reports), while
+    // letting ggdeploymentd overwrite it with the real deployment configuration
+    // ARN (written at a higher timestamp). Using the default current-time
+    // timestamp here would clobber that deployment-assigned ARN on every
+    // restart, leaving fleetConfigArns empty so the cloud never displays TES.
     ret = ggl_gg_config_write(
         GG_BUF_LIST(
             GG_STR("services"),
@@ -283,7 +290,7 @@ GgError http_server(void) {
             GG_STR("configArn")
         ),
         gg_obj_list(GG_LIST()),
-        NULL
+        &(int64_t) { 0 }
     );
     if (ret != GG_ERR_OK) {
         GG_LOGE("Failed to write configuration arn list for TES to the config."


### PR DESCRIPTION
## Description

Brief description of the changes in this PR.

## Related Issue

The first commit fixes the issue: #1126 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [x] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [x] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [x] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
    - https://github.com/aws-greengrass/aws-greengrass-testing/pull/307 
- [x] Tested manually

## Additional Notes
Tested manually by:
- Deploying 2 components and one of them depends on TES
- Wait for deployment to finish
- Do a new deployment removes 1 of the components 
- Wait for deployment to finish
- Check in the console if the removed component's name is removed from the console
- Do a new deployment again that removes the component that depends on TES
- Wait for deployment to finish
- Check if the component as well as TES is removed from cloud.


_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
