### PR TITLE
Persist and report deployment status across reconnect/reboot

### DIFF
--- a/modules/ggdeploymentd/src/iot_jobs_listener.c
+++ b/modules/ggdeploymentd/src/iot_jobs_listener.c
@@ -194,6 +194,29 @@ static GgError deserialize_payload(
     return GG_ERR_OK;
 }
 
+// True if an IoT Jobs UpdateJobExecution rejection won't succeed on retry, per
+// the Jobs ErrorResponse "code" contract. InternalError and RequestThrottled
+// are transient, and any unrecognized code is treated as transient too, so
+// those fall through to the persist/retry path.
+static bool reject_is_permanent(GgObject result) {
+    if (gg_obj_type(result) != GG_TYPE_MAP) {
+        return false;
+    }
+    GgObject *code_obj;
+    if (!gg_map_get(gg_obj_into_map(result), GG_STR("code"), &code_obj)
+        || (gg_obj_type(*code_obj) != GG_TYPE_BUF)) {
+        return false;
+    }
+    GgBuffer code = gg_obj_into_buf(*code_obj);
+    return gg_buffer_eq(code, GG_STR("InvalidTopic"))
+        || gg_buffer_eq(code, GG_STR("InvalidJson"))
+        || gg_buffer_eq(code, GG_STR("InvalidRequest"))
+        || gg_buffer_eq(code, GG_STR("InvalidStateTransition"))
+        || gg_buffer_eq(code, GG_STR("ResourceNotFound"))
+        || gg_buffer_eq(code, GG_STR("VersionMismatch"))
+        || gg_buffer_eq(code, GG_STR("TerminalStateReached"));
+}
+
 static GgError update_job_to(
     GgBuffer job_id, GgBuffer job_status, GgBuffer socket_name
 ) {
@@ -215,7 +238,9 @@ static GgError update_job_to(
         gg_kv(GG_STR("clientToken"), gg_obj_buf(GG_STR("jobs-nucleus-lite")))
     ));
 
-    static uint8_t response_scratch[512];
+    // Holds the decoded /accepted or /rejected response. Sized to fit a
+    // rejection's executionState payload so the reject code can be classified.
+    static uint8_t response_scratch[1024];
     GgArena call_alloc = gg_arena_init(GG_BUF(response_scratch));
     GgObject result = { 0 };
     ret = ggl_aws_iot_call(
@@ -223,16 +248,30 @@ static GgError update_job_to(
     );
     if (ret != GG_ERR_OK) {
         GG_LOGE("Failed to publish on update job topic.");
-        // Persist so the job listener can re-send the status after reconnect
-        // or restart.
         if (track_pending) {
-            (void) status_keeper_persist(job_id, job_status);
-            // Wake the job listener so it starts the periodic flush retry even
-            // when no MQTT reconnect follows (e.g. a throttle reject or
-            // response timeout while the connection stays up).
-            pthread_once(&listener_cond_once, init_listener_cond);
-            GG_MTX_SCOPE_GUARD(&listener_mutex);
-            pthread_cond_signal(&listener_cond);
+            if ((ret == GG_ERR_REMOTE) && reject_is_permanent(result)) {
+                // Cloud permanently rejected this update (e.g. the job already
+                // reached a terminal state, or was superseded). Retrying can't
+                // succeed, so drop any pending slot instead of re-sending it
+                // indefinitely.
+                GG_LOGW(
+                    "Update permanently rejected; clearing pending status for "
+                    "job %.*s.",
+                    (int) job_id.len,
+                    job_id.data
+                );
+                (void) status_keeper_clear();
+            } else {
+                // Transport failure / timeout / retryable reject
+                // (InternalError, RequestThrottled): persist so the job
+                // listener can re-send the status after reconnect or restart,
+                // and wake it to start the periodic flush retry even when no
+                // MQTT reconnect follows.
+                (void) status_keeper_persist(job_id, job_status);
+                pthread_once(&listener_cond_once, init_listener_cond);
+                GG_MTX_SCOPE_GUARD(&listener_mutex);
+                pthread_cond_signal(&listener_cond);
+            }
         }
         return GG_ERR_FAILURE;
     }

--- a/modules/ggdeploymentd/src/iot_jobs_listener.c
+++ b/modules/ggdeploymentd/src/iot_jobs_listener.c
@@ -340,6 +340,14 @@ static GgError enqueue_job(GgMap deployment_doc, GgBuffer job_id) {
         ++retries;
     }
 
+    // A new deployment supersedes any status still pending for a previous one.
+    // greengrass lite tracks a single deployment at a time ($next), so reaching
+    // here with a new job_id means the prior deployment has finalized and any
+    // held status is stale -- drop it so we never re-publish a superseded job's
+    // status. status_keeper_clear() self-gates on the pending hint, so this is
+    // a no-op when nothing is pending.
+    (void) status_keeper_clear();
+
     if (ret != GG_ERR_OK) {
         (void) update_job(job_id, GG_STR("FAILURE"));
     }

--- a/modules/ggdeploymentd/src/iot_jobs_listener.c
+++ b/modules/ggdeploymentd/src/iot_jobs_listener.c
@@ -27,11 +27,16 @@
 #include <pthread.h>
 #include <string.h>
 #include <sys/types.h>
+#include <time.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdnoreturn.h>
 
 #define MAX_THING_NAME_LEN 128
+
+// Re-publish a persisted status at most this often while one is pending, so a
+// publish that failed without an MQTT disconnect still recovers.
+#define STATUS_FLUSH_RETRY_SECONDS 60
 
 typedef enum QualityOfService {
     QOS_FIRE_AND_FORGET = 0,
@@ -69,8 +74,23 @@ static uint8_t current_deployment_id_buf[64];
 static GgByteVec current_deployment_id;
 
 static pthread_mutex_t listener_mutex = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t listener_cond = PTHREAD_COND_INITIALIZER;
+// listener_cond uses CLOCK_MONOTONIC so the flush retry timeout is immune to
+// wall-clock changes. It is initialized exactly once via listener_cond_once:
+// both the listener thread (before waiting) and update_job_to on the
+// deployment-handler thread (before signaling) run pthread_once, since either
+// may reach the cond first after startup.
+static pthread_cond_t listener_cond;
+static pthread_once_t listener_cond_once = PTHREAD_ONCE_INIT;
 static bool needs_describe = false;
+static bool needs_flush = false;
+
+static void init_listener_cond(void) {
+    pthread_condattr_t cond_attr;
+    pthread_condattr_init(&cond_attr);
+    pthread_condattr_setclock(&cond_attr, CLOCK_MONOTONIC);
+    pthread_cond_init(&listener_cond, &cond_attr);
+    pthread_condattr_destroy(&cond_attr);
+}
 
 static void listen_for_jobs_deployments(void);
 
@@ -207,6 +227,12 @@ static GgError update_job_to(
         // or restart.
         if (track_pending) {
             (void) status_keeper_persist(job_id, job_status);
+            // Wake the job listener so it starts the periodic flush retry even
+            // when no MQTT reconnect follows (e.g. a throttle reject or
+            // response timeout while the connection stays up).
+            pthread_once(&listener_cond_once, init_listener_cond);
+            GG_MTX_SCOPE_GUARD(&listener_mutex);
+            pthread_cond_signal(&listener_cond);
         }
         return GG_ERR_FAILURE;
     }
@@ -424,21 +450,82 @@ static GgError next_job_execution_changed_callback(
     return GG_ERR_OK;
 }
 
+// Re-send the persisted pending status (if any) by re-running update_job with
+// the slot's contents. On success update_job_to clears the slot; on failure it
+// re-persists. Reads from config each time, so a status persisted before a
+// restart is recovered.
+static void flush_pending_status(void) {
+    static uint8_t slot_scratch[512];
+    GgArena alloc = gg_arena_init(GG_BUF(slot_scratch));
+    GgBuffer job_id = { 0 };
+    GgBuffer job_status = { 0 };
+    GgError ret = status_keeper_read(&alloc, &job_id, &job_status);
+    if (ret != GG_ERR_OK) {
+        // Nothing pending to flush (or the slot was unreadable).
+        return;
+    }
+    GG_LOGI(
+        "Re-sending pending deployment status %.*s for job %.*s.",
+        (int) job_status.len,
+        job_status.data,
+        (int) job_id.len,
+        job_id.data
+    );
+    (void) update_job(job_id, job_status);
+}
+
 noreturn void *job_listener_thread(void *ctx) {
     (void) ctx;
+
+    pthread_once(&listener_cond_once, init_listener_cond);
+
     (void) gg_backoff(1, 1000, 0, get_thing_name, NULL);
+
+    // Sync the pending-status hint with on-disk state before subscribing, so a
+    // status persisted before a restart is tracked (and re-sent on connect).
+    {
+        static uint8_t slot_scratch[512];
+        GgArena slot_alloc = gg_arena_init(GG_BUF(slot_scratch));
+        (void) status_keeper_read(&slot_alloc, NULL, NULL);
+    }
+
     listen_for_jobs_deployments();
 
     // coverity[infinite_loop]
     while (true) {
+        bool do_describe = false;
+        bool do_flush = false;
         {
             GG_MTX_SCOPE_GUARD(&listener_mutex);
-            while (!needs_describe) {
-                pthread_cond_wait(&listener_cond, &listener_mutex);
+            while (!needs_describe && !needs_flush) {
+                if (status_keeper_has_pending()) {
+                    // A status is awaiting delivery: wake periodically to retry
+                    // the flush even with no reconnect (covers a publish that
+                    // failed while the connection stayed up).
+                    struct timespec deadline;
+                    clock_gettime(CLOCK_MONOTONIC, &deadline);
+                    deadline.tv_sec += STATUS_FLUSH_RETRY_SECONDS;
+                    (void) pthread_cond_timedwait(
+                        &listener_cond, &listener_mutex, &deadline
+                    );
+                    if (status_keeper_has_pending()) {
+                        needs_flush = true;
+                    }
+                } else {
+                    pthread_cond_wait(&listener_cond, &listener_mutex);
+                }
             }
+            do_describe = needs_describe;
             needs_describe = false;
+            do_flush = needs_flush;
+            needs_flush = false;
         }
-        (void) gg_backoff(10, 10000, 0, describe_next_job, NULL);
+        if (do_describe) {
+            (void) gg_backoff(10, 10000, 0, describe_next_job, NULL);
+        }
+        if (do_flush) {
+            flush_pending_status();
+        }
     }
 }
 
@@ -479,6 +566,7 @@ static GgError iot_jobs_on_reconnect(
         GG_LOGD("Reconnected to MQTT; requesting new job query publish.");
         GG_MTX_SCOPE_GUARD(&listener_mutex);
         needs_describe = true;
+        needs_flush = true;
         pthread_cond_signal(&listener_cond);
     }
     return GG_ERR_OK;

--- a/modules/ggdeploymentd/src/iot_jobs_listener.c
+++ b/modules/ggdeploymentd/src/iot_jobs_listener.c
@@ -6,6 +6,7 @@
 #include "bootstrap_manager.h"
 #include "deployment_model.h"
 #include "deployment_queue.h"
+#include "status_keeper.h"
 #include <assert.h>
 #include <gg/arena.h>
 #include <gg/backoff.h>
@@ -182,6 +183,11 @@ static GgError update_job_to(
         return ret;
     }
 
+    // The pending-status slot is only tracked for the primary MQTT socket.
+    // The endpoint-switch path uses a temporary "iotcoreddeploy" socket with
+    // its own retry; persisting that would later flush via the wrong account.
+    bool track_pending = gg_buffer_eq(socket_name, GG_STR("aws_iot_mqtt"));
+
     // expectedVersion omitted to avoid VersionMismatch errors on MQTT
     // reconnect races; only one ggdeploymentd updates a given job.
     GgObject payload_object = gg_obj_map(GG_MAP(
@@ -197,7 +203,19 @@ static GgError update_job_to(
     );
     if (ret != GG_ERR_OK) {
         GG_LOGE("Failed to publish on update job topic.");
+        // Persist so the job listener can re-send the status after reconnect
+        // or restart.
+        if (track_pending) {
+            (void) status_keeper_persist(job_id, job_status);
+        }
         return GG_ERR_FAILURE;
+    }
+
+    // Publish succeeded: drop any previously-persisted pending status (it is
+    // now delivered, or superseded by this newer one). Self-gated in
+    // status_keeper, so the happy path issues no config call.
+    if (track_pending) {
+        (void) status_keeper_clear();
     }
 
     // save jobs ID to config in case of bootstrap

--- a/modules/ggdeploymentd/src/status_keeper.c
+++ b/modules/ggdeploymentd/src/status_keeper.c
@@ -1,0 +1,136 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "status_keeper.h"
+#include <gg/arena.h>
+#include <gg/buffer.h>
+#include <gg/cleanup.h>
+#include <gg/error.h>
+#include <gg/flags.h>
+#include <gg/log.h>
+#include <gg/map.h>
+#include <gg/object.h>
+#include <ggl/core_bus/gg_config.h>
+#include <pthread.h>
+#include <sys/types.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+// ggconfigd key path for the pending deployment-status slot.
+#define PENDING_STATUS_KEY_PATH \
+    GG_BUF_LIST( \
+        GG_STR("services"), \
+        GG_STR("DeploymentService"), \
+        GG_STR("pendingStatus") \
+    )
+
+// Guards the config slot and the slot_pending hint. update_job_to can be
+// reached from both the deployment-handler thread and the job-listener thread,
+// so all operations are serialized here. ggconfigd serializes the underlying
+// config ops, but the in-memory hint still needs guarding.
+static pthread_mutex_t slot_mtx = PTHREAD_MUTEX_INITIALIZER;
+
+// Cheap cache of "does a slot exist". Kept in sync by persist (set), read
+// (set on hit), and clear (unset). Authoritative state is the config slot;
+// this only lets the happy path avoid a config call.
+static bool slot_pending = false;
+
+GgError status_keeper_persist(GgBuffer job_id, GgBuffer status) {
+    GG_MTX_SCOPE_GUARD(&slot_mtx);
+
+    // NULL timestamp => ggconfigd stamps with current time (matches the
+    // configuration-merge write in component_config.c).
+    GgError ret = ggl_gg_config_write(
+        PENDING_STATUS_KEY_PATH,
+        gg_obj_map(GG_MAP(
+            gg_kv(GG_STR("job_id"), gg_obj_buf(job_id)),
+            gg_kv(GG_STR("status"), gg_obj_buf(status))
+        )),
+        NULL
+    );
+    if (ret != GG_ERR_OK) {
+        GG_LOGE(
+            "Failed to persist pending deployment status: %s", gg_strerror(ret)
+        );
+        return ret;
+    }
+
+    slot_pending = true;
+    GG_LOGD(
+        "Persisted pending status %.*s for job %.*s.",
+        (int) status.len,
+        status.data,
+        (int) job_id.len,
+        job_id.data
+    );
+    return GG_ERR_OK;
+}
+
+GgError status_keeper_read(GgArena *alloc, GgBuffer *job_id, GgBuffer *status) {
+    GG_MTX_SCOPE_GUARD(&slot_mtx);
+
+    GgObject slot_obj;
+    GgError ret = ggl_gg_config_read(PENDING_STATUS_KEY_PATH, alloc, &slot_obj);
+    if (ret != GG_ERR_OK) {
+        // Typically GG_ERR_NOENTRY: no slot stored. Leave the hint untouched on
+        // a transient read error; only a confirmed write/clear changes it.
+        return ret;
+    }
+
+    if (gg_obj_type(slot_obj) != GG_TYPE_MAP) {
+        GG_LOGE("Pending status slot is not a map.");
+        return GG_ERR_INVALID;
+    }
+
+    GgObject *job_id_obj = NULL;
+    GgObject *status_obj = NULL;
+    ret = gg_map_validate(
+        gg_obj_into_map(slot_obj),
+        GG_MAP_SCHEMA(
+            { GG_STR("job_id"), GG_REQUIRED, GG_TYPE_BUF, &job_id_obj },
+            { GG_STR("status"), GG_REQUIRED, GG_TYPE_BUF, &status_obj }
+        )
+    );
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("Pending status slot is missing required fields.");
+        return ret;
+    }
+
+    if (job_id != NULL) {
+        *job_id = gg_obj_into_buf(*job_id_obj);
+    }
+    if (status != NULL) {
+        *status = gg_obj_into_buf(*status_obj);
+    }
+
+    slot_pending = true;
+    return GG_ERR_OK;
+}
+
+GgError status_keeper_clear(void) {
+    GG_MTX_SCOPE_GUARD(&slot_mtx);
+
+    // Self-gated no-op when nothing is pending (see status_keeper.h for the
+    // startup-sync requirement).
+    if (!slot_pending) {
+        return GG_ERR_OK;
+    }
+
+    GgError ret = ggl_gg_config_delete(PENDING_STATUS_KEY_PATH);
+    if (ret != GG_ERR_OK) {
+        GG_LOGE(
+            "Failed to clear pending deployment status: %s", gg_strerror(ret)
+        );
+        return ret;
+    }
+
+    slot_pending = false;
+    GG_LOGD("Cleared pending deployment status slot.");
+    return GG_ERR_OK;
+}
+
+bool status_keeper_has_pending(void) {
+    GG_MTX_SCOPE_GUARD(&slot_mtx);
+    return slot_pending;
+}

--- a/modules/ggdeploymentd/src/status_keeper.h
+++ b/modules/ggdeploymentd/src/status_keeper.h
@@ -1,0 +1,61 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GGDEPLOYMENTD_STATUS_KEEPER_H
+#define GGDEPLOYMENTD_STATUS_KEEPER_H
+
+//! Single-slot persistence for the latest undelivered IoT Jobs status update.
+//!
+//! ggdeploymentd reports deployment status (IN_PROGRESS / SUCCEEDED / FAILED)
+//! to IoT Jobs with a single fire-and-forget publish. If that publish fails
+//! (flaky network, reboot mid-outage) the update is lost and the cloud-side job
+//! is left stale. This module persists the pending status to ggconfigd so it
+//! can be re-sent once connectivity returns or after a restart.
+//!
+//! greengrass lite only tracks one deployment at a time ($next), so a single
+//! slot is stored at config `services/DeploymentService/pendingStatus` and
+//! replaced in place -- this is intentionally NOT a queue.
+//!
+//! Pure storage: this module persists / reads / clears the slot. Flush
+//! orchestration (deciding when to re-send) lives in iot_jobs_listener.c.
+//!
+//! Thread-safe: all access is guarded by an internal mutex.
+
+#include <gg/arena.h>
+#include <gg/error.h>
+#include <gg/types.h>
+#include <stdbool.h>
+
+/// Persist (overwrite) the pending status slot.
+///
+/// Writes `{ job_id, status }` to the config slot, replacing any existing slot
+/// in place. `job_id` is required to rebuild the update topic on re-send. On
+/// success the in-memory "pending" hint is set.
+GgError status_keeper_persist(GgBuffer job_id, GgBuffer status);
+
+/// Read the pending status slot.
+///
+/// On success returns GG_ERR_OK and points `job_id` and `status` at buffers
+/// allocated from `alloc` (valid for the lifetime of `alloc`'s backing memory).
+/// Any out-pointer may be NULL if that field is not needed. Returns the
+/// underlying config error if no slot is stored (typically GG_ERR_NOENTRY). On
+/// success the in-memory "pending" hint is set, so calling this once at startup
+/// syncs the hint with on-disk state.
+GgError status_keeper_read(GgArena *alloc, GgBuffer *job_id, GgBuffer *status);
+
+/// Clear the pending status slot.
+///
+/// Idempotent: if the in-memory "pending" hint indicates nothing is stored this
+/// is a no-op that issues no config call (keeps the happy path free of I/O).
+/// The hint must be synced first via status_keeper_read() at startup so a slot
+/// persisted before a restart is not skipped. Clears the hint on success.
+GgError status_keeper_clear(void);
+
+/// In-memory check for whether a slot is (believed to be) pending.
+///
+/// Reads the cached hint (no config call of its own) to gate the periodic
+/// flush retry. The config slot remains authoritative.
+bool status_keeper_has_pending(void);
+
+#endif


### PR DESCRIPTION
 ## Problem
  ggdeploymentd reports deployment status (IN_PROGRESS / SUCCEEDED / FAILED)
  to IoT Jobs with a single fire-and-forget publish. If that publish fails —
  flaky network, or a reboot mid-outage — the update is lost and the cloud-side
  job is left stuck non-terminal. Because nucleus lite tracks work via `$next`,
  that stale job is what $next keeps returning.
  
  ## Change
  Adds a config-backed, single-slot status keeper in ggdeploymentd. The latest
  undelivered status (`{job_id, status}`) is persisted to ggconfigd and re-sent
  when possible:
  
  - **Persist** on publish failure (the single chokepoint in `update_job_to`).
  - **Flush** on MQTT reconnect, on startup (covers reboots — the slot lives in
    ggconfigd, not memory), and on a 60s retry timer while a slot is pending.
  - **Clear** on successful delivery.
  - **Supersede**: a new deployment drops any stale slot (lite only tracks one
    deployment at a time).
  - **Drop on permanent reject**: if the cloud rejects with a non-retryable code
    (e.g. `InvalidStateTransition`, `TerminalStateReached`), clear the slot
    instead of retrying forever. Transport failures and retryable rejects
    (`InternalError`, `RequestThrottled`) keep retrying.
  
  Reuses the existing job-listener thread; no new threads.
  
  ## Commits
  1. Add status_keeper for pending deployment status
  2. Persist deployment status on publish failure
  3. Flush persisted status on reconnect and retry
  4. Clear stale status slot on new deployment
  5. Classify permanent vs retryable job rejects
  
  ## Testing
  - `nix flake check` green on every commit (build, clang-tidy, IWYU, cppcheck,
    tests).
  - Manual end-to-end against real IoT Core: persist → reconnect-flush → clear,
    60s-timer retry, reboot recovery, new-deployment supersede, and
    permanent-reject drop (captured a real `InvalidStateTransition`). Confirmed
    the bug reproduces on `main` (status stuck `IN_PROGRESS`) and is fixed here.
