### PR TITLE
recipe2unit: order user-declared dependencies with After=

### DIFF
--- a/modules/recipe2unit/src/unit_file_generator.c
+++ b/modules/recipe2unit/src/unit_file_generator.c
@@ -65,12 +65,26 @@ static GgError parse_dependency_type(
                 &ret, out, gg_kv_key(component_dependency)
             );
             gg_byte_vec_chain_append(&ret, out, GG_STR(".service\n"));
+            // BindsTo= does not order startup (systemd.unit(5)); add After=
+            // so the Type=notify dependency is READY before dependents start.
+            gg_byte_vec_chain_append(&ret, out, GG_STR("After=ggl."));
+            gg_byte_vec_chain_append(
+                &ret, out, gg_kv_key(component_dependency)
+            );
+            gg_byte_vec_chain_append(&ret, out, GG_STR(".service\n"));
             if (ret != GG_ERR_OK) {
                 return ret;
             }
 
         } else {
             GgError ret = gg_byte_vec_append(out, GG_STR("Wants=ggl."));
+            gg_byte_vec_chain_append(
+                &ret, out, gg_kv_key(component_dependency)
+            );
+            gg_byte_vec_chain_append(&ret, out, GG_STR(".service\n"));
+            // Wants= does not order startup either; add After= (see HARD
+            // branch above).
+            gg_byte_vec_chain_append(&ret, out, GG_STR("After=ggl."));
             gg_byte_vec_chain_append(
                 &ret, out, gg_kv_key(component_dependency)
             );

--- a/modules/tes-serverd/unit/ggl.aws.greengrass.TokenExchangeService.service.in
+++ b/modules/tes-serverd/unit/ggl.aws.greengrass.TokenExchangeService.service.in
@@ -19,7 +19,7 @@ StateDirectory=greengrass
 WorkingDirectory=%S/greengrass
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=greengrass-lite.target
 
 [Unit]
 After=ggl.core.ggconfigd.service

--- a/test_modules/recipe2unit-test/src/entry.c
+++ b/test_modules/recipe2unit-test/src/entry.c
@@ -2,45 +2,233 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX - License - Identifier : Apache - 2.0
 
+#include <errno.h>
 #include <fcntl.h>
+#include <ftw.h>
 #include <gg/arena.h>
 #include <gg/buffer.h>
+#include <gg/cleanup.h>
 #include <gg/error.h>
 #include <gg/file.h>
 #include <gg/log.h>
 #include <gg/types.h>
 #include <ggl/recipe2unit.h>
+#include <grp.h>
+#include <pwd.h>
 #include <recipe2unit-test.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 
-// For the testing purpose, move the sample recipe.yml to /run/packages/recipes
-// and rename it to recipe-1.0.0.yml
+// Forward declare structure for use in the function below.
+struct stat;
+
+// Placeholder component names kept intentionally generic.
+#define TEST_COMPONENT_NAME "com.example.TestComponent"
+#define TEST_COMPONENT_VERSION "1.0.0"
+#define TEST_HARD_DEP "com.example.HardDep"
+#define TEST_SOFT_DEP "com.example.SoftDep"
+
+// A recipe with one HARD and one SOFT dependency plus a run lifecycle, so the
+// generated run/startup unit file contains the [Unit] dependency directives.
+static const char TEST_RECIPE[]
+    = "---\n"
+      "RecipeFormatVersion: \"2020-01-25\"\n"
+      "ComponentName: " TEST_COMPONENT_NAME "\n"
+      "ComponentVersion: \"" TEST_COMPONENT_VERSION "\"\n"
+      "ComponentDescription: Dependency ordering test component.\n"
+      "ComponentPublisher: Example\n"
+      "ComponentDependencies:\n"
+      "  " TEST_HARD_DEP ":\n"
+      "    VersionRequirement: \">=1.0.0 <2.0.0\"\n"
+      "    DependencyType: \"HARD\"\n"
+      "  " TEST_SOFT_DEP ":\n"
+      "    VersionRequirement: \">=1.0.0 <2.0.0\"\n"
+      "    DependencyType: \"SOFT\"\n"
+      "Manifests:\n"
+      "  - Platform:\n"
+      "      os: linux\n"
+      "      runtime: \"*\"\n"
+      "    Lifecycle:\n"
+      "      run: \"true\"\n";
+
+static GgError write_text_file(const char *path, const char *content) {
+    FILE *file = fopen(path, "we");
+    if (file == NULL) {
+        GG_LOGE("Failed to open %s for writing: %d.", path, errno);
+        return GG_ERR_FAILURE;
+    }
+    size_t len = strlen(content);
+    size_t written = fwrite(content, 1, len, file);
+    int close_ret = fclose(file);
+    if ((written != len) || (close_ret != 0)) {
+        GG_LOGE("Failed to write %s.", path);
+        return GG_ERR_FAILURE;
+    }
+    return GG_ERR_OK;
+}
+
+static GgError read_text_file(
+    const char *path, char *out, size_t out_cap, size_t *out_len
+) {
+    FILE *file = fopen(path, "re");
+    if (file == NULL) {
+        GG_LOGE("Failed to open %s for reading: %d.", path, errno);
+        return GG_ERR_FAILURE;
+    }
+    size_t total = fread(out, 1, out_cap - 1, file);
+    int close_ret = fclose(file);
+    if (close_ret != 0) {
+        return GG_ERR_FAILURE;
+    }
+    out[total] = '\0';
+    *out_len = total;
+    return GG_ERR_OK;
+}
+
+static GgError assert_contains(const char *haystack, const char *needle) {
+    if (strstr(haystack, needle) == NULL) {
+        GG_LOGE(
+            "Generated unit file is missing expected directive: %s", needle
+        );
+        return GG_ERR_FAILURE;
+    }
+    GG_LOGI("Found expected directive: %s", needle);
+    return GG_ERR_OK;
+}
+
+// Looks up the current process's user and group names so the generated unit
+// owns its working directory as the caller. This keeps the test hermetic: the
+// fchown() performed during generation targets the caller's own uid/gid and so
+// succeeds without elevated privileges.
+static GgError current_user_and_group(
+    const char **user_out, const char **group_out
+) {
+    struct passwd *pw = getpwuid(getuid());
+    if ((pw == NULL) || (pw->pw_name == NULL)) {
+        GG_LOGE("Failed to resolve current user name.");
+        return GG_ERR_FAILURE;
+    }
+    struct group *gr = getgrgid(getgid());
+    if ((gr == NULL) || (gr->gr_name == NULL)) {
+        GG_LOGE("Failed to resolve current group name.");
+        return GG_ERR_FAILURE;
+    }
+    *user_out = pw->pw_name;
+    *group_out = gr->gr_name;
+    return GG_ERR_OK;
+}
+
+// nftw callback that removes a single path. Returns 0 so traversal continues
+// even if an individual removal fails, mirroring the recursive-delete idiom
+// used elsewhere in this project.
+static int unlink_cb(
+    const char *path, const struct stat *sb, int type_flag, struct FTW *ftw_buf
+) {
+    (void) sb;
+    (void) type_flag;
+    (void) ftw_buf;
+    if (remove(path) != 0) {
+        GG_LOGW("Failed to remove %s: %d.", path, errno);
+    }
+    return 0;
+}
+
+// Recursively removes the temporary directory tree (recipe, generated unit
+// files, the work directory, and the directories themselves) so the test
+// leaves nothing behind under /tmp. Registered with GG_CLEANUP so it runs on
+// every exit path, including early error returns.
+static void cleanup_remove_tree(char **path) {
+    if ((path == NULL) || (*path == NULL)) {
+        return;
+    }
+    // FTW_DEPTH visits directory contents before the directory itself so the
+    // tree empties bottom-up; FTW_PHYS avoids following symlinks.
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    (void) nftw(*path, unlink_cb, 16, FTW_DEPTH | FTW_PHYS);
+}
 
 GgError run_recipe2unit_test(void) {
+    // Build a temporary root directory laid out like a Greengrass root:
+    //   <root>/packages/recipes/<name>-<version>.yml
+    char root_dir[] = "/tmp/recipe2unit-test-XXXXXX";
+    if (mkdtemp(root_dir) == NULL) {
+        GG_LOGE("Failed to create temp dir: %d.", errno);
+        return GG_ERR_FAILURE;
+    }
+    // Ensure the entire temp tree is removed on every exit path below.
+    GG_CLEANUP(cleanup_remove_tree, (char *) root_dir);
+
+    char path_buf[4096];
+    int printed = snprintf(path_buf, sizeof(path_buf), "%s/packages", root_dir);
+    if ((printed < 0) || ((size_t) printed >= sizeof(path_buf))) {
+        return GG_ERR_FAILURE;
+    }
+    if ((mkdir(path_buf, 0755) != 0) && (errno != EEXIST)) {
+        GG_LOGE("Failed to create %s: %d.", path_buf, errno);
+        return GG_ERR_FAILURE;
+    }
+    printed
+        = snprintf(path_buf, sizeof(path_buf), "%s/packages/recipes", root_dir);
+    if ((printed < 0) || ((size_t) printed >= sizeof(path_buf))) {
+        return GG_ERR_FAILURE;
+    }
+    if ((mkdir(path_buf, 0755) != 0) && (errno != EEXIST)) {
+        GG_LOGE("Failed to create %s: %d.", path_buf, errno);
+        return GG_ERR_FAILURE;
+    }
+
+    printed = snprintf(
+        path_buf,
+        sizeof(path_buf),
+        "%s/packages/recipes/%s-%s.yml",
+        root_dir,
+        TEST_COMPONENT_NAME,
+        TEST_COMPONENT_VERSION
+    );
+    if ((printed < 0) || ((size_t) printed >= sizeof(path_buf))) {
+        return GG_ERR_FAILURE;
+    }
+    GgError ret = write_text_file(path_buf, TEST_RECIPE);
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+
+    const char *user = NULL;
+    const char *group = NULL;
+    ret = current_user_and_group(&user, &group);
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+
     static Recipe2UnitArgs args = { 0 };
-    GgBuffer root_dir = GG_STR(".");
-    GgBuffer recipe_runner_path = GG_STR("[Path to recipe runner here]");
+    GgBuffer recipe_runner_path = GG_STR("/bin/sh");
 
     int root_path_fd;
-    GgError ret = gg_dir_open(root_dir, O_PATH, false, &root_path_fd);
+    ret = gg_dir_open(
+        gg_buffer_from_null_term(root_dir), O_PATH, false, &root_path_fd
+    );
     if (ret != GG_ERR_OK) {
         GG_LOGE("Failed to open root dir.");
         return ret;
     }
+    GG_CLEANUP(cleanup_close, root_path_fd);
     args.root_path_fd = root_path_fd;
 
-    memcpy(args.root_dir, root_dir.data, root_dir.len + 1);
-    args.user = "ubuntu";
-    args.group = "ubuntu";
+    memcpy(args.root_dir, root_dir, strlen(root_dir) + 1);
+    args.user = user;
+    args.group = group;
     memcpy(
         args.recipe_runner_path,
         recipe_runner_path.data,
         recipe_runner_path.len + 1
     );
-    args.component_name = GG_STR("[Component Name here]");
-    args.component_version = GG_STR("[Component Version here]");
+    args.component_name = GG_STR(TEST_COMPONENT_NAME);
+    args.component_version = GG_STR(TEST_COMPONENT_VERSION);
 
     GgObject recipe_map;
     GgObject *component_name_obj;
@@ -48,7 +236,56 @@ GgError run_recipe2unit_test(void) {
     GgArena alloc = gg_arena_init(GG_BUF(big_buffer_for_bump));
     HasPhase phases = { 0 };
 
-    return convert_to_unit(
+    ret = convert_to_unit(
         &args, &alloc, &recipe_map, &component_name_obj, &phases
     );
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("convert_to_unit failed.");
+        return ret;
+    }
+    if (!phases.has_run_startup) {
+        GG_LOGE("Expected a run/startup unit file to be generated.");
+        return GG_ERR_FAILURE;
+    }
+
+    // Read back the generated run/startup unit file.
+    printed = snprintf(
+        path_buf,
+        sizeof(path_buf),
+        "%s/ggl.%s.service",
+        root_dir,
+        TEST_COMPONENT_NAME
+    );
+    if ((printed < 0) || ((size_t) printed >= sizeof(path_buf))) {
+        return GG_ERR_FAILURE;
+    }
+
+    static char unit_text[8192];
+    size_t unit_len = 0;
+    ret = read_text_file(path_buf, unit_text, sizeof(unit_text), &unit_len);
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+    GG_LOGI("Generated unit file (%zu bytes):\n%s", unit_len, unit_text);
+
+    // A HARD dependency must produce BindsTo= AND a matching After= for
+    // ordering. A SOFT dependency must produce Wants= AND a matching After=.
+    GgError check = GG_ERR_OK;
+    GgError step;
+    step = assert_contains(unit_text, "BindsTo=ggl." TEST_HARD_DEP ".service");
+    check = (check == GG_ERR_OK) ? step : check;
+    step = assert_contains(unit_text, "After=ggl." TEST_HARD_DEP ".service");
+    check = (check == GG_ERR_OK) ? step : check;
+    step = assert_contains(unit_text, "Wants=ggl." TEST_SOFT_DEP ".service");
+    check = (check == GG_ERR_OK) ? step : check;
+    step = assert_contains(unit_text, "After=ggl." TEST_SOFT_DEP ".service");
+    check = (check == GG_ERR_OK) ? step : check;
+
+    if (check != GG_ERR_OK) {
+        GG_LOGE("Dependency ordering assertions failed.");
+        return check;
+    }
+
+    GG_LOGI("All dependency ordering assertions passed.");
+    return GG_ERR_OK;
 }


### PR DESCRIPTION
## Description

`recipe2unit`'s `parse_dependency_type` emits `BindsTo=` (HARD) or `Wants=`
(SOFT) for each user-declared component dependency, but never `After=`. Per
`systemd.unit(5)`, neither directive enforces start ordering, so on a cold boot
systemd starts a dependent component in parallel with the dependency it relies
on.

This matters for `Type=notify` dependencies such as `tes-serverd`
(TokenExchangeService), which binds an ephemeral port, writes it to config, and
only then signals `READY=1`. Without ordering, `recipe-runner` can spawn a
dependent out-of-process component and read a stale port before `tes-serverd`
publishes the current one, baking a dead `AWS_CONTAINER_CREDENTIALS_FULL_URI`
into the component's environment. Any out-of-process component that uses the AWS
SDK container-credentials provider then fails every credential fetch (connection
refused) until it is manually restarted — and because the unit reports
`active (running)`, the failure is silent.

This change adds `After=ggl.<dep>.service` in both the HARD and SOFT branches,
mirroring the existing hardcoded `ggipcd` dependency in the same file. Since
`tes-serverd` is `Type=notify` and signals `READY` only after writing its port,
`After=` alone is sufficient to close the race.

It also changes the TokenExchangeService unit's `[Install] WantedBy=` from
`multi-user.target` to `greengrass-lite.target`, aligning it with every other
greengrass-lite unit (it was the lone outlier, and already declares
`PartOf=greengrass-lite.target`).

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. `nix flake check -L` passes locally.
- [ ] **Documentation updated** (if applicable) — N/A
- [ ] **Tests added/updated in aws-greengrass-testing** (if applicable) — N/A.
      Verified no unit-file-generation/ordering assertions exist there; this is
      a generation change covered in-tree, and the fix targets a cold-start
      race that isn't deterministically testable in integration.

## Documentation Updates

- [ ] Updated README.md if needed — N/A
- [ ] Updated relevant documentation in `docs/` folder — N/A
- [ ] Requested to update public documentation if applicable — N/A

## Testing

- [x] Existing tests pass (`nix flake check -L`: formatting, clang-tidy, iwyu,
      shellcheck, editorconfig, spelling, cmake-lint, the clang build, and the
      armv6l/musl Pi cross-build all pass).
- [ ] Added tests to aws-greengrass-testing repository — N/A (see above).
- [x] New functionality is covered by a test — extended
      `test_modules/recipe2unit-test` to generate a unit from a recipe with one
      HARD and one SOFT dependency and assert the output contains both the
      dependency directive (`BindsTo=`/`Wants=`) and a matching `After=`.
      Note: per the existing `test_modules` convention these harnesses are
      compiled and linted by `nix flake check` but not auto-executed (not
      CTest-registered); I ran it manually and it exits 0.

## Additional Notes

- **SOFT-dep ordering:** adding `After=` to the `Wants=` branch could form an
  ordering cycle if two components declared mutual dependencies. systemd detects
  ordering cycles at transaction load, drops one `After=` job with a warning,
  and proceeds — so this does not deadlock.
- **Unit-file buffer:** each declared dependency now emits two lines instead of
  one into the fixed `MAX_UNIT_FILE_BUF_SIZE` (2048-byte) buffer in `parser.c`.
  This is bounds-checked and fails safely (returns an error, no overflow), but a
  recipe with a very large number of declared dependencies that previously just
  fit could now exceed it. Happy to bump the buffer if preferred.
- **Bundled `WantedBy` change:** included because, together with `After=`, it is
  part of making TES-dependent components start reliably. I can split it into a
  separate PR if you'd rather keep this one to the `After=` change only.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
