### PR TITLE
Add After= to component unit files for ordering

### DIFF
--- a/modules/recipe2unit/src/unit_file_generator.c
+++ b/modules/recipe2unit/src/unit_file_generator.c
@@ -65,12 +65,26 @@ static GgError parse_dependency_type(
                 &ret, out, gg_kv_key(component_dependency)
             );
             gg_byte_vec_chain_append(&ret, out, GG_STR(".service\n"));
+            // BindsTo= does not order startup (systemd.unit(5)); add After=
+            // so the Type=notify dependency is READY before dependents start.
+            gg_byte_vec_chain_append(&ret, out, GG_STR("After=ggl."));
+            gg_byte_vec_chain_append(
+                &ret, out, gg_kv_key(component_dependency)
+            );
+            gg_byte_vec_chain_append(&ret, out, GG_STR(".service\n"));
             if (ret != GG_ERR_OK) {
                 return ret;
             }
 
         } else {
             GgError ret = gg_byte_vec_append(out, GG_STR("Wants=ggl."));
+            gg_byte_vec_chain_append(
+                &ret, out, gg_kv_key(component_dependency)
+            );
+            gg_byte_vec_chain_append(&ret, out, GG_STR(".service\n"));
+            // Wants= does not order startup either; add After= (see HARD
+            // branch above).
+            gg_byte_vec_chain_append(&ret, out, GG_STR("After=ggl."));
             gg_byte_vec_chain_append(
                 &ret, out, gg_kv_key(component_dependency)
             );

--- a/modules/tes-serverd/unit/ggl.aws.greengrass.TokenExchangeService.service.in
+++ b/modules/tes-serverd/unit/ggl.aws.greengrass.TokenExchangeService.service.in
@@ -19,7 +19,7 @@ StateDirectory=greengrass
 WorkingDirectory=%S/greengrass
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=greengrass-lite.target
 
 [Unit]
 After=ggl.core.ggconfigd.service


### PR DESCRIPTION
## Description

`recipe2unit`'s `parse_dependency_type` emits `BindsTo=` (HARD) or `Wants=`
(SOFT) for each user-declared component dependency, but never `After=`. Per
`systemd.unit(5)`, neither directive enforces start ordering, so on a cold boot
systemd starts a dependent component in parallel with the dependency it relies
on.

This matters for `Type=notify` dependencies such as `tes-serverd`
(TokenExchangeService), which binds an ephemeral port, writes it to config, and
only then signals `READY=1`. Without ordering, `recipe-runner` can spawn a
dependent out-of-process component and read a stale port before `tes-serverd`
publishes the current one, baking a dead `AWS_CONTAINER_CREDENTIALS_FULL_URI`
into the component's environment. Any out-of-process component that uses the AWS
SDK container-credentials provider then fails every credential fetch (connection
refused) until it is manually restarted — and because the unit reports
`active (running)`, the failure is silent.

This change adds `After=ggl.<dep>.service` in both the HARD and SOFT branches,
mirroring the existing hardcoded `ggipcd` dependency in the same file. Since
`tes-serverd` is `Type=notify` and signals `READY` only after writing its port,
`After=` alone is sufficient to close the race.

It also changes the TokenExchangeService unit's `[Install] WantedBy=` from
`multi-user.target` to `greengrass-lite.target`, aligning it with every other
greengrass-lite unit (it was the lone outlier, and already declares
`PartOf=greengrass-lite.target`).

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. `nix flake check -L` passes locally.
- [ ] **Documentation updated** (if applicable) — N/A
- [ ] **Tests added/updated in aws-greengrass-testing** (if applicable) — N/A

## Documentation Updates

- [ ] Updated README.md if needed — N/A
- [ ] Updated relevant documentation in `docs/` folder — N/A
- [ ] Requested to update public documentation if applicable — N/A

## Testing

- [x] Existing tests pass — `nix flake check -L` is green (formatting,
      clang-tidy, iwyu, shellcheck, editorconfig, spelling, cmake-lint,
      unit-tests, the clang build, and the armv6l/musl Pi cross-build).
- [ ] Added tests to aws-greengrass-testing repository — N/A
- [ ] New functionality is covered by a test — this is a systemd unit-file
      generation change; validated via `nix flake check -L` above.
- [x] Manually tested the changes - check below for more details

## Additional Notes

Reproduced and verified on a device running nucleus lite in a container with a
persistent (bind-mounted) ggconfigd, where `tes-serverd` binds a new ephemeral
port on each start:

1. Cold start (reboot / container restart) so services come up in parallel from
   an already-populated ggconfigd holding the previous session's TES port.
2. Before the fix — the dependent component's environment held a stale port:
   - `cat /proc/$(pgrep -f <component>)/environ | tr '\0' '\n' \
        | grep AWS_CONTAINER_CREDENTIALS_FULL_URI`
   - vs `journalctl -u ggl.aws.greengrass.TokenExchangeService.service \
        | grep "Listening on"`
   The two ports differed, and every credential fetch failed with
   `Connection refused (os error 111)` while the unit still reported
   `active (running)` (silent failure).
   - `systemctl cat ggl.<component>.service | grep -E 'BindsTo|After|Wants'`
     confirmed `BindsTo=`/`Wants=` present with **no** matching `After=`.
3. After the fix (rebuilt with this change) — on cold boot the component's
   `AWS_CONTAINER_CREDENTIALS_FULL_URI` port matches the live `tes-serverd`
   port and credential fetches succeed.
4. Cross-check: pre-fix, a manual `systemctl restart` of the component alone
   made the ports match (recipe-runner re-reads the now-current ggconfigd),
   confirming the start-ordering race as the root cause.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
