### PR TITLE
Request tracing

### DIFF
--- a/modules/core-bus/src/client_common.c
+++ b/modules/core-bus/src/client_common.c
@@ -17,7 +17,7 @@
 #include <gg/log.h>
 #include <gg/object.h>
 #include <gg/socket.h>
-#include <gg/trace.h>
+#include <gg/trace.h> // IWYU pragma: keep (used only under GG_TRACE_ENABLED)
 #include <gg/vector.h>
 #include <ggl/core_bus/constants.h>
 #include <pthread.h>

--- a/modules/core-bus/src/client_common.c
+++ b/modules/core-bus/src/client_common.c
@@ -17,6 +17,7 @@
 #include <gg/log.h>
 #include <gg/object.h>
 #include <gg/socket.h>
+#include <gg/trace.h>
 #include <gg/vector.h>
 #include <ggl/core_bus/constants.h>
 #include <pthread.h>
@@ -65,11 +66,14 @@ GgError ggl_client_send_message(
 
     GgBuffer send_buffer = GG_BUF(ggl_core_bus_client_payload_array);
 
-    EventStreamHeader headers[] = {
+    EventStreamHeader headers[5] = {
         { GG_STR("method"), { EVENTSTREAM_STRING, .string = method } },
         { GG_STR("type"), { EVENTSTREAM_INT32, .int32 = (int32_t) type } },
     };
-    size_t headers_len = sizeof(headers) / sizeof(headers[0]);
+    size_t headers_len = 2;
+#ifdef GG_TRACE_ENABLED
+    headers_len += gg_trace_attach_headers(&headers[2], 3);
+#endif
 
     GgObject params_obj = gg_obj_map(params);
     ret = eventstream_encode(

--- a/modules/core-bus/src/server.c
+++ b/modules/core-bus/src/server.c
@@ -15,6 +15,7 @@
 #include <gg/io.h>
 #include <gg/log.h>
 #include <gg/object.h>
+#include <gg/trace.h>
 #include <gg/types.h>
 #include <gg/vector.h>
 #include <ggl/core_bus/constants.h>
@@ -297,6 +298,11 @@ static GgError client_ready(void *ctx, uint32_t handle) {
             }
 
             set_current_handle(handle);
+
+            // Inherit any inbound trace context for the handler's duration;
+            // defensively clears stale context on this reused worker thread
+            // first, and clears again on scope exit.
+            GG_TRACE_INHERIT_SCOPE(msg.headers);
 
             ret = handler->handler(handler->ctx, params, handle);
 

--- a/modules/gg-fleet-statusd/src/entry.c
+++ b/modules/gg-fleet-statusd/src/entry.c
@@ -10,6 +10,7 @@
 #include <gg/log.h>
 #include <gg/map.h>
 #include <gg/object.h>
+#include <gg/trace.h>
 #include <gg/types.h>
 #include <gg/utils.h>
 #include <gg_fleet_statusd.h>
@@ -207,6 +208,8 @@ static void *ggl_fleet_status_service_thread(void *ctx) {
             GG_LOGE("Fleet status service thread failed to sleep, exiting.");
             return NULL;
         }
+
+        GG_TRACE_ROOT_SCOPE("fleet_status_tick", NULL);
 
         ret = publish_fleet_status_update(
             thing_name, GG_STR("CADENCE"), GG_MAP(), GG_LIST()

--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -32,6 +32,7 @@
 #include <gg/log.h>
 #include <gg/map.h>
 #include <gg/object.h>
+#include <gg/trace.h>
 #include <gg/utils.h>
 #include <gg/vector.h>
 #include <ggl/core_bus/client.h>
@@ -4107,6 +4108,14 @@ static GgError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
                ));
 
         bool bootstrap_deployment_succeeded = false;
+
+        GG_TRACE_ROOT_SCOPE(
+            "deployment_jobs",
+            "job_id=%.*s",
+            (int) bootstrap_deployment.deployment_id.len,
+            (char *) bootstrap_deployment.deployment_id.data
+        );
+
         atomic_store(&deployment_in_progress, true);
         GG_LOGD("Deployment in progress (resuming bootstrap deployment).");
         handle_deployment(
@@ -4157,6 +4166,13 @@ static GgError ggl_deployment_listen(GglDeploymentHandlerThreadArgs *args) {
         if (ret != GG_ERR_OK) {
             return ret;
         }
+
+        GG_TRACE_ROOT_SCOPE(
+            "deployment_jobs",
+            "job_id=%.*s",
+            (int) deployment->deployment_id.len,
+            (char *) deployment->deployment_id.data
+        );
 
         set_current_job(deployment->iot_job_id, deployment->deployment_id);
 

--- a/modules/ggipcd/src/ipc_server.c
+++ b/modules/ggipcd/src/ipc_server.c
@@ -25,6 +25,7 @@
 #include <gg/log.h>
 #include <gg/map.h>
 #include <gg/object.h>
+#include <gg/trace.h>
 #include <ggipc/auth.h>
 #include <ggl/socket_handle.h>
 #include <ggl/socket_server.h>
@@ -388,6 +389,12 @@ static GgError handle_stream_operation(
     if (ret != GG_ERR_OK) {
         return ret;
     }
+
+    // ggipcd is a trace root: inbound IPC carries no trace context, so start a
+    // fresh trace per operation (cleared automatically on scope exit).
+    GG_TRACE_ROOT_SCOPE(
+        "ipc_request", "op=%.*s", (int) operation.len, (char *) operation.data
+    );
 
     return ggl_ipc_handle_operation(
         operation, payload_data, handle, common_headers.stream_id, ipc_error


### PR DESCRIPTION
## Description

Wires the gg-sdk request-tracing layer into GG Lite so a single logical request
is correlated end-to-end across daemons. core-bus carries trace context over
EventStream headers automatically, and three daemons become trace root entry
points. No call-site changes for daemon authors.

- Propagate trace context across core-bus calls: outbound `ggl_call` attaches
  T/S/P EventStream headers when a trace is active; the server applies inbound
  context for the handler's duration and auto-clears on return
  (`client_common.c`, `server.c`).
- Make `ggipcd` a trace root at the inbound IPC operation boundary
  (`ipc_server.c`).
- Make `ggdeploymentd` a trace root at the deployment trigger
  (`deployment_handler.c`).
- Make `gg-fleet-statusd` a trace root per periodic poll (`entry.c`).
- All trace code self-gates behind `GG_TRACE_ENABLED`; a daemon built without
  `GG_LOG_TRACE` is an opaque pass-through and does not break the trace.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [x] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

**Depends on the gg-sdk request-tracing change.** GG Lite includes `gg/trace.h`,
which only exists once the gg-sdk tracing PR merges and ships. This PR does not
yet bump `fc_deps.json` (it still pins gg-sdk `v1.0.3`), so CI builds will fail
at the `#include` until a follow-up commit bumps `fc_deps.json` to a gg-sdk
release that contains `gg/trace.h`. Merge order: gg-sdk PR -> gg-sdk release ->
bump `fc_deps.json` here -> merge this PR.

`nix flake check` lint/format checks pass on this branch. The compile checks
(`build-clang -DENABLE_WERROR`, `clang-tidy`, `iwyu`, `unit-tests`) were verified
green against the trace-enabled gg-sdk via a temporary `fc_deps.json` override;
they will run in CI once the version bump lands.

Tracing was validated end-to-end on an AL2023 core device via journalctl:
ipc_request (PublishToTopic), deployment_jobs (local and cloud IoT Jobs),
fleet_status_tick, mixed-version compatibility, and a 24-way concurrency stress
test. The trace-context unit suite (9 cases) lives in the gg-sdk PR.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._