### PR TITLE
Validate IPC authorization policy resources

### DIFF
--- a/docs/design/policy-validation.md
+++ b/docs/design/policy-validation.md
@@ -1,0 +1,95 @@
+# `ggl-policy-validation` design
+
+See the deployment-time requirement
+[`[ggdeploymentd-3.3]`](../spec/executable/ggdeploymentd.md) for the public
+contract.
+
+## Background
+
+Greengrass component `accessControl` policies use a small grammar for resource
+strings (see the public docs for
+[IPC authorization policies](https://docs.aws.amazon.com/greengrass/v2/developerguide/interprocess-communication.html#ipc-authorization-policies)
+for the user-facing description):
+
+- `*` is a wildcard that can appear anywhere and matches any sequence of
+  characters.
+- `${*}`, `${?}`, and `${$}` are escapes that produce literal `*`, `?`, and `$`
+  characters in the matched topic.
+
+Anything else inside a `${...}` escape is undefined; in particular, a bare `?`
+was previously accepted by Greengrass Lite and silently honored as a literal `?`
+character in the topic. AWS IoT Core does not allow `?` in topic names, so a
+policy or request topic containing `?` is effectively inert (it can never match
+a real cloud topic) and almost always indicates a mistake by the recipe author.
+
+This module rejects malformed resource strings up front, both at deployment time
+(in `ggdeploymentd`) and at IPC call time (in `ggipcd`).
+
+## Design decisions
+
+### 1. Be stricter than Greengrass v2
+
+Greengrass V2 only logs and skips malformed `accessControl` policies; the
+deployment still succeeds. We chose to **fail** the deployment in Lite instead.
+
+The reasons it is acceptable to break parity here:
+
+- **Migration path is already manual.** Customers moving from v2 to Lite inspect
+  and adjust their component recipes anyway as part of migration, so a
+  deploy-time error pointing at the offending field is strictly more helpful
+  than the silent v2 behavior.
+
+### 2. Fail the deployment, don't silently filter
+
+When `ggdeploymentd` detects a malformed `accessControl` resource it **fails the
+entire deployment** and logs the offending component and resource string.
+Failing fast surfaces the error directly to the user instead of letting the
+component start with a policy that can never grant access. When cloud-side
+reporting is added, the failure reason will also be surfaced through the
+deployment status API.
+
+### 3. Two enforcement points: deploy time **and** IPC call time
+
+The validator is called from two places:
+
+- `ggdeploymentd` — on every `accessControl` resource it finds in the recipe
+  `DefaultConfiguration` and in the deployment doc `configurationUpdate.merge`,
+  before writing the merged configuration to the config store.
+- `ggipcd` — on the request resource (the topic being published or subscribed
+  to) at the start of `ggl_ipc_auth`, before any policy lookup.
+
+Both gates are needed because the rule applies symmetrically: a policy that
+would never match anything useful is a mistake, and a request topic that AWS IoT
+Core would reject is also a mistake. The deploy-time gate keeps malformed
+configuration out of the config store; the call-time gate catches malformed
+request topics that originate at runtime and never appeared in any deployment.
+
+## Implementation
+
+```
+modules/
+├── ggl-policy-validation/
+│   ├── CMakeLists.txt
+│   ├── include/ggl/policy_validation.h
+│   │     └── GgError ggl_validate_policy_resource(GgBuffer resource);
+│   └── src/policy_validation.c
+│         ├── ggl_validate_policy_resource(...) — leaf validator
+│         └── 12 inline tests guarded by `GG_SDK_TESTING`
+├── ggdeploymentd/
+│   └── src/access_control_validation.{c,h}
+│         ├── validate_access_control_policies(GgObject *config_obj)
+│         └── validate_merge_access_control(GglDeployment *, GgBuffer)
+│         (walk deployment-doc shape; call ggl_validate_policy_resource
+│         on each resource string)
+└── ggipcd/
+    └── src/ipc_authz.c
+          └── ggl_ipc_auth(...) — calls ggl_validate_policy_resource(resource)
+            before any policy lookup
+```
+
+The validator returns `GG_ERR_INVALID` for a malformed resource and logs the
+offending string and position. At deploy time the call-site logs
+`"Deployment rejected: invalid accessControl policy in component <name>."` and
+the deployment is reported FAILED. At IPC call time the existing `ggl_ipc_auth`
+non-OK handling produces an `UnauthorizedError` to the caller; the validator's
+specific reason is in the ggipcd journal.

--- a/docs/spec/executable/ggdeploymentd.md
+++ b/docs/spec/executable/ggdeploymentd.md
@@ -15,7 +15,10 @@ A (very) brief overview of the key steps that should be executed during a
 deployment task processing:
 
 - Deployment validation: includes verifying that the deployment is not stale,
-  and checking that any kernel required capabilities are satisfied.
+  checking that any kernel required capabilities are satisfied, and validating
+  that all `accessControl` policy `resources` strings in component
+  `DefaultConfiguration` and in deployment `configurationUpdate.merge` are
+  well-formed.
 - Dependency resolution: Resolve the versions of components required by the
   deployment, including getting root components from all thing groups and
   negotiating component version with cloud. This step also gets component
@@ -89,6 +92,24 @@ the following requirements.
      configuration.
    - [ggdeploymentd-3.2] The deployment service may handle configuration updates
      and merge/reset configuration from a deployment document.
+   - [ggdeploymentd-3.3] The deployment service rejects deployments whose
+     `accessControl` policy resources are malformed. See the public docs for
+     [IPC authorization policies](https://docs.aws.amazon.com/greengrass/v2/developerguide/interprocess-communication.html#ipc-authorization-policies)
+     for the user-facing description of `accessControl` and the supported
+     wildcard / escape syntax.
+     - [ggdeploymentd-3.3.1] A resource string is malformed if it contains a
+       bare `?`, or a `${...}` escape other than `${*}`, `${?}`, or `${$}`.
+     - [ggdeploymentd-3.3.2] Both the recipe `DefaultConfiguration` and the
+       deployment `configurationUpdate.merge` are checked.
+     - [ggdeploymentd-3.3.3] A deployment that contains any malformed
+       `accessControl` resource is reported as FAILED, and the malformed
+       configuration is not persisted to the config store.
+     - [ggdeploymentd-3.3.4] The same well-formedness rule is enforced at IPC
+       call time by `ggipcd` against the request resource (the topic being
+       published or subscribed to). The shared check lives in the
+       `ggl-policy-validation` module so the deploy-time and call-time gates
+       cannot drift. See
+       [`policy-validation` design](../../design/policy-validation.md).
 4. [ggdeploymentd-4] The deployment service is aware of device membership within
    multiple thing groups when executing a new deployment.
    - [ggdeploymentd-4.1] If the device has multiple deployments from different

--- a/modules/ggdeploymentd/CMakeLists.txt
+++ b/modules/ggdeploymentd/CMakeLists.txt
@@ -7,6 +7,7 @@ ggl_init_module(
   LIBS gg-sdk
        ggl-constants
        ggl-common
+       ggl-policy-validation
        core-bus
        ggl-docker-client
        ggl-http

--- a/modules/ggdeploymentd/src/access_control_validation.c
+++ b/modules/ggdeploymentd/src/access_control_validation.c
@@ -1,0 +1,99 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "access_control_validation.h"
+#include <gg/buffer.h>
+#include <gg/error.h>
+#include <gg/list.h>
+#include <gg/map.h>
+#include <gg/object.h>
+#include <ggl/policy_validation.h>
+#include <stddef.h>
+
+GgError validate_access_control_policies(GgObject *config_obj) {
+    if (config_obj == NULL) {
+        return GG_ERR_OK;
+    }
+    if (gg_obj_type(*config_obj) != GG_TYPE_MAP) {
+        return GG_ERR_OK;
+    }
+
+    GgObject *ac_obj;
+    if (!gg_map_get(
+            gg_obj_into_map(*config_obj), GG_STR("accessControl"), &ac_obj
+        )) {
+        return GG_ERR_OK;
+    }
+    if (gg_obj_type(*ac_obj) != GG_TYPE_MAP) {
+        return GG_ERR_OK;
+    }
+
+    GG_MAP_FOREACH (service_kv, gg_obj_into_map(*ac_obj)) {
+        if (gg_obj_type(*gg_kv_val(service_kv)) != GG_TYPE_MAP) {
+            continue;
+        }
+        GG_MAP_FOREACH (policy_kv, gg_obj_into_map(*gg_kv_val(service_kv))) {
+            if (gg_obj_type(*gg_kv_val(policy_kv)) != GG_TYPE_MAP) {
+                continue;
+            }
+            GgObject *resources_obj;
+            if (!gg_map_get(
+                    gg_obj_into_map(*gg_kv_val(policy_kv)),
+                    GG_STR("resources"),
+                    &resources_obj
+                )) {
+                continue;
+            }
+            if (gg_obj_type(*resources_obj) != GG_TYPE_LIST) {
+                continue;
+            }
+            GG_LIST_FOREACH (res_obj, gg_obj_into_list(*resources_obj)) {
+                if (gg_obj_type(*res_obj) != GG_TYPE_BUF) {
+                    continue;
+                }
+                GgBuffer res = gg_obj_into_buf(*res_obj);
+                GgError ret = ggl_validate_policy_resource(res);
+                if (ret != GG_ERR_OK) {
+                    return ret;
+                }
+            }
+        }
+    }
+    return GG_ERR_OK;
+}
+
+GgError validate_merge_access_control(
+    GglDeployment *deployment, GgBuffer component_name
+) {
+    GgObject *doc_component_info;
+    if (!gg_map_get(
+            deployment->components, component_name, &doc_component_info
+        )) {
+        return GG_ERR_OK;
+    }
+    if (gg_obj_type(*doc_component_info) != GG_TYPE_MAP) {
+        return GG_ERR_OK;
+    }
+
+    GgObject *config_update;
+    if (!gg_map_get(
+            gg_obj_into_map(*doc_component_info),
+            GG_STR("configurationUpdate"),
+            &config_update
+        )) {
+        return GG_ERR_OK;
+    }
+    if (gg_obj_type(*config_update) != GG_TYPE_MAP) {
+        return GG_ERR_OK;
+    }
+
+    GgObject *merge_obj;
+    if (!gg_map_get(
+            gg_obj_into_map(*config_update), GG_STR("merge"), &merge_obj
+        )) {
+        return GG_ERR_OK;
+    }
+
+    return validate_access_control_policies(merge_obj);
+}

--- a/modules/ggdeploymentd/src/access_control_validation.h
+++ b/modules/ggdeploymentd/src/access_control_validation.h
@@ -1,0 +1,18 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GGDEPLOYMENTD_ACCESS_CONTROL_VALIDATION_H
+#define GGDEPLOYMENTD_ACCESS_CONTROL_VALIDATION_H
+
+#include "deployment_model.h"
+#include <gg/error.h>
+#include <gg/types.h>
+
+GgError validate_access_control_policies(GgObject *config_obj);
+
+GgError validate_merge_access_control(
+    GglDeployment *deployment, GgBuffer component_name
+);
+
+#endif

--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "deployment_handler.h"
+#include "access_control_validation.h"
 #include "artifact_permission.h"
 #include "bootstrap_manager.h"
 #include "component_config.h"
@@ -3438,6 +3439,17 @@ static void handle_deployment(
                     GG_STR("DefaultConfiguration"),
                     &default_config_obj
                 )) {
+                ret = validate_access_control_policies(default_config_obj);
+                if (ret != GG_ERR_OK) {
+                    GG_LOGE(
+                        "Deployment rejected: invalid accessControl policy "
+                        "in component %.*s.",
+                        (int) gg_kv_key(*pair).len,
+                        gg_kv_key(*pair).data
+                    );
+                    return;
+                }
+
                 ret = ggl_gg_config_write(
                     GG_BUF_LIST(
                         GG_STR("services"),
@@ -3465,6 +3477,17 @@ static void handle_deployment(
                 (int) gg_kv_key(*pair).len,
                 gg_kv_key(*pair).data
             );
+        }
+
+        ret = validate_merge_access_control(deployment, gg_kv_key(*pair));
+        if (ret != GG_ERR_OK) {
+            GG_LOGE(
+                "Deployment rejected: invalid accessControl policy in "
+                "component %.*s.",
+                (int) gg_kv_key(*pair).len,
+                gg_kv_key(*pair).data
+            );
+            return;
         }
 
         ret = apply_configurations(

--- a/modules/ggipcd/CMakeLists.txt
+++ b/modules/ggipcd/CMakeLists.txt
@@ -8,6 +8,7 @@ ggl_init_module(
   LIBS gg-sdk
        ggl-common
        ggl-constants
+       ggl-policy-validation
        core-bus
        core-bus-gg-config
        core-bus-aws-iot-mqtt

--- a/modules/ggipcd/src/ipc_authz.c
+++ b/modules/ggipcd/src/ipc_authz.c
@@ -14,6 +14,7 @@
 #include <gg/map.h>
 #include <gg/object.h>
 #include <ggl/core_bus/gg_config.h>
+#include <ggl/policy_validation.h>
 #include <string.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -77,11 +78,16 @@ GgError ggl_ipc_auth(
 ) {
     assert(info != NULL);
 
+    GgError ret = ggl_validate_policy_resource(resource);
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+
     static uint8_t policy_mem[4096];
     GgArena alloc = gg_arena_init(GG_BUF(policy_mem));
 
     GgObject policies;
-    GgError ret = ggl_gg_config_read(
+    ret = ggl_gg_config_read(
         GG_BUF_LIST(
             GG_STR("services"),
             info->component,

--- a/modules/ggl-policy-validation/CMakeLists.txt
+++ b/modules/ggl-policy-validation/CMakeLists.txt
@@ -1,0 +1,5 @@
+# aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+ggl_init_module(ggl-policy-validation LIBS gg-sdk)

--- a/modules/ggl-policy-validation/include/ggl/policy_validation.h
+++ b/modules/ggl-policy-validation/include/ggl/policy_validation.h
@@ -1,0 +1,18 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GGL_POLICY_VALIDATION_H
+#define GGL_POLICY_VALIDATION_H
+
+//! Greengrass accessControl policy resource validation
+
+#include <gg/error.h>
+#include <gg/types.h>
+
+/// Returns GG_ERR_OK if @p resource is a valid Greengrass policy resource
+/// string, GG_ERR_INVALID otherwise.  A resource is invalid if it contains a
+/// bare '?' or a '${...}' escape other than '${*}', '${?}', or '${$}'.
+GgError ggl_validate_policy_resource(GgBuffer resource);
+
+#endif

--- a/modules/ggl-policy-validation/src/policy_validation.c
+++ b/modules/ggl-policy-validation/src/policy_validation.c
@@ -1,0 +1,114 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gg/error.h>
+#include <gg/log.h>
+#include <gg/types.h>
+#include <ggl/policy_validation.h>
+#include <stddef.h>
+#include <stdint.h>
+
+GgError ggl_validate_policy_resource(GgBuffer resource) {
+    for (size_t i = 0; i < resource.len; i++) {
+        uint8_t c = resource.data[i];
+        if (c == (uint8_t) '?') {
+            GG_LOGE(
+                "Invalid policy resource: bare '?' at position %d in '%.*s'.",
+                (int) i,
+                (int) resource.len,
+                resource.data
+            );
+            return GG_ERR_INVALID;
+        }
+        if ((c == (uint8_t) '$') && (i + 1 < resource.len)
+            && (resource.data[i + 1] == (uint8_t) '{')) {
+            if (i + 3 >= resource.len) {
+                GG_LOGE(
+                    "Invalid policy resource: unterminated escape in '%.*s'.",
+                    (int) resource.len,
+                    resource.data
+                );
+                return GG_ERR_INVALID;
+            }
+            uint8_t escaped = resource.data[i + 2];
+            if (((escaped != (uint8_t) '*') && (escaped != (uint8_t) '?')
+                 && (escaped != (uint8_t) '$'))
+                || (resource.data[i + 3] != (uint8_t) '}')) {
+                GG_LOGE(
+                    "Invalid policy resource: bad escape sequence in '%.*s'.",
+                    (int) resource.len,
+                    resource.data
+                );
+                return GG_ERR_INVALID;
+            }
+            i += 3;
+        }
+    }
+    return GG_ERR_OK;
+}
+
+#ifdef GG_SDK_TESTING
+
+#include <gg/test.h>
+#include <unity.h>
+
+GG_TEST_DEFINE(policy_resource_simple_topic) {
+    GG_TEST_ASSERT_OK(ggl_validate_policy_resource(GG_STR("test/topic")));
+}
+
+GG_TEST_DEFINE(policy_resource_wildcard_star) {
+    GG_TEST_ASSERT_OK(ggl_validate_policy_resource(GG_STR("*")));
+}
+
+GG_TEST_DEFINE(policy_resource_embedded_star) {
+    GG_TEST_ASSERT_OK(ggl_validate_policy_resource(GG_STR("factory/1/*/status"))
+    );
+}
+
+GG_TEST_DEFINE(policy_resource_dollar_no_brace) {
+    GG_TEST_ASSERT_OK(ggl_validate_policy_resource(GG_STR("$aws/things/x")));
+}
+
+GG_TEST_DEFINE(policy_resource_escape_star) {
+    GG_TEST_ASSERT_OK(ggl_validate_policy_resource(GG_STR("${*}")));
+}
+
+GG_TEST_DEFINE(policy_resource_escape_question) {
+    GG_TEST_ASSERT_OK(ggl_validate_policy_resource(GG_STR("${?}")));
+}
+
+GG_TEST_DEFINE(policy_resource_escape_dollar) {
+    GG_TEST_ASSERT_OK(ggl_validate_policy_resource(GG_STR("${$}")));
+}
+
+GG_TEST_DEFINE(policy_resource_literals_hash_plus) {
+    GG_TEST_ASSERT_OK(ggl_validate_policy_resource(GG_STR("a/b#c+d")));
+}
+
+GG_TEST_DEFINE(policy_resource_bare_question) {
+    TEST_ASSERT_EQUAL_INT(
+        GG_ERR_INVALID,
+        ggl_validate_policy_resource(GG_STR("invalid?/resource"))
+    );
+}
+
+GG_TEST_DEFINE(policy_resource_bad_escape_char) {
+    TEST_ASSERT_EQUAL_INT(
+        GG_ERR_INVALID, ggl_validate_policy_resource(GG_STR("a${x}b"))
+    );
+}
+
+GG_TEST_DEFINE(policy_resource_unterminated_dollar_brace) {
+    TEST_ASSERT_EQUAL_INT(
+        GG_ERR_INVALID, ggl_validate_policy_resource(GG_STR("a${"))
+    );
+}
+
+GG_TEST_DEFINE(policy_resource_unterminated_escape_no_close) {
+    TEST_ASSERT_EQUAL_INT(
+        GG_ERR_INVALID, ggl_validate_policy_resource(GG_STR("a${?"))
+    );
+}
+
+#endif


### PR DESCRIPTION
## Description

Greengrass Lite did not validate the resource strings in component
`accessControl` authorization policies. An invalid resource such as
`"invalid?/resource"` was accepted and silently honored, even though `?`
is not a supported wildcard in Greengrass policy syntax (and AWS IoT
Core does not allow `?` in topic names at all).

A new shared module `ggl-policy-validation` owns the rule: a resource
is rejected if it contains a bare `?` or a `${...}` escape other than
`${*}`, `${?}`, or `${$}`. The check is enforced at two points so the
deploy-time and call-time gates cannot drift:

- **`ggdeploymentd`** — validates every `accessControl` resource in the
  recipe `DefaultConfiguration` and in the deployment
  `configurationUpdate.merge`, before writing the merged configuration
  to the config store. A malformed resource fails the deployment, so
  an invalid policy never reaches the config store.
- **`ggipcd`** — validates the request resource (the topic being
  published or subscribed to) at the start of `ggl_ipc_auth`, before
  any policy lookup, so a runtime call to a malformed topic is denied
  at the IPC layer.

Both gates call `ggl_validate_policy_resource()` from
`modules/ggl-policy-validation/`. Inline unit tests live alongside the
function (12 cases under `GG_SDK_TESTING`).

Spec requirement `[ggdeploymentd-3.3]` (with sub-bullets covering both
gates) and a new design doc at `docs/design/policy-validation.md`
capture the rationale.

## Related Issue

Fixes #799

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L`
      locally
- [x] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [x] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws
      internal only)

## Testing

- [x] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [x] New functionality is covered by tests

## Additional Notes

End-to-end verified on a Linux EC2 instance:

- 12/12 inline unit tests in `ggl-policy-validation-inline-test` pass.
- Deploy-time gate: a recipe with `devices/?/status` is rejected with
  `Deployment rejected: invalid accessControl policy in component
  com.example.BadPolicy.` and the job is reported FAILED. A recipe
  with `devices/*/status` is accepted.
- IPC call-time gate: a Python component (with policy resources
  `["*"]`) calling `publish_to_topic("test/?topic", ...)` and
  `publish_to_topic("a${x}b", ...)` receives `UnauthorizedError`; the
  same component publishing to `test/topic` succeeds. ggipcd logs
  `ggl-policy-validation: Invalid policy resource: bare '?' at
  position 5 in 'test/?topic'.` for the rejected calls.
- All 11 `nix flake check` checks pass locally on x86_64-linux.

_By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice._
