### PR TITLE
Bound UAT parallelism to avoid AWS throttling

### DIFF
--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -15,6 +15,14 @@ on:
         description: "Ref (branch) on the testing repo to use"
         required: false
 
+# Serialize UAT runs so multiple PRs/merges don't hammer the shared AWS
+# account concurrently and trip IoT Core / IoT
+# Jobs API rate quotas. Only one UAT run executes at a time; newer runs queue.
+# cancel-in-progress: false => let the in-flight run finish (don't lose coverage).
+concurrency:
+  group: uat-component-tests
+  cancel-in-progress: false
+
 jobs:
   list-tests:
     if:
@@ -62,6 +70,11 @@ jobs:
     needs: list-tests
     strategy:
       fail-fast: false
+      # Cap how many test jobs hit the shared AWS account at once within a
+      # single run. Combined with the run-level `concurrency` lane above, the
+      # account never sees more than this many UAT jobs concurrently. Tune up
+      # if throttling stays clear; tune down if ThrottlingExceptions persist.
+      max-parallel: 4
       matrix:
         test: ${{ fromJson(needs.list-tests.outputs.tests) }}
     permissions:

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -84,6 +84,12 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      # Spread initial API load across the shared account so parallel matrix
+      # jobs don't all hit AWS simultaneously and trigger synchronized throttling.
+      - name: Stagger start to decorrelate parallel AWS API bursts
+        run: sleep $(( RANDOM % 30 ))
+        shell: bash
+
       - name: Checkout lite repository
         uses: actions/checkout@v6
 


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-lite/issues/1133

**Description of changes:**

Workflow-only change to `.github/workflows/uat.yml`:

- Add a run-level `concurrency` group (`group: uat-component-tests`, `cancel-in-progress: false`) so only one UAT run executes at a time; newer runs queue instead of piling onto the shared AWS account concurrently.
- Add `max-parallel: 4` to the test matrix to cap how many test jobs hit the account at once within a run.
- Add a per-job start-stagger step (`sleep $(( RANDOM % 30 ))`) as the first step of the test job, to decorrelate the parallel matrix jobs' AWS API bursts (both setup and teardown).

**Error log**
`An error occurred (ThrottlingException) when calling the DeleteDeployment operation (reached max retries: 4): Exceeded the AWS IoT Jobs service quota for the number of jobs with status DELETION_IN_PROGRESS. Please check number of jobs currently being deleted, wait at least one minute, and try again.`

**Fix verification**
https://github.com/felicityzhao9/aws-greengrass-lite/actions/runs/28060571048/job/83073532562
All UAT tests passed without the ThrottlingException error any more.