### PR TITLE
Exit tesd on credential configuration change

### DIFF
--- a/modules/tesd/src/entry.c
+++ b/modules/tesd/src/entry.c
@@ -10,24 +10,128 @@
 #include <gg/types.h>
 #include <ggl/core_bus/gg_config.h>
 #include <ggl/proxy/environment.h>
-#include <string.h>
 #include <tesd.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 static GgError cred_config_change_callback(
     void *ctx, uint32_t handle, GgObject data
 ) {
-    (void) ctx;
     (void) handle;
     (void) data;
+    const char *key = (const char *) ctx;
+    GG_LOGI("Configuration key '%s' changed, restarting tesd.", key);
+    _Exit(0);
+}
 
-    tes_update_cred_url();
+// Subscribe to all config keys that affect credential fetches. When any of
+// these change, tesd exits so systemd restarts it with fresh config.
+//
+// Keys monitored:
+//   iotCredEndpoint     - HTTPS endpoint for the IoT Credential Provider
+//   iotRoleAlias        - IAM role alias used in the credential request URL
+//   thingName           - sent as x-amzn-iot-thingname header in credential req
+//   certificateFilePath - client cert for mTLS to the credential provider
+//   privateKeyPath      - private key for mTLS to the credential provider
+//   rootCaPath          - CA cert for TLS verification of credential provider
+static GgError subscribe_to_cred_config_changes(TesdArgs *args) {
+    GgError ret = ggl_gg_config_subscribe(
+        GG_BUF_LIST(GG_STR("system"), GG_STR("thingName")),
+        cred_config_change_callback,
+        NULL,
+        (void *) "thingName",
+        NULL
+    );
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("Failed to subscribe to thingName changes: %d.", ret);
+        return ret;
+    }
+
+    ret = ggl_gg_config_subscribe(
+        GG_BUF_LIST(GG_STR("system"), GG_STR("certificateFilePath")),
+        cred_config_change_callback,
+        NULL,
+        (void *) "certificateFilePath",
+        NULL
+    );
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("Failed to subscribe to certificateFilePath changes: %d.", ret);
+        return ret;
+    }
+
+    ret = ggl_gg_config_subscribe(
+        GG_BUF_LIST(GG_STR("system"), GG_STR("rootCaPath")),
+        cred_config_change_callback,
+        NULL,
+        (void *) "rootCaPath",
+        NULL
+    );
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("Failed to subscribe to rootCaPath changes: %d.", ret);
+        return ret;
+    }
+
+    ret = ggl_gg_config_subscribe(
+        GG_BUF_LIST(GG_STR("system"), GG_STR("privateKeyPath")),
+        cred_config_change_callback,
+        NULL,
+        (void *) "privateKeyPath",
+        NULL
+    );
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("Failed to subscribe to privateKeyPath changes: %d.", ret);
+        return ret;
+    }
+
+    if (args->role_alias == NULL) {
+        ret = ggl_gg_config_subscribe(
+            GG_BUF_LIST(
+                GG_STR("services"),
+                GG_STR("aws.greengrass.NucleusLite"),
+                GG_STR("configuration"),
+                GG_STR("iotRoleAlias")
+            ),
+            cred_config_change_callback,
+            NULL,
+            (void *) "iotRoleAlias",
+            NULL
+        );
+        if (ret != GG_ERR_OK) {
+            GG_LOGE("Failed to subscribe to iotRoleAlias changes: %d.", ret);
+            return ret;
+        }
+    }
+
+    if (args->cred_endpoint == NULL) {
+        ret = ggl_gg_config_subscribe(
+            GG_BUF_LIST(
+                GG_STR("services"),
+                GG_STR("aws.greengrass.NucleusLite"),
+                GG_STR("configuration"),
+                GG_STR("iotCredEndpoint")
+            ),
+            cred_config_change_callback,
+            NULL,
+            (void *) "iotCredEndpoint",
+            NULL
+        );
+        if (ret != GG_ERR_OK) {
+            GG_LOGE("Failed to subscribe to iotCredEndpoint changes: %d.", ret);
+            return ret;
+        }
+    }
+
     return GG_ERR_OK;
 }
 
 GgError run_tesd(TesdArgs *args) {
     GgError ret = ggl_proxy_set_environment();
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+
+    ret = subscribe_to_cred_config_changes(args);
     if (ret != GG_ERR_OK) {
         return ret;
     }
@@ -78,29 +182,12 @@ GgError run_tesd(TesdArgs *args) {
         return ret;
     }
 
-    // Role alias: CLI override or config with subscription
+    // Role alias: CLI override or config
     bool role_alias_from_config = (args->role_alias == NULL);
     static uint8_t role_alias_mem[128] = { 0 };
     GgBuffer role_alias;
 
     if (role_alias_from_config) {
-        ret = ggl_gg_config_subscribe(
-            GG_BUF_LIST(
-                GG_STR("services"),
-                GG_STR("aws.greengrass.NucleusLite"),
-                GG_STR("configuration"),
-                GG_STR("iotRoleAlias")
-            ),
-            cred_config_change_callback,
-            NULL,
-            NULL,
-            NULL
-        );
-        if (ret != GG_ERR_OK) {
-            GG_LOGE("Failed to subscribe to iotRoleAlias changes: %d.", ret);
-            return ret;
-        }
-
         alloc = gg_arena_init(GG_BUF(role_alias_mem));
         ret = ggl_gg_config_read_str(
             GG_BUF_LIST(
@@ -120,29 +207,12 @@ GgError run_tesd(TesdArgs *args) {
         GG_LOGD("Using CLI override for iotRoleAlias.");
     }
 
-    // Credential endpoint: CLI override or config with subscription
+    // Credential endpoint: CLI override or config
     bool cred_endpoint_from_config = (args->cred_endpoint == NULL);
     static uint8_t cred_endpoint_mem[128] = { 0 };
     GgBuffer cred_endpoint;
 
     if (cred_endpoint_from_config) {
-        ret = ggl_gg_config_subscribe(
-            GG_BUF_LIST(
-                GG_STR("services"),
-                GG_STR("aws.greengrass.NucleusLite"),
-                GG_STR("configuration"),
-                GG_STR("iotCredEndpoint")
-            ),
-            cred_config_change_callback,
-            NULL,
-            NULL,
-            NULL
-        );
-        if (ret != GG_ERR_OK) {
-            GG_LOGE("Failed to subscribe to iotCredEndpoint changes: %d.", ret);
-            return ret;
-        }
-
         alloc = gg_arena_init(GG_BUF(cred_endpoint_mem));
         ret = ggl_gg_config_read_str(
             GG_BUF_LIST(

--- a/modules/tesd/src/token_service.c
+++ b/modules/tesd/src/token_service.c
@@ -12,7 +12,6 @@
 #include <gg/map.h>
 #include <gg/object.h>
 #include <gg/vector.h>
-#include <ggl/core_bus/gg_config.h>
 #include <ggl/core_bus/server.h>
 #include <ggl/http.h>
 #include <limits.h>
@@ -65,107 +64,6 @@ static void rebuild_url(void) {
         return;
     }
     GG_LOGD("Credential URL: %s", global_cred_details.url);
-}
-
-/// Compare old and new credential config values, update changed fields,
-/// and rebuild the URL. Caller must hold cred_details_mtx.
-static void apply_cred_config_changes(
-    const char *old_ep,
-    const char *new_ep,
-    size_t new_ep_len,
-    const char *old_alias,
-    const char *new_alias,
-    size_t new_alias_len
-) {
-    if ((strncmp(old_ep, new_ep, MAX_CRED_ENDPOINT_LEN) == 0)
-        && (strncmp(old_alias, new_alias, MAX_ROLE_ALIAS_LEN) == 0)) {
-        return;
-    }
-
-    if (strncmp(old_ep, new_ep, MAX_CRED_ENDPOINT_LEN) != 0) {
-        GG_LOGI(
-            "iotCredEndpoint updated from %s to %.*s",
-            old_ep,
-            (int) new_ep_len,
-            new_ep
-        );
-        memcpy(global_cred_details.cred_endpoint, new_ep, new_ep_len + 1);
-    }
-
-    if (strncmp(old_alias, new_alias, MAX_ROLE_ALIAS_LEN) != 0) {
-        GG_LOGI(
-            "iotRoleAlias updated from %s to %.*s",
-            old_alias,
-            (int) new_alias_len,
-            new_alias
-        );
-        memcpy(global_cred_details.role_alias, new_alias, new_alias_len + 1);
-    }
-
-    rebuild_url();
-}
-
-void tes_update_cred_url(void) {
-    GG_MTX_SCOPE_GUARD(&cred_details_mtx);
-
-    char old_endpoint[MAX_CRED_ENDPOINT_LEN + 1];
-    char old_alias[MAX_ROLE_ALIAS_LEN + 1];
-    memcpy(
-        old_endpoint, global_cred_details.cred_endpoint, sizeof(old_endpoint)
-    );
-    memcpy(old_alias, global_cred_details.role_alias, sizeof(old_alias));
-
-    uint8_t ep_mem[MAX_CRED_ENDPOINT_LEN + 1] = { 0 };
-    GgArena ep_alloc = gg_arena_init(
-        gg_buffer_substr(GG_BUF(ep_mem), 0, MAX_CRED_ENDPOINT_LEN)
-    );
-    GgBuffer new_ep;
-    GgError ret = ggl_gg_config_read_str(
-        GG_BUF_LIST(
-            GG_STR("services"),
-            GG_STR("aws.greengrass.NucleusLite"),
-            GG_STR("configuration"),
-            GG_STR("iotCredEndpoint")
-        ),
-        &ep_alloc,
-        &new_ep
-    );
-    if (ret != GG_ERR_OK) {
-        GG_LOGW("Failed to read updated iotCredEndpoint: %d.", ret);
-        return;
-    }
-
-    uint8_t alias_mem[MAX_ROLE_ALIAS_LEN + 1] = { 0 };
-    GgArena alias_alloc = gg_arena_init(
-        gg_buffer_substr(GG_BUF(alias_mem), 0, MAX_ROLE_ALIAS_LEN)
-    );
-    GgBuffer new_alias;
-    ret = ggl_gg_config_read_str(
-        GG_BUF_LIST(
-            GG_STR("services"),
-            GG_STR("aws.greengrass.NucleusLite"),
-            GG_STR("configuration"),
-            GG_STR("iotRoleAlias")
-        ),
-        &alias_alloc,
-        &new_alias
-    );
-    if (ret != GG_ERR_OK) {
-        GG_LOGW("Failed to read updated iotRoleAlias: %d.", ret);
-        return;
-    }
-
-    ep_mem[new_ep.len] = '\0';
-    alias_mem[new_alias.len] = '\0';
-
-    apply_cred_config_changes(
-        old_endpoint,
-        (char *) ep_mem,
-        new_ep.len,
-        old_alias,
-        (char *) alias_mem,
-        new_alias.len
-    );
 }
 
 static GgError request_token_from_aws(GgBuffer *response) {

--- a/modules/tesd/src/token_service.h
+++ b/modules/tesd/src/token_service.h
@@ -18,8 +18,4 @@ GgError initiate_request(
     GgBuffer interface_name
 );
 
-/// Update the credential URL at runtime. Thread-safe.
-/// Re-reads both endpoint and role_alias from ggconfigd under a mutex.
-void tes_update_cred_url(void);
-
 #endif


### PR DESCRIPTION
## Problem

Components using AWS SDKs cache credentials obtained from TES. When credential
configuration changes (e.g., `iotCredEndpoint`, `iotRoleAlias`), the current
in-process URL update in `tesd` does not invalidate SDK-side credential caches
in components. Components continue using stale credentials until they expire (up
to 1 hour).

The `tes_update_cred_url()` function re-reads the endpoint and role alias from
ggconfigd and updates the credential URL in memory — but this only affects
subsequent TES fetches from tesd itself. Component processes with their own SDK
credential caches never see the change.

## Solution

Replace the in-process URL update with `_Exit(0)`. When any credential-relevant
config key changes, tesd exits cleanly. systemd restarts it via
`Restart=always`, and tesd re-reads all configuration fresh on startup.

A follow-up change will add `BindsTo=ggl.core.tesd.service` to tes-serverd,
which will propagate the restart to tes-serverd and all dependent components,
forcing their AWS SDK clients to reinitialize and fetch fresh credentials.

## Changes

- `modules/tesd/src/entry.c`:
  - `cred_config_change_callback()` now logs the changed key and calls `_Exit(0)`
  - All subscriptions consolidated into `subscribe_to_cred_config_changes()`
  - Added subscriptions for 4 system keys (`thingName`, `certificateFilePath`,
    `rootCaPath`, `privateKeyPath`) — unconditional
  - `iotRoleAlias` and `iotCredEndpoint` subscriptions remain conditional on CLI
    override flags (existing behavior)

- `modules/tesd/src/token_service.c`:
  - Removed `tes_update_cred_url()` and `apply_cred_config_changes()` (dead code)
  - Removed `#include <ggl/core_bus/gg_config.h>` (no longer needed)

- `modules/tesd/src/token_service.h`:
  - Removed `tes_update_cred_url()` declaration

## Testing

Verified via endpoint switch deployment on a containerized Greengrass Lite
device (us-east-1 → us-west-2). Relevant journal output:

```
Jun 24 18:28:48 tesd[90]: Credential URL: https://c24redacted.credentials.iot.us-east-1.amazonaws.com/role-aliases/GreengrassCoreTokenExchangeRoleAlias/credentials
Jun 24 18:29:03 tesd[90]: Configuration key 'iotCredEndpoint' changed, restarting tesd.
Jun 24 18:29:03 systemd[1]: ggl.core.tesd.service: Deactivated successfully.
Jun 24 18:29:04 systemd[1]: ggl.core.tesd.service: Scheduled restart job, restart counter is at 1.
Jun 24 18:29:04 systemd[1]: Started ggl.core.tesd.service - core-bus IoT credential provider.
Jun 24 18:29:04 tesd[121]: Credential URL: https://c24redacted.credentials.iot.us-west-2.amazonaws.com/role-aliases/GreengrassCoreTokenExchangeRoleAlias/credentials
```

- tesd detects `iotCredEndpoint` change, logs it, and exits
- systemd restarts tesd ~1 second later (PID 90 → 121)
- On restart, tesd reads fresh config and builds URL with the new endpoint
- Device remains HEALTHY after the switch
