### PR TITLE
Update documentation to standardize Greengrass nucleus / Greengrass nucleus lite naming

### DIFF
--- a/.github/workflows/packaging/install-greengrass-lite.sh
+++ b/.github/workflows/packaging/install-greengrass-lite.sh
@@ -33,7 +33,7 @@ check_ubuntu_version() {
             return 0
         fi
     fi
-    echo "Warning: This greengrass lite package is only tested working with Ubuntu 22.04, 24.04, Debian 12, 13"
+    echo "Warning: This Greengrass nucleus lite package is only tested working with Ubuntu 22.04, 24.04, Debian 12, 13"
     echo "Current system: $PRETTY_NAME"
     return 0
 }
@@ -150,7 +150,7 @@ install() {
 
 # uninstall
 uninstall() {
-    echo "Uninstalling Greengrass Lite..."
+    echo "Uninstalling Greengrass nucleus lite..."
 
     systemctl stop greengrass-lite.target
     systemctl disable greengrass-lite.target

--- a/.github/workflows/packaging/readme.template.txt
+++ b/.github/workflows/packaging/readme.template.txt
@@ -1,13 +1,13 @@
 ###############################################################################
-# AWS Greengrass Lite
+# AWS Greengrass nucleus lite
 ###############################################################################
 
 AWS IoT Greengrass runtime for constrained devices.
 
-The Greengrass Lite nucleus provides a smaller alternative to the Java
+The Greengrass nucleus lite provides a smaller alternative to the Java
 nucleus for Greengrass v2 deployments.
 
-Greengrass Lite aims to maintain compatibility with the Java nucleus, and
+Greengrass nucleus lite aims to maintain compatibility with the Java nucleus, and
 implements a subset of its functionality.
 
 There is a arm32, arm64 and x86-64 version available of this zip file.
@@ -58,7 +58,7 @@ sudo ./install-greengrass-lite.sh -u
 # UPGRADE
 ###############################################################################
 
-When a new version of greengrass lite is available and you want to keep your
+When a new version of Greengrass nucleus lite is available and you want to keep your
 configuration and components. Install just the deb package from the zip, without
 using the (initial-) installation script.
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ AWS IoT Greengrass runtime for constrained devices.
 The Greengrass nucleus lite provides a lightweight alternative to the Greengrass
 nucleus runtime.
 
-The nucleus lite aims to be compatible with the Greengrass nucleus, but
-implements a subset of its functionality. Expect future releases to reduce the
-feature gap.
+The Greengrass nucleus lite aims to be compatible with the Greengrass nucleus,
+but implements a subset of its functionality. Expect future releases to reduce
+the feature gap.
 
 ## Getting started
 
@@ -38,12 +38,12 @@ SDKs and Quick Start guides that support platforms such as STM32, Renesas, NXP
 and Raspberry Pi.
 
 For a self-paced workshop, see the
-[Greengrass Nucleus Lite Workshop](https://catalog.workshops.aws/greengrass-nucleus-lite/en-US).
+[Greengrass nucleus lite Workshop](https://catalog.workshops.aws/greengrass-nucleus-lite/en-US).
 
 For Yocto/OpenEmbedded integration, check out
 [meta-aws](https://github.com/aws4embeddedlinux/meta-aws) and
 [meta-aws-demos](https://github.com/aws4embeddedlinux/meta-aws-demos) which
-provide recipes and examples for building AWS Greengrass Lite.
+provide recipes and examples for building AWS Greengrass nucleus lite.
 
 ### ⚠️ Important Notice
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -102,7 +102,8 @@ results as nucleus when used with the AWS IoT Device SDKs. Users of
 aws-greengrass-sdk-lite will need to update to version 0.3.0 of the SDK.
 
 Recipe manifests must now have the platform runtime set to `aws_nucleus_lite` or
-`*`. A missing platform runtime is now correctly handled as classic only.
+`*`. A missing platform runtime is now correctly handled as Greengrass nucleus
+only.
 
 ## New with this release
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,7 +1,7 @@
-# GGLite Resource Benchmark Harness
+# Greengrass nucleus lite Resource Benchmark Harness
 
-Reproducible benchmark harness for measuring AWS Greengrass Nucleus Lite
-(GGLite) resource consumption across x86_64, aarch64, and armv7l architectures.
+Reproducible benchmark harness for measuring Greengrass nucleus lite resource
+consumption across x86_64, aarch64, and armv7l architectures.
 
 The harness covers two scenarios:
 
@@ -25,7 +25,7 @@ benchmark/
 ├── scripts/
 │   ├── cloud-setup.env.example      # Template for AWS resource env vars
 │   ├── provision-account.sh         # One-time account setup (idempotent)
-│   ├── provision-device.sh          # Install GGLite on a target device
+│   ├── provision-device.sh          # Install Greengrass nucleus lite on a target device
 │   ├── run-all.sh                   # Orchestrator: smoke → scenarios → report
 │   ├── smoke-test.sh                # 6-test go/no-go gate
 │   ├── measure.sh                   # Phase 1 concurrent PSS/RSS/CPU/startup sampling
@@ -82,7 +82,8 @@ cp cloud-setup.env.example cloud-setup.env
 
 ### 2. Provision a target device (host)
 
-Installs GGLite on the device and writes its certificates / config:
+Installs Greengrass nucleus lite on the device and writes its certificates /
+config:
 
 ```bash
 ./provision-device.sh <device-ip> <arch>
@@ -167,13 +168,13 @@ following are **out of scope**:
 
 - **CI integration for automated regression detection.** The harness runs on
   demand; wiring it into a scheduled CI workflow is a separate effort.
-- **Network degradation testing.** Measuring GGLite behavior under flaky MQTT /
-  TES connectivity is out of scope (Phase 2 measures network _utilization_, not
-  degradation).
+- **Network degradation testing.** Measuring Greengrass nucleus lite behavior
+  under flaky MQTT / TES connectivity is out of scope (Phase 2 measures network
+  _utilization_, not degradation).
 - **Flash wear and IOPS.** Constrained devices can fail from write amplification
   on embedded flash; not measured here.
-- **riscv64.** Architecture is experimental in GGLite and not part of the
-  primary benchmark matrix.
+- **riscv64.** Architecture is experimental in Greengrass nucleus lite and not
+  part of the primary benchmark matrix.
 - **Concurrent-deployment stress testing.** Unusual failure mode.
 - **`RelWithDebInfo` build comparison.** Only `MinSizeRel` is measured; the
   harness is build-type-agnostic so this can be repeated later.

--- a/benchmark/REPORT.md
+++ b/benchmark/REPORT.md
@@ -1,4 +1,4 @@
-# GGLite Resource Benchmark Report
+# Greengrass nucleus lite Resource Benchmark Report
 
 Detailed benchmark report with full methodology and raw data. See
 `benchmark/README.md` for context and `docs/RESOURCE_LIMITS.md` for the
@@ -30,14 +30,14 @@ armv7l at 12.4 MB). See individual arch sections for per-daemon breakdowns.
 
 #### Primary Metric
 
-**Headline: PSS (Proportional Set Size)** summed across all GGLite daemon
-processes, sampled at a 10-second interval over a 10-minute steady-state window
-(after 5-minute warmup), reported as **median** with p95 / p99 / max also
-captured.
+**Headline: PSS (Proportional Set Size)** summed across all Greengrass nucleus
+lite daemon processes, sampled at a 10-second interval over a 10-minute
+steady-state window (after 5-minute warmup), reported as **median** with p95 /
+p99 / max also captured.
 
 #### Defining the "15 MB RAM footprint target"
 
-The Greengrass Lite architecture document
+The Greengrass nucleus lite architecture document
 ([`docs/design/gg-architecture.md`](../docs/design/gg-architecture.md))
 originally targeted a memory footprint below 10 MB. Based on the measurements in
 this report, the documented requirement has been revised to **15 MB** (see
@@ -46,15 +46,15 @@ reflects the actual achievable footprint across all supported architectures with
 realistic component workloads.
 
 For the purpose of this report, the "15 MB RAM footprint" is formally defined
-as: **median PSS, summed across all long-running GGLite daemons (`ggipcd`,
-`ggdeploymentd`, `gghealthd`, `ggconfigd`, `ggpubsubd`, `iotcored`, `tesd`,
-`tes-serverd`, `gg-fleet-statusd`), at realistic-load steady state**, sampled
-every 10 seconds over a 10-minute window after a 5-minute warmup.
+as: **median PSS, summed across all long-running Greengrass nucleus lite daemons
+(`ggipcd`, `ggdeploymentd`, `gghealthd`, `ggconfigd`, `ggpubsubd`, `iotcored`,
+`tesd`, `tes-serverd`, `gg-fleet-statusd`), at realistic-load steady state**,
+sampled every 10 seconds over a 10-minute window after a 5-minute warmup.
 
-PSS is chosen because GGLite is a multi-daemon system that shares libc, libssl,
-and libcurl across processes; PSS attributes shared pages fairly and does not
-double-count them like RSS does. `recipe-runner` is excluded because it is
-ephemeral (runs only during component lifecycle events).
+PSS is chosen because Greengrass nucleus lite is a multi-daemon system that
+shares libc, libssl, and libcurl across processes; PSS attributes shared pages
+fairly and does not double-count them like RSS does. `recipe-runner` is excluded
+because it is ephemeral (runs only during component lifecycle events).
 
 #### Secondary Metrics
 
@@ -97,7 +97,7 @@ A 6-test smoke suite must pass before measurement begins on each architecture:
 | Simple component | `hello-world` + `ipc-publisher` + `ipc-subscriber`                                | 1 msg/sec IPC                                            |
 | Realistic load   | `ipc-publisher` × 2 + `ipc-subscriber` × 2 + `iot-core-publisher` + `s3-uploader` | 2 msg/sec local IPC, 1 msg/sec IoT Core, 1 S3 upload/min |
 
-#### GGLite Version
+#### Greengrass nucleus lite Version
 
 v2.5.0 prebuilt `.deb` packages (MinSizeRel build type) — what customers
 actually install.
@@ -119,8 +119,8 @@ below.
 
 #### Per-Daemon Breakdown (realistic-load)
 
-All 9 long-running GGLite daemons sampled. `recipe-runner` is ephemeral (runs
-only during deployments) and is not sampled at steady state.
+All 9 long-running Greengrass nucleus lite daemons sampled. `recipe-runner` is
+ephemeral (runs only during deployments) and is not sampled at steady state.
 
 | Daemon           | Median PSS (KB) | Median RSS (KB) |
 | ---------------- | --------------- | --------------- |
@@ -139,10 +139,11 @@ only during deployments) and is not sampled at steady state.
 - **Total daemon PSS at idle (baseline): ~14.6 MB** — matches aarch64 baseline
   within 0.1% (aarch64: 14,615 KB)
 - **Daemon PSS overhead from running components**: +215 KB (baseline →
-  realistic-load) — growth in GGLite daemon memory caused by handling 5 deployed
-  components (deployment metadata cached by `ggdeploymentd`, IPC subscriptions
-  in `ggipcd`, per-component config in `ggconfigd`). Component process memory is
-  NOT included; this measures only the GGLite daemons. Same pattern as aarch64.
+  realistic-load) — growth in Greengrass nucleus lite daemon memory caused by
+  handling 5 deployed components (deployment metadata cached by `ggdeploymentd`,
+  IPC subscriptions in `ggipcd`, per-component config in `ggconfigd`). Component
+  process memory is NOT included; this measures only the Greengrass nucleus lite
+  daemons. Same pattern as aarch64.
 - **RSS vs PSS gap**: RSS (51.6 MB) is 3.5× PSS (14.6 MB) due to shared library
   pages across 9 daemons — confirms PSS is the correct metric for multi-process
   memory accounting
@@ -197,7 +198,7 @@ component work directories are created. Observed ceiling at realistic-load with
 - **Device**: EC2 `t3.small` (2 vCPU, 2 GB RAM), us-west-2, Intel Xeon Platinum
   8259CL @ 2.50 GHz
 - **OS**: Ubuntu 24.04.4 LTS (Noble Numbat), kernel 6.17.0-1013-aws
-- **GGLite version**: v2.5.0 (prebuilt amd64 .deb from
+- **Greengrass nucleus lite version**: v2.5.0 (prebuilt amd64 .deb from
   `aws-greengrass-lite-deb-x86-64.zip`, MinSizeRel)
 - **Harness invocation**: `sudo bash scripts/run-all.sh x86_64` — identical to
   aarch64 invocation. No x86_64-specific script forks or changes were required;
@@ -206,9 +207,9 @@ component work directories are created. Observed ceiling at realistic-load with
 #### Run Stability
 
 Four consecutive runs were executed on the same EC2 instance (run 1 immediately
-after provisioning; runs 2–4 back-to-back with a warm GGLite install and cached
-TES credentials). Run 1 is a first-boot artifact and is excluded from the
-stability check — see _Startup Time_ note above.
+after provisioning; runs 2–4 back-to-back with a warm Greengrass nucleus lite
+install and cached TES credentials). Run 1 is a first-boot artifact and is
+excluded from the stability check — see _Startup Time_ note above.
 
 **Run 1 (cold start, EXCLUDED)**: median PSS inflated by ~1.5 MB across all
 scenarios because TES did not complete its first credential exchange within the
@@ -226,8 +227,8 @@ variance.
 
 All three steady-state runs land comfortably within the 5% acceptance-criterion
 window. The first-boot inflation is documented explicitly so operators
-provisioning GGLite on a fresh device know to wait ~2 minutes for TES to warm
-before making capacity-planning decisions.
+provisioning Greengrass nucleus lite on a fresh device know to wait ~2 minutes
+for TES to warm before making capacity-planning decisions.
 
 ---
 
@@ -243,8 +244,8 @@ before making capacity-planning decisions.
 
 #### Per-Daemon Breakdown (realistic-load)
 
-All 9 long-running GGLite daemons sampled. `recipe-runner` is ephemeral (runs
-only during deployments) and is not sampled at steady state.
+All 9 long-running Greengrass nucleus lite daemons sampled. `recipe-runner` is
+ephemeral (runs only during deployments) and is not sampled at steady state.
 
 | Daemon           | Median PSS (KB) | Median RSS (KB) |
 | ---------------- | --------------- | --------------- |
@@ -263,14 +264,15 @@ only during deployments) and is not sampled at steady state.
 - **Total daemon PSS at idle (baseline): ~14.6 MB** — within the 15 MB RAM
   footprint target
 - **Daemon PSS overhead from running components**: +1.2 MB (baseline →
-  realistic-load) — growth in GGLite daemon memory caused by handling 5 deployed
-  components (deployment metadata cached by `ggdeploymentd`, IPC subscriptions
-  in `ggipcd`, per-component config in `ggconfigd`). Component process memory is
-  NOT included; this measures only the GGLite daemons.
+  realistic-load) — growth in Greengrass nucleus lite daemon memory caused by
+  handling 5 deployed components (deployment metadata cached by `ggdeploymentd`,
+  IPC subscriptions in `ggipcd`, per-component config in `ggconfigd`). Component
+  process memory is NOT included; this measures only the Greengrass nucleus lite
+  daemons.
 - **RSS vs PSS gap**: RSS (50.9 MB) is 3.5× PSS (14.6 MB) due to shared library
   pages across 9 daemons — confirms PSS is the correct metric
 - **CPU utilization**: Minimal at all load levels (~3.1% usr, ~90% idle) —
-  GGLite is not CPU-bound
+  Greengrass nucleus lite is not CPU-bound
 - **Largest daemons by PSS**: `ggdeploymentd` (4.98 MB), `tesd` (4.25 MB),
   `iotcored` (2.68 MB) — together account for ~82% of total PSS
 - **Startup time**: 1,700 ms from `systemctl restart greengrass-lite.target`
@@ -304,7 +306,7 @@ deployed, runtime size was ~400 KB in prior runs.
 
 - **Device**: Raspberry Pi 4 (aarch64), Debian GNU/Linux, kernel
   6.12.47+rpt-rpi-v8
-- **GGLite version**: v2.5.0 (prebuilt arm64 .deb, MinSizeRel)
+- **Greengrass nucleus lite version**: v2.5.0 (prebuilt arm64 .deb, MinSizeRel)
 - **Harness invocation**: `sudo bash scripts/run-all.sh aarch64`
 
 #### Run Stability
@@ -325,8 +327,8 @@ deployed, runtime size was ~400 KB in prior runs.
 
 #### Per-Daemon Breakdown (realistic-load)
 
-All 9 long-running GGLite daemons sampled. `recipe-runner` is ephemeral (runs
-only during deployments) and is not sampled at steady state.
+All 9 long-running Greengrass nucleus lite daemons sampled. `recipe-runner` is
+ephemeral (runs only during deployments) and is not sampled at steady state.
 
 | Daemon           | Median PSS (KB) | Median RSS (KB) |
 | ---------------- | --------------- | --------------- |
@@ -344,7 +346,7 @@ only during deployments) and is not sampled at steady state.
 
 On armv7l, user-space is limited to ~3 GB virtual address space (vs. 128 TB on
 aarch64). VSS is reported here prominently because it indicates how much of the
-limited 32-bit address space GGLite consumes.
+limited 32-bit address space Greengrass nucleus lite consumes.
 
 Total VSS across all 9 daemons at realistic-load: **~180 MB** (well within the 3
 GB limit). Individual daemon VSS ranges from 8–35 MB. No risk of address space
@@ -355,10 +357,11 @@ exhaustion even with many components deployed.
 - **Total daemon PSS at idle (baseline): ~12.3 MB** — 16% lower than aarch64
   (14.6 MB) due to smaller 32-bit pointers and reduced alignment padding
 - **Daemon PSS overhead from running components**: +64 KB (baseline →
-  realistic-load) — growth in GGLite daemon memory caused by handling 5 deployed
-  components (deployment metadata cached by `ggdeploymentd`, IPC subscriptions
-  in `ggipcd`, per-component config in `ggconfigd`). Component process memory is
-  NOT included; this measures only the GGLite daemons.
+  realistic-load) — growth in Greengrass nucleus lite daemon memory caused by
+  handling 5 deployed components (deployment metadata cached by `ggdeploymentd`,
+  IPC subscriptions in `ggipcd`, per-component config in `ggconfigd`). Component
+  process memory is NOT included; this measures only the Greengrass nucleus lite
+  daemons.
 - **RSS vs PSS gap**: RSS (44.6 MB) is 3.6× PSS (12.3 MB) — same shared-library
   effect as aarch64
 - **CPU utilization**: Higher than aarch64 (~11% usr vs ~3.1%) — the 32-bit
@@ -372,8 +375,8 @@ exhaustion even with many components deployed.
 #### Startup Time
 
 Measurement method: `systemctl restart greengrass-lite.target`, then poll until
-every service under the target is active. The 9 core GGLite daemons start within
-~2–3 seconds on this hardware on a fresh install.
+every service under the target is active. The 9 core Greengrass nucleus lite
+daemons start within ~2–3 seconds on this hardware on a fresh install.
 
 #### Disk Usage
 
@@ -387,7 +390,7 @@ every service under the target is active. The 9 core GGLite daemons start within
 
 - **Device**: Raspberry Pi 3 Model B (armv7l), Raspbian GNU/Linux 13 (trixie),
   kernel 6.12.75+rpt-rpi-v7
-- **GGLite version**: v2.5.0 (prebuilt armhf .deb, MinSizeRel)
+- **Greengrass nucleus lite version**: v2.5.0 (prebuilt armhf .deb, MinSizeRel)
 - **Harness invocation**: `sudo bash scripts/run-all.sh armv7l`
 
 #### Run Stability
@@ -405,11 +408,12 @@ within 0.4% coefficient of variation (well within the 5% stability criterion).
 
 ## Phase 2 — Cloud Deployment
 
-Phase 1 (above) measured GGLite at **steady state** using local `ggl-cli`
-deployments. Phase 2 exercises the full **customer cloud-deployment path** —
-`aws greengrassv2 create-deployment` → IoT Jobs → `ggdeploymentd` → TES-signed
-S3 artifact download → `iotcored` MQTT handshake — and captures deployment-time
-peak resource consumption at 1-second granularity during the deployment window.
+Phase 1 (above) measured Greengrass nucleus lite at **steady state** using local
+`ggl-cli` deployments. Phase 2 exercises the full **customer cloud-deployment
+path** — `aws greengrassv2 create-deployment` → IoT Jobs → `ggdeploymentd` →
+TES-signed S3 artifact download → `iotcored` MQTT handshake — and captures
+deployment-time peak resource consumption at 1-second granularity during the
+deployment window.
 
 ### Phase 2 Cross-Architecture Summary
 
@@ -474,7 +478,8 @@ unchanged when absent.
 
 3 consecutive `cloud-deploy-initial` runs on 2026-05-11 via EC2 instance (Ubuntu
 24.04, us-west-2), using `/proc`-based samplers plus post-deploy steady-state
-capture. Same GGLite v2.5.0 amd64.deb as the Phase 1 x86_64 measurements.
+capture. Same Greengrass nucleus lite v2.5.0 amd64.deb as the Phase 1 x86_64
+measurements.
 
 **Headline**: deployment-time peak PSS is **+5.0% over Phase 1 steady-state**
 (14,818 → 15,558 kB mean peak), with **5.7% coefficient of variation** across
@@ -572,14 +577,15 @@ footprint, not transient peaks.
 
 3 consecutive `cloud-deploy-initial` runs on 2026-05-11 on the RPi 4 device,
 using direct `/proc` polling samplers plus post-deploy steady-state capture.
-Same RPi 4 / same GGLite v2.5.0 arm64.deb as the Phase 1 aarch64 measurements.
+Same RPi 4 / same Greengrass nucleus lite v2.5.0 arm64.deb as the Phase 1
+aarch64 measurements.
 
 **Headline**: deployment-time peak PSS is **+2.4% over Phase 1 steady-state**
 (+3.3% at max), with **1.2% coefficient of variation** across the 3 runs — well
 under the 10% AC target. Post-deploy steady-state PSS settles at ~15.8 MB with
 **1.2% CV across runs** (well under the 5% AC target). Device memory budget:
-**~16 MB PSS** headroom is sufficient for a device that runs GGLite comfortably
-at ~15 MB steady-state.
+**~16 MB PSS** headroom is sufficient for a device that runs Greengrass nucleus
+lite comfortably at ~15 MB steady-state.
 
 #### Deployment-time Peak Summary
 
@@ -675,7 +681,8 @@ cloud-deploy steady-state, not the transient peak.
 
 3 consecutive `cloud-deploy-initial` runs on 2026-05-11 on the RPi 3 device via
 SSH jump host, using the same `/proc`-based samplers validated on aarch64. Same
-RPi 3 / same GGLite v2.5.0 armhf `.deb` as the Phase 1 armv7l measurements.
+RPi 3 / same Greengrass nucleus lite v2.5.0 armhf `.deb` as the Phase 1 armv7l
+measurements.
 
 **Headline**: deployment-time peak PSS is **+6.7% over Phase 1 realistic-load
 steady-state** (12.39 MB → 13.23 MB), with an **extremely tight 0.037%
@@ -821,8 +828,8 @@ footprint on armv7l.
 
 - **Device**: Raspberry Pi 3 Model B (armv7l), Raspbian GNU/Linux 13 (trixie),
   kernel 6.12.75+rpt-rpi-v7, 1 GB RAM, SD-card storage
-- **GGLite version**: v2.5.0 (prebuilt armhf .deb, MinSizeRel) — same build as
-  Phase 1
+- **Greengrass nucleus lite version**: v2.5.0 (prebuilt armhf .deb, MinSizeRel)
+  — same build as Phase 1
 - **Harness**: `cloud-deploy-initial.sh` invoked directly 3 times via tmux +
   `ssh -J` jump host (not `run-all.sh --phase2` — skips Phase 1 scenarios and
   `cloud-deploy-update.sh` to keep the AWS-credential window tight, same pattern

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -111,9 +111,9 @@ adduser -g <gid from previous command> gg_component
 
 ## (Optional) Using Podman
 
-Instead of installing Greengrass Lite directly on a system, you can use a
-container. The provided container has the build dependencies, system users
-already provided, as well as Greengrass Lite built and installed.
+Instead of installing Greengrass nucleus lite directly on a system, you can use
+a container. The provided container has the build dependencies, system users
+already provided, as well as Greengrass nucleus lite built and installed.
 
 The following steps assume you want to use `./run` for persistent state, you
 place your Greengrass config file in `./run/config.yaml`, and certs/keys in
@@ -149,7 +149,7 @@ podman run -it -v $PWD/run/config.yaml:/etc/greengrass/config.yaml \
   --replace --name ggl ggl:latest
 ```
 
-To persist the Greengrass Lite run dir, you can bind a host directory to
+To persist the Greengrass nucleus lite run dir, you can bind a host directory to
 `/var/lib/greengrass` (assuming certs/keys are in `./run/rootPath/certs`):
 
 ```sh
@@ -214,12 +214,12 @@ The following configuration flags may be set with cmake (with `-D`):
 
 - `GGL_SYSTEMD_SYSTEM_USER`
 
-  The system user to use for Greengrass Lite nucleus services (not components).
+  The system user to use for Greengrass nucleus lite services (not components).
   Must exist on system.
 
 - `GGL_SYSTEMD_SYSTEM_GROUP`
 
-  The system group to use for Greengrass Lite nucleus services (not components).
+  The system group to use for Greengrass nucleus lite services (not components).
   Must exist on system.
 
 - `GGL_SYSTEMD_SYSTEM_DIR`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,4 +1,4 @@
-# Greengrass Nucleus Lite Developer setup
+# Greengrass nucleus lite Developer setup
 
 This guide is for developers working on the Greengrass nucleus lite codebase to
 set up.

--- a/docs/PKCS11_SUPPORT.md
+++ b/docs/PKCS11_SUPPORT.md
@@ -1,11 +1,11 @@
 # PKCS#11 Support
 
-Greengrass Lite supports PKCS#11 URIs for `privateKeyPath` and
+Greengrass nucleus lite supports PKCS#11 URIs for `privateKeyPath` and
 `certificateFilePath`. This allows the device private key (and optionally the
 certificate) to be stored in a hardware security module or software token rather
 than as files on disk.
 
-Greengrass Lite uses the OpenSSL
+Greengrass nucleus lite uses the OpenSSL
 [OSSL_STORE](https://www.openssl.org/docs/man3.0/man7/ossl_store.html) API to
 load keys and certificates. When an OpenSSL PKCS#11 provider is configured, any
 `pkcs11:` URI is handled transparently.
@@ -98,8 +98,8 @@ aws iot create-certificate-from-csr \
 
 Import the certificate into the token using your HSM's tooling.
 
-The user running Greengrass Lite (`ggcore`) must have read/write access to the
-token files. For SoftHSM, add `ggcore` to the `softhsm` group:
+The user running Greengrass nucleus lite (`ggcore`) must have read/write access
+to the token files. For SoftHSM, add `ggcore` to the `softhsm` group:
 
 ```bash
 sudo usermod -aG softhsm ggcore
@@ -148,7 +148,7 @@ If `openssl list -providers` does not show the pkcs11 provider:
 
 ### Permission Denied
 
-If Greengrass Lite fails to access the token:
+If Greengrass nucleus lite fails to access the token:
 
 - Verify `ggcore` can access the PKCS#11 module's token storage
 - For SoftHSM, ensure `ggcore` is in the `softhsm` group and that token files

--- a/docs/Provisioning.md
+++ b/docs/Provisioning.md
@@ -18,8 +18,8 @@ Provisioning.
 
 ### Custom Provisioning
 
-Greengrass Lite is a collection of microservices, so it's not limited to a
-specific provisioning solution. You may use your own provisioning method by
+Greengrass nucleus lite is a collection of microservices, so it's not limited to
+a specific provisioning solution. You may use your own provisioning method by
 simply following a few principles:
 
 - `ggconfig.d` will only look into `/etc/greengrass/config.yaml` or
@@ -32,7 +32,8 @@ simply following a few principles:
   contents of the file. Hence, any systemd service file for provisioning should
   mark itself to run with `Before=ggl.core.ggconfigd.service`.
 
-Any solution that respects the above rules will work with GG Nucleus Lite.
+Any solution that respects the above rules will work with Greengrass nucleus
+lite.
 
 ### Manual Provisioning
 
@@ -41,7 +42,7 @@ device credentials from the console by following these steps:
 
 - Go to:
   `IoT Core > Greengrass devices > Core devices > Set up core device > Set up one core device`
-- Modify the name fields as required and then select `Nucleus Lite`
+- Modify the name fields as required and then select `Greengrass nucleus lite`
 - Find the `Create thing` button and click it
 - Then click `Download connection kit`
 

--- a/docs/RECIPE_SUPPORT_CHANGES.md
+++ b/docs/RECIPE_SUPPORT_CHANGES.md
@@ -1,8 +1,8 @@
-# Types of Recipes Supported by GG nucleus lite
+# Types of Recipes Supported by Greengrass nucleus lite
 
-For GG nucleus lite we only support basic recipe format and support for more
-complex recipe will be delivered with future release. Below is the summary of
-what's not supported. If it's not mentioned in the list then that case is
+For Greengrass nucleus lite we only support basic recipe format and support for
+more complex recipe will be delivered with future release. Below is the summary
+of what's not supported. If it's not mentioned in the list then that case is
 supported as mentioned in the
 [aws docs](https://docs.aws.amazon.com/greengrass/v2/developerguide/component-recipe-reference.html).
 
@@ -18,7 +18,7 @@ supported as mentioned in the
 - Only linux lifecycles are supported with the current release.
 
 - Only generic component (`aws.greengrass.generic`) recipe types are supported
-  with lite.
+  with Greengrass nucleus lite.
 
 - Some lifecycle steps are not currently supported:
 
@@ -31,8 +31,9 @@ supported as mentioned in the
 - Refering to global lifecycle requires mentioning `all` field for it to work.
   Refer to [sample recipe 3](./examples/supported_lifecyle_types/3.yaml).
 
-- "runtime": "\*"(for classic and lite) or "runtime": "aws_nucleus_lite" is
-  required new field that needs to be added for it to work with lite. See
+- "runtime": "\*"(for Greengrass V2) or "runtime": "aws_nucleus_lite" is
+  required new field that needs to be added for it to work with Greengrass
+  nucleus lite. See
   [sample recipe 1](./examples/supported_lifecyle_types/1.json).
 
   ```yaml
@@ -44,7 +45,7 @@ supported as mentioned in the
 
 - Regex support is not available within recipe.
 
-- GG nucleus lite only support variable replacement for following cases:
+- Greengrass nucleus lite only support variable replacement for following cases:
 
   - artifacts:path
   - artifacts:decompressedPath

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -44,7 +44,7 @@ devices with the steps from
 one or the other.
 
 To configure Greengrass, you will need a config YAML file, in the same format as
-the Classic nucleus config. An example config file is available in
+the Greengrass nucleus config. An example config file is available in
 [`docs/examples/sample_nucleus_config.yaml`](examples/sample_nucleus_config.yaml).
 If this is the first time you are creating a GG device, please follow the
 instruction in the [Provisioning.md](./Provisioning.md) to get a role alias,

--- a/docs/TPM_SUPPORT.md
+++ b/docs/TPM_SUPPORT.md
@@ -1,10 +1,10 @@
-# TPM 2.0 Support for AWS Greengrass Lite
+# TPM 2.0 Support for AWS Greengrass nucleus lite
 
-This guide demonstrates how to set up AWS Greengrass Lite with TPM 2.0 support
-using Amazon EC2 NitroTPM. The TPM provides hardware-backed security for device
-identity and cryptographic operations.
+This guide demonstrates how to set up AWS Greengrass nucleus lite with TPM 2.0
+support using Amazon EC2 NitroTPM. The TPM provides hardware-backed security for
+device identity and cryptographic operations.
 
-Greengrass Lite uses the OpenSSL
+Greengrass nucleus lite uses the OpenSSL
 [OSSL_STORE](https://www.openssl.org/docs/man3.0/man7/ossl_store.html) API to
 load the private key. When an OpenSSL 3 provider for TPM 2.0 is configured and
 activated via `openssl.cnf`, any `handle:` URI is handled transparently.
@@ -186,9 +186,9 @@ For detailed manual provisioning steps, see the
 curl -o AmazonRootCA1.pem https://www.amazontrust.com/repository/AmazonRootCA1.pem
 ```
 
-## Greengrass Lite Setup
+## Greengrass nucleus lite Setup
 
-### Step 7: Set up Greengrass Lite
+### Step 7: Set up Greengrass nucleus lite
 
 #### 7.1 Install Dependencies
 
@@ -253,7 +253,7 @@ sudo mkdir -p /etc/greengrass/
 sudo cp ./config.yaml /etc/greengrass/config.yaml
 ```
 
-### Step 8: Build and Run Greengrass Lite
+### Step 8: Build and Run Greengrass nucleus lite
 
 #### 8.1 Build
 

--- a/docs/design/gg-architecture.md
+++ b/docs/design/gg-architecture.md
@@ -1,11 +1,11 @@
-# Greengrass Lite Architecture
+# Greengrass nucleus lite Architecture
 
 ## Introduction and Goals
 
-Greengrass Lite is a size constrained version of Greengrass v2. The intent is to
-reduce the memory footprint below 10MB with smaller being better. The potential
-applications increase dramatically as size reduces so there is no maximum
-“acceptable” size defined.
+Greengrass nucleus lite is a size constrained version of Greengrass V2. The
+intent is to reduce the memory footprint below 10MB with smaller being better.
+The potential applications increase dramatically as size reduces so there is no
+maximum “acceptable” size defined.
 
 > **Note:** The original 10 MB target has been revised to **15 MB** based on
 > measured footprint across all supported architectures with realistic component
@@ -28,9 +28,9 @@ The most important customer requirements are listed below:
 ### Reduce Size
 
 Target a small size to allow integration into IoT gateways, home routers, and
-virtual machines. A scaleable greengrass lite system that can be “right-sized”
-to a customer application will open many opportunities. Every MB used by
-Greengrass reduces the memory available to the target application.
+virtual machines. A scaleable Greengrass nucleus lite system that can be
+“right-sized” to a customer application will open many opportunities. Every MB
+used by Greengrass reduces the memory available to the target application.
 
 ### Support Generic Components
 
@@ -43,11 +43,12 @@ system.
 
 ### Platform Support
 
-The immediate customer need for Greengrass lite is to run on embedded Linux
-systems. However it is anticipated that non-linux systems may be targeted. The
-architecture will need to isolate platform issues to simplify adding additional
-platforms. It is acceptable to have multiple versions of platform specific
-services. Different platforms are referred to as hosts in this document.
+The immediate customer need for Greengrass nucleus lite is to run on embedded
+Linux systems. However it is anticipated that non-linux systems may be targeted.
+The architecture will need to isolate platform issues to simplify adding
+additional platforms. It is acceptable to have multiple versions of platform
+specific services. Different platforms are referred to as hosts in this
+document.
 
 ### Shared MQTT
 
@@ -381,18 +382,19 @@ system, they customer will be successful in debugging.
 Orchestration is the process of starting the components in the correct order and
 ensuring that they stay running. Greengrass components provide a recipe document
 that informs the orchestrator how to start the component and what the
-dependencies are. Greengrass lite will use the recipe document as the input and
-translate the document into the host native orchestrator format. For example,
-the recipe can be processed into a systemd unit file or windows system service
-registry entry. The translation process must be developed for each host. The
-translator can be performed by the customer during component development, in the
-GG cloud console or in the GG edge device. Recipe documents contain descriptions
-of each phase of a generic component operation and any dependencies needed by
-the component. These documents can be translated during deployment into systemd
-or initd documents and then the translated documents will be used by the host to
-automatically start Greengrass. A Greengrass system monitor can keep track of
-the component health by using host native interfaces (systemd/windows has an API
-for this). This strategy requires 2 simple host native components.
+dependencies are. Greengrass nucleus lite will use the recipe document as the
+input and translate the document into the host native orchestrator format. For
+example, the recipe can be processed into a systemd unit file or windows system
+service registry entry. The translation process must be developed for each host.
+The translator can be performed by the customer during component development, in
+the GG cloud console or in the GG edge device. Recipe documents contain
+descriptions of each phase of a generic component operation and any dependencies
+needed by the component. These documents can be translated during deployment
+into systemd or initd documents and then the translated documents will be used
+by the host to automatically start Greengrass. A Greengrass system monitor can
+keep track of the component health by using host native interfaces
+(systemd/windows has an API for this). This strategy requires 2 simple host
+native components.
 
 1. Recipe translation
 2. Component Health monitoring
@@ -434,7 +436,7 @@ used for backups, restore and security. An open question is if components should
 use direct access to sqlite or if they should go through a configuration
 abstraction. The abstraction allows the database to be changed without affecting
 the components but sqlite is already cross platform and widely supported on all
-the hosts being considered for Greengrass lite.
+the hosts being considered for Greengrass nucleus lite.
 
 ## Runtime View
 
@@ -689,19 +691,19 @@ the SQLite to the previous point and then restart greengrass.
 
 #### per-component failure response
 
-Greengrass Lite consists of core components that are each started by host
-orchestration files. It is possible per-component failure recovery processes to
-take place. This level of detail is not currently defined in the recipe files so
-the current recommendation is a global roll-back. However, a future update to
-recipes could allow corrective action on each component before a global
-roll-back takes places.
+Greengrass nucleus lite consists of core components that are each started by
+host orchestration files. It is possible per-component failure recovery
+processes to take place. This level of detail is not currently defined in the
+recipe files so the current recommendation is a global roll-back. However, a
+future update to recipes could allow corrective action on each component before
+a global roll-back takes places.
 
 #### graceful degradation
 
-Greengrass Lite consists of core components that may not all fail in the event
-of a problem. In this case, some services may be able to continue operation
-allowing a “limp-home” mode. This behavior can be created in the recovery
-handling.
+Greengrass nucleus lite consists of core components that may not all fail in the
+event of a problem. In this case, some services may be able to continue
+operation allowing a “limp-home” mode. This behavior can be created in the
+recovery handling.
 
 #### Logging
 
@@ -714,7 +716,7 @@ must be in a different partition to avoid being affected and loosing log data.
 
 ## Architecture Decisions
 
-The architectural strategy of this Greengrass lite is to be as simple as
+The architectural strategy of this Greengrass nucleus lite is to be as simple as
 possible and letting the host native services handle processes to the extent
 possible. Memory safety will be handled by using industry standard tools such as
 CBMC, valgrind, and fuzzers or by language choices such as RUST. These decisions
@@ -736,14 +738,14 @@ developed and validated in isolation.
 ## Additional Areas to Discuss
 
 - Configuration store - each component has configuration associated with it,
-  that (GGv2-classic) is timestamp merged with multiple authority and available
-  via IPC configuration functions. Related- if someone brings a new protocol
-  translation, how do they apply the security guards on that too.
+  that (Greengrass nucleus) is timestamp merged with multiple authority and
+  available via IPC configuration functions. Related- if someone brings a new
+  protocol translation, how do they apply the security guards on that too.
 - “config.yaml”/TLOG - debate on if it is really necessary/desirable to switch
-  between GG-classic and GG-lite. If you can relax that requirement - in which
-  case the argument may be asked if it’s really the same “v2” product - it
-  relaxes need to capture and log config transactions. Related question is how
-  the top-level system configuration is applied.
+  between Greengrass nucleus and Greengrass nucleus lite. If you can relax that
+  requirement - in which case the argument may be asked if it’s really the same
+  “v2” product - it relaxes need to capture and log config transactions. Related
+  question is how the top-level system configuration is applied.
 - IPC security - there is rule-based security around IPC, and also finer detail
   in pub/sub actions. This doesn’t map well to file permissions. Deeper dive in
   this with AppSec involvement. In particular, there is an identity attestation
@@ -753,9 +755,9 @@ developed and validated in isolation.
   re-presents to GG to prove it is “FooBar” or a representative of “FooBar” - a
   non-breaking alternative to obtain this identity is required as FooBar is now
   started by systemd and not by the GG orchestrator.
-- With GG-classic and previous GG-lite design, there was a path on how
-  components/binary signatures can be verified to allow end-to-end attestation -
-  how might this be accomplished here
+- With Greengrass nucleus and previous Greengrass nucleus lite design, there was
+  a path on how components/binary signatures can be verified to allow end-to-end
+  attestation - how might this be accomplished here
 - The architecture is thread heavy to promote simplicity. Do an estimation of an
   application that has sufficient complexity of pub/subs, and number of threads
   that are likely to be consumed (but idle) - what is the resource cost of that

--- a/docs/design/gg-fleet-statusd.md
+++ b/docs/design/gg-fleet-statusd.md
@@ -1,4 +1,4 @@
-# GG Lite - Fleet Status Service Daemon Design
+# Greengrass nucleus lite - Fleet Status Service Daemon Design
 
 See [gg-fleet-statusd spec](../spec/executable/gg-fleet-statusd.md) for the
 public interface for gg-fleet-statusd.
@@ -7,10 +7,10 @@ public interface for gg-fleet-statusd.
 
 The fleet status service enables Greengrass to collect and report the health
 status of deployed components to the cloud. This allows customers to track their
-device status in the console. GG Lite will replicate GG Classic behavior,
-ensuring that customers can still see component statuses in the console just as
-they do with Classic. This task will be handled by `gg-fleet-statusd`, an
-individual process part of GG Lite.
+device status in the console. Greengrass nucleus lite will replicate Greengrass
+nucleus behavior, ensuring that customers can still see component statuses in
+the console just as they do with Greengrass nucleus. This task will be handled
+by `gg-fleet-statusd`, an individual process part of Greengrass nucleus lite.
 
 ## Requirements
 

--- a/docs/design/ggconfigd.md
+++ b/docs/design/ggconfigd.md
@@ -25,7 +25,7 @@ The structure of the configuration hierarchy is as follows:
 |  ├─ rootCaPath
 |  └─ certificateFilePath
 └─ services/              # component-specific configurations
-   ├─ NucleusLite/         # A reserved component section shared by GG-Lite core components
+   ├─ NucleusLite/         # A reserved component section shared by Greengrass nucleus lite core components
    │  ├─ iotRoleAlias
    │  ├─ iotDataEndpoint
    |  ├─ iotCredEndpoint
@@ -199,7 +199,7 @@ Some options for implementing notification grouping are:
 1. Have a separate task which sends out notifications. This would be separate
    from the write handler, which currently sends out notifications as part of a
    write operation.
-1. See how the V2 Classic nucleus does it, and do something similar.
+1. See how the Greengrass nucleus does it, and do something similar.
 
 ### Suppressing Notifications when the value is written to but has not changed
 
@@ -218,7 +218,7 @@ values to suppress unnecessary notifications.
 
 ### Subscription behavior for keys which become deleted
 
-In GG Classic, if a key is deleted (e.g. via reset config paths during
+In Greengrass nucleus, if a key is deleted (e.g. via reset config paths during
 deployment), then all subscriptions to that key are also deleted. Even if the
 key is re-created later, the previous subscriptions are gone and they will not
 be notified anymore. This is an undesirable situation for component writers to
@@ -255,14 +255,14 @@ no values were written to notify on.
 
 ### (Not) considering timestamps when deleting keys
 
-With GG Classic, if deployments that reset (delete) parts of the config are
-applied out of order, they can result in a different resulting config state, and
-deployment ordering behavior does not apply to configs which were deleted.
+With Greengrass nucleus, if deployments that reset (delete) parts of the config
+are applied out of order, they can result in a different resulting config state,
+and deployment ordering behavior does not apply to configs which were deleted.
 Config deletes are always applied at the time of deployment processing. This is
-because with GG classic, deleted keys do not have any state (notably a timestamp
-of a potential previous deletion) associated with them, and timestamps are not
-checked before resetting config keys. Lite replicates this, and also does not
-store any state about deleted keys currently.
+because with Greengrass nucleus, deleted keys do not have any state (notably a
+timestamp of a potential previous deletion) associated with them, and timestamps
+are not checked before resetting config keys. Greengrass nucleus lite replicates
+this, and also does not store any state about deleted keys currently.
 
 In the future it would be good to add in this deleted-key state with the
 associated timestamp, and check timestamps before deleting keys. This would

--- a/docs/design/ggdeploymentd-design.md
+++ b/docs/design/ggdeploymentd-design.md
@@ -1,11 +1,11 @@
-# GG-Lite `ggdeploymentd`: Initial Implementation Design
+# Greengrass nucleus lite `ggdeploymentd`: Initial Implementation Design
 
 ## Overview
 
-The GG-Lite deployment daemon (`ggdeploymentd`) is a service that is responsible
-for receiving and processing deployments. It should be able to receive
-deployments from all possible sources and execute the deployment tasks from a
-queue.
+The Greengrass nucleus lite deployment daemon (`ggdeploymentd`) is a service
+that is responsible for receiving and processing deployments. It should be able
+to receive deployments from all possible sources and execute the deployment
+tasks from a queue.
 
 As an initial goal toward complete deployment implementation, a subset of
 deployments is being considered for this document. The user story for this

--- a/docs/design/gghealthd-design.md
+++ b/docs/design/gghealthd-design.md
@@ -4,13 +4,13 @@ See [gghealthd spec](../spec/executable/gghealthd.md) for the public interface
 for gghealthd.
 
 gghealthd is intended to forward and serve component lifecycle state updates
-between gghealthd's clients and the Greengrass Lite core device's orchestrator.
-Communication with the orchestrator requires its own binary ABI or network
-protocol depending on the system. Therefore, gghealthd is an abstraction over a
-subset orchestration's API. In order to support state updates via Greengrass
-Classic IPC over ggipcd, gghealthd shall be implemented as a core component, a
-service, with permissions to update a component's orchestration state on its
-behalf.
+between gghealthd's clients and the Greengrass nucleus lite core device's
+orchestrator. Communication with the orchestrator requires its own binary ABI or
+network protocol depending on the system. Therefore, gghealthd is an abstraction
+over a subset orchestration's API. In order to support state updates via
+Greengrass nucleus IPC over ggipcd, gghealthd shall be implemented as a core
+component, a service, with permissions to update a component's orchestration
+state on its behalf.
 
 # Responsibilities
 

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -1,4 +1,4 @@
-# Greengrass Nucleus Lite Design Overview
+# Greengrass nucleus lite Design Overview
 
 Greengrass nucleus lite is a collection of small systemd-managed daemons that
 implement the AWS IoT Greengrass v2 runtime for resource-constrained Linux

--- a/docs/design/policy-validation.md
+++ b/docs/design/policy-validation.md
@@ -17,10 +17,11 @@ for the user-facing description):
   characters in the matched topic.
 
 Anything else inside a `${...}` escape is undefined; in particular, a bare `?`
-was previously accepted by Greengrass Lite and silently honored as a literal `?`
-character in the topic. AWS IoT Core does not allow `?` in topic names, so a
-policy or request topic containing `?` is effectively inert (it can never match
-a real cloud topic) and almost always indicates a mistake by the recipe author.
+was previously accepted by Greengrass nucleus lite and silently honored as a
+literal `?` character in the topic. AWS IoT Core does not allow `?` in topic
+names, so a policy or request topic containing `?` is effectively inert (it can
+never match a real cloud topic) and almost always indicates a mistake by the
+recipe author.
 
 This module rejects malformed resource strings up front, both at deployment time
 (in `ggdeploymentd`) and at IPC call time (in `ggipcd`).
@@ -30,14 +31,15 @@ This module rejects malformed resource strings up front, both at deployment time
 ### 1. Be stricter than Greengrass v2
 
 Greengrass V2 only logs and skips malformed `accessControl` policies; the
-deployment still succeeds. We chose to **fail** the deployment in Lite instead.
+deployment still succeeds. We chose to **fail** the deployment in Greengrass
+nucleus lite instead.
 
 The reasons it is acceptable to break parity here:
 
-- **Migration path is already manual.** Customers moving from v2 to Lite inspect
-  and adjust their component recipes anyway as part of migration, so a
-  deploy-time error pointing at the offending field is strictly more helpful
-  than the silent v2 behavior.
+- **Migration path is already manual.** Customers moving from Greengrass nucleus
+  to Greengrass nucleus lite inspect and adjust their component recipes anyway
+  as part of migration, so a deploy-time error pointing at the offending field
+  is strictly more helpful than the silent v2 behavior.
 
 ### 2. Fail the deployment, don't silently filter
 

--- a/docs/design/tes-http-serverd/tes-http-serverd.md
+++ b/docs/design/tes-http-serverd/tes-http-serverd.md
@@ -1,4 +1,4 @@
-# GG-Lite `tes-http-serverd`: Design
+# Greengrass nucleus lite `tes-http-serverd`: Design
 
 > note: The “`tes-http-serverd`“ design is a living document, and will
 > progressively change over time as we introduce new features or refactor old

--- a/docs/examples/supported_lifecyle_types/1.json
+++ b/docs/examples/supported_lifecyle_types/1.json
@@ -16,7 +16,7 @@
     {
       "Platform": {
         "os": "linux",
-        "runtime": "*", // Notice this is a required new field for GGLite
+        "runtime": "*", // Notice this is a required new field for Greengrass nucleus lite
         "architecture": "amd64"
       },
       "Lifecycle": {

--- a/docs/examples/supported_lifecyle_types/4.yaml
+++ b/docs/examples/supported_lifecyle_types/4.yaml
@@ -13,7 +13,7 @@ ComponentDependencies:
 Manifests:
   - Platform:
       os: "linux"
-      runtime: "*" # Notice this is a required new field for GGLite
+      runtime: "*" # Notice this is a required new field for Greengrass nucleus lite
     Lifecycle: {}
     Selections:
       - linux

--- a/docs/fleet_provisioning/fleet_provisioning.md
+++ b/docs/fleet_provisioning/fleet_provisioning.md
@@ -11,7 +11,7 @@ to learn how to create appropriate policies and claim certificates.
 
 Greengrass nucleus lite's fleet provisioning generates CSR and private keys
 locally and then sends the CSR to IoT Core to generate a certificate. This
-behavior is different from the default behavior of Greengrass classic's fleet
+behavior is different from the default behavior of Greengrass nucleus's fleet
 provisioning. Therefore, make sure your claim certificate has connect, publish,
 subscribe, and receive access to `CreateCertificateFromCsr` and `RegisterThing`
 topics mentioned in the

--- a/docs/spec/executable/ggconfigd.md
+++ b/docs/spec/executable/ggconfigd.md
@@ -67,7 +67,7 @@ error.
 
 ### Error Constants
 
-- ERRORS are part of the GGLITE Core Bus API Error handling.
+- ERRORS are part of the Greengrass nucleus lite Core Bus API Error handling.
 
 | Error Name     | Purpose                                                 |
 | -------------- | ------------------------------------------------------- |

--- a/docs/spec/executable/ggdeploymentd.md
+++ b/docs/spec/executable/ggdeploymentd.md
@@ -1,8 +1,9 @@
 # `ggdeploymentd` spec
 
-The GG-Lite deployment daemon (`ggdeploymentd`) is a service that is responsible
-for receiving and processing deployments. It should be able to receive
-deployments from multiple sources and maintain a queue of deployment tasks.
+The Greengrass nucleus lite deployment daemon (`ggdeploymentd`) is a service
+that is responsible for receiving and processing deployments. It should be able
+to receive deployments from multiple sources and maintain a queue of deployment
+tasks.
 
 The deployment daemon will need to receive deployments (can be from a local
 deployment, AWS IoT Shadow, or AWS IoT Jobs), placing them into a queue so that
@@ -44,8 +45,9 @@ deployment task processing:
   at the end of the deployment process.
 
 A deployment is considered cancellable anytime before the merge configuration
-step begins merging the configuration. The GG-Lite implementation may choose to
-change this to allow cancellation at any step (TBD).
+step begins merging the configuration. The Greengrass nucleus lite
+implementation may choose to change this to allow cancellation at any step
+(TBD).
 
 It is possible for a deployment to require a bootstrap. This means that Nucleus
 will need to restart during the deployment. In these deployments, the merge
@@ -254,7 +256,8 @@ device following a deployment.
 
 ## NucleusLite Bootstrap
 
-GG-Lite supports bootstrap deployments for the NucleusLite component.
+Greengrass nucleus lite supports bootstrap deployments for the NucleusLite
+component.
 
 - Upon receiving a deployment, all deployment info will be stored in the config
   database under services -> DeploymentService -> deploymentState

--- a/docs/spec/executable/gghealthd.md
+++ b/docs/spec/executable/gghealthd.md
@@ -117,7 +117,7 @@ then the device is unhealthy, else healthy.
 ### update_status
 
 Updates a component to a new lifecycle state, replicating this state update to
-the orchestrator. This API is intended to bridge the Greengrass Classic
+the orchestrator. This API is intended to bridge the Greengrass nucleus
 `UpdateState` API which is used for `start` generic component lifecycle steps
 which allow component-managed state transitions over IPC.
 

--- a/docs/spec/executable/teshttpserverd.md
+++ b/docs/spec/executable/teshttpserverd.md
@@ -38,7 +38,7 @@ The following is the current daemon implementation flow:
 - The URI in which the Token Exchange Service is hosted on. When a component
   creates an AWS SDK client, the client recognizes this URI environment variable
   and uses the token in the `AWS_CONTAINER_AUTHORIZATION_TOKEN` to connect to
-  the token exchange service and retrieve AWS credentials. Greengrass Nucleus
-  Lite will export this variable for example the AWS SDK to use.
+  the token exchange service and retrieve AWS credentials. Greengrass nucleus
+  lite will export this variable for example the AWS SDK to use.
 
 ## Core Bus API

--- a/docs/spec/library/gghttplib.md
+++ b/docs/spec/library/gghttplib.md
@@ -1,7 +1,8 @@
 # `gghttplib` spec
 
-The GG-Lite HTTP library (`gghttplib`) is a library that implements HTTP related
-functions that other lite components may need.
+The Greengrass nucleus lite HTTP library (`gghttplib`) is a library that
+implements HTTP related functions that other Greengrass nucleus lite components
+may need.
 
 The following components are expected to have some reliance or functionality
 that is contained within the gghttplib:

--- a/docs/spec/tls_helper.md
+++ b/docs/spec/tls_helper.md
@@ -1,8 +1,8 @@
-# Greengrass Lite TLS helper API
+# Greengrass nucleus lite TLS helper API
 
-AWS Greengrass Lite will allow TLS communication support to be pluggable through
-the TLS helper interface. This enables allow customers to plug in custom TLS
-setups, such as using TPM, PKCS#11, a different TLS library, etc.
+AWS Greengrass nucleus lite will allow TLS communication support to be pluggable
+through the TLS helper interface. This enables allow customers to plug in custom
+TLS setups, such as using TPM, PKCS#11, a different TLS library, etc.
 
 ## Requirements
 

--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -879,10 +879,10 @@ static GgError get_recipe_artifacts(
         }
 
         // Resolve artifact file permissions from recipe.
-        // Default is 0755 for backward compatibility with existing Nucleus
-        // Lite deployments. Note: Greengrass Nucleus defaults to Read:OWNER,
-        // Execute:NONE (0440). This difference is intentional to avoid
-        // regression.
+        // Default is 0755 for backward compatibility with existing Greengrass
+        // nucleus lite deployments. Note: Greengrass Nucleus defaults to
+        // Read:OWNER, Execute:NONE (0440). This difference is intentional to
+        // avoid regression.
         mode_t mode = 0755;
         if (permission_obj != NULL) {
             mode
@@ -1598,7 +1598,7 @@ static GgError resolve_dependencies(
             GgBuffer software_version = GG_STR(GGL_VERSION);
             if (!gg_buffer_eq(component_version, software_version)) {
                 GG_LOGE(
-                    "The deployment failed. The aws.greengrass.NucleusLite component version specified in the deployment is %.*s, but the version of the GG Lite software is %.*s. Please ensure that the version in the deployment matches before attempting the deployment again.",
+                    "The deployment failed. The aws.greengrass.NucleusLite component version specified in the deployment is %.*s, but the version of the Greengrass nucleus lite software is %.*s. Please ensure that the version in the deployment matches before attempting the deployment again.",
                     (int) component_version.len,
                     component_version.data,
                     (int) software_version.len,

--- a/modules/ggdeploymentd/src/iot_jobs_listener.c
+++ b/modules/ggdeploymentd/src/iot_jobs_listener.c
@@ -396,11 +396,11 @@ static GgError enqueue_job(
     }
 
     // A new deployment supersedes any status still pending for a previous one.
-    // greengrass lite tracks a single deployment at a time ($next), so reaching
-    // here with a new job_id means the prior deployment has finalized and any
-    // held status is stale -- drop it so we never re-publish a superseded job's
-    // status. status_keeper_clear() self-gates on the pending hint, so this is
-    // a no-op when nothing is pending.
+    // Greengrass nucleus lite tracks a single deployment at a time ($next), so
+    // reaching here with a new job_id means the prior deployment has finalized
+    // and any held status is stale -- drop it so we never re-publish a
+    // superseded job's status. status_keeper_clear() self-gates on the pending
+    // hint, so this is a no-op when nothing is pending.
     (void) status_keeper_clear();
 
     if (ret != GG_ERR_OK) {

--- a/modules/ggdeploymentd/src/status_keeper.h
+++ b/modules/ggdeploymentd/src/status_keeper.h
@@ -13,9 +13,9 @@
 //! is left stale. This module persists the pending status to ggconfigd so it
 //! can be re-sent once connectivity returns or after a restart.
 //!
-//! greengrass lite only tracks one deployment at a time ($next), so a single
-//! slot is stored at config `services/DeploymentService/pendingStatus` and
-//! replaced in place -- this is intentionally NOT a queue.
+//! Greengrass nucleus lite only tracks one deployment at a time ($next), so a
+//! single slot is stored at config `services/DeploymentService/pendingStatus`
+//! and replaced in place -- this is intentionally NOT a queue.
 //!
 //! Pure storage: this module persists / reads / clears the slot. Flush
 //! orchestration (deciding when to re-send) lives in iot_jobs_listener.c.

--- a/modules/ggipcd/bin/ggipcd.c
+++ b/modules/ggipcd/bin/ggipcd.c
@@ -7,7 +7,8 @@
 #include <ggipcd.h>
 #include <ggl/nucleus/init.h>
 
-static char doc[] = "ggipcd -- Greengrass IPC server for Nucleus Lite";
+static char doc[]
+    = "ggipcd -- Greengrass IPC server for Greengrass nucleus lite";
 
 static struct argp_option opts[] = {
     { "socket", 's', "path", 0, "GG IPC socket path", 0 },

--- a/modules/ggipcd/src/services/authorizationagent/token_validator.c
+++ b/modules/ggipcd/src/services/authorizationagent/token_validator.c
@@ -79,7 +79,7 @@ GgError ggl_handle_token_validation(
                 "Invalid token used by stream manager when trying to authorize."
             ) };
 
-        // Greengrass Classic returns an error to the caller instead of setting
+        // Greengrass nucleus returns an error to the caller instead of setting
         // the value to 'false'.
         // https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/b003cf0db575f546456bef69530126cf3e0b6a68/src/main/java/com/aws/greengrass/authorization/AuthorizationIPCAgent.java#L83
         return GG_ERR_FAILURE;

--- a/modules/ggipcd/unit/ggl.core.ggipcd.service.in
+++ b/modules/ggipcd/unit/ggl.core.ggipcd.service.in
@@ -18,5 +18,5 @@ Group=@GGL_SYSTEMD_SYSTEM_GROUP@
 WorkingDirectory=/var/lib/greengrass
 
 [Unit]
-Description=Proxy service between core-bus and GG Classic IPC
+Description=Proxy service between core-bus and Greengrass nucleus IPC
 After=ggl.core.ggconfigd.service

--- a/modules/ggl-cli/bin/ggl-cli.c
+++ b/modules/ggl-cli/bin/ggl-cli.c
@@ -37,7 +37,7 @@ int component_count = 0;
 static char *remove_components[MAX_LOCAL_DEPLOYMENT_COMPONENTS];
 int remove_count = 0;
 
-static char doc[] = "ggl-cli -- Greengrass CLI for Nucleus Lite";
+static char doc[] = "ggl-cli -- Greengrass CLI for Greengrass nucleus lite";
 
 static struct argp_option opts[] = {
     { "recipe-dir", 'r', "path", 0, "Recipe directory to merge", 0 },

--- a/modules/ggl-recipe/src/recipe.c
+++ b/modules/ggl-recipe/src/recipe.c
@@ -370,9 +370,9 @@ static GgError manifest_selection(
 
         GgMap platform = gg_obj_into_map(*platform_obj);
 
-        // The manifest is only valid for lite if runtime is explicitly
-        // aws_nucleus_lite or *. If the value isn't set then that manifest is
-        // classic-only.
+        // The manifest is only valid for Greengrass nucleus lite if runtime is
+        // explicitly aws_nucleus_lite or *. If the value isn't set then that
+        // manifest is Greengrass nucleus only.
         GgObject *runtime_obj = NULL;
         if (gg_map_get(platform, GG_STR("runtime"), &runtime_obj)) {
             if (gg_obj_type(*runtime_obj) != GG_TYPE_BUF) {
@@ -387,7 +387,8 @@ static GgError manifest_selection(
                 return GG_ERR_OK;
             }
         } else {
-            // If runtime field is not set, that explicitly means classic-only
+            // If runtime field is not set, that explicitly means Greengrass
+            // nucleus only
             GG_LOGD(
                 "Skipping manifest as it does not include a runtime platform field."
             );

--- a/modules/recipe2unit/src/parser.c
+++ b/modules/recipe2unit/src/parser.c
@@ -199,11 +199,11 @@ GgError convert_to_unit(
         && existing_phases->has_install == false
         && existing_phases->has_run_startup == false) {
         GG_LOGE(
-            "Recipes without at least 1 valid lifecycle step aren't currently supported by GGLite"
+            "Recipes without at least 1 valid lifecycle step aren't currently supported by Greengrass nucleus lite"
         );
 
         GG_LOGW(
-            "Note that in GG Lite, keys are case sensitive. Check the recipe reference for the correct casing."
+            "Note that in Greengrass nucleus lite, keys are case sensitive. Check the recipe reference for the correct casing."
         );
         return GG_ERR_INVALID;
     }

--- a/modules/recipe2unit/src/unit_file_generator.c
+++ b/modules/recipe2unit/src/unit_file_generator.c
@@ -453,10 +453,14 @@ static GgError update_unit_file_buffer(
 
 static void compatibility_check(GgMap selected_lifecycle_map) {
     if (gg_map_get(selected_lifecycle_map, GG_STR("shutdown"), NULL)) {
-        GG_LOGI("'shutdown' phase isn't currently supported by GGLite");
+        GG_LOGI(
+            "'shutdown' phase isn't currently supported by Greengrass nucleus lite"
+        );
     }
     if (gg_map_get(selected_lifecycle_map, GG_STR("recover"), NULL)) {
-        GG_LOGI("'recover' phase isn't currently supported by GGLite");
+        GG_LOGI(
+            "'recover' phase isn't currently supported by Greengrass nucleus lite"
+        );
     }
 }
 

--- a/modules/tes-serverd/bin/tes-serverd.c
+++ b/modules/tes-serverd/bin/tes-serverd.c
@@ -2,7 +2,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// tes-serverd -- A lightweight http server daemon for GGLite
+// tes-serverd -- A lightweight http server daemon for Greengrass nucleus lite
 
 #include <gg/error.h>
 #include <ggl/nucleus/init.h>


### PR DESCRIPTION
## Description

Standardize Greengrass product naming repo-wide to the canonical terms:
`Greengrass nucleus` (full nucleus), `Greengrass nucleus lite` (lite runtime),
and `Greengrass V2` (when referring to both). Replaces deprecated
`Greengrass Classic` / `Classic nucleus` and ad-hoc short forms (`GG Lite`,
`GG-Lite`, `GGLite`, `Nucleus Lite`). Identifiers, config tokens, and AWS
resource names are intentionally left unchanged.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] Code passes all the quality test. Can try `nix flake check -L` locally
- [x] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [x] Updated README.md if needed
- [x] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Naming/comment changes only; no functional changes. `nix fmt` runs clean.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
