### PR TITLE
Use time-sync.target for time sync dependency

### DIFF
--- a/modules/iotcored/unit/ggl.core.iotcored.service.in
+++ b/modules/iotcored/unit/ggl.core.iotcored.service.in
@@ -23,4 +23,4 @@ After=ggl.core.ggconfigd.service
 # Wait for network devices to be up
 After=network.target
 # Wait for NTP time
-After=systemd-time-wait-sync.service
+After=time-sync.target

--- a/modules/tesd/unit/ggl.core.tesd.service.in
+++ b/modules/tesd/unit/ggl.core.tesd.service.in
@@ -27,4 +27,4 @@ After=ggl.core.iotcored.service
 # Wait for network devices to be up
 After=network.target
 # Wait for NTP time
-After=systemd-time-wait-sync.service
+After=time-sync.target


### PR DESCRIPTION
This keeps waiting for time sync working with other providers of time-sync.target instead of depending on systemd-timesyncd.