### PR TITLE
feat(tes-serverd): Add BindsTo dependency on tesd for credential cascade

### DIFF
--- a/modules/tes-serverd/unit/ggl.aws.greengrass.TokenExchangeService.service.in
+++ b/modules/tes-serverd/unit/ggl.aws.greengrass.TokenExchangeService.service.in
@@ -3,6 +3,7 @@ StartLimitInterval=20
 StartLimitBurst=10
 Description=Sigv4 Gen component IoT credential provider
 PartOf=greengrass-lite.target
+BindsTo=ggl.core.tesd.service
 
 
 [Service]
@@ -24,4 +25,5 @@ WantedBy=greengrass-lite.target
 [Unit]
 After=ggl.core.ggconfigd.service
 After=ggl.core.iotcored.service
+After=ggl.core.tesd.service
 After=network.target


### PR DESCRIPTION
## Summary

Add `BindsTo=ggl.core.tesd.service` and `After=ggl.core.tesd.service` to tes-serverd's systemd unit file. This ensures that when tesd exits on credential configuration change (merged in #1103), tes-serverd stops and restarts, cascading to all components with a HARD dependency on `aws.greengrass.TokenExchangeService`. Components then reinitialize AWS SDK clients with fresh credentials from the new endpoint.

## Changes

1 file changed, 2 insertions:
- `BindsTo=ggl.core.tesd.service` — stops tes-serverd when tesd goes inactive
- `After=ggl.core.tesd.service` — ensures correct startup ordering on restart

## Cascade chain

```
ggconfigd (config write: iotCredEndpoint/iotRoleAlias change)
  → tesd subscription fires → tesd exits (_Exit(0))
    → systemd restarts tesd (Restart=always)
    → tes-serverd stops (BindsTo=ggl.core.tesd.service)  ← THIS PR
      → components stop (BindsTo=ggl.aws.greengrass.TokenExchangeService.service)
    → tes-serverd restarts (Restart=always, After=ggl.core.tesd.service)
      → components restart (Restart=on-failure)
        → AWS SDK reinitializes → fetches fresh credentials from new endpoint
```

## Testing

All endpoint switch integration tests pass with this change:

```
3 passed in 711.31s (0:11:51)
```

- ✅ `test_Deployment_20_T1` — Validation and pre-flight failures
- ✅ `test_Deployment_20_T2` — Happy path endpoint switch
- ✅ `test_Deployment_20_T3` — TES cascade credential refresh (from [aws-greengrass-testing#310](https://github.com/aws-greengrass/aws-greengrass-testing/pull/310))

T3 specifically verifies the cascade: deploys a component with HARD TES dependency, performs endpoint switch, and asserts the component gets destination credentials (`ggl-uat-role-dest` role ARN + destination region IoT endpoint) after the cascade restart.

