### PR TITLE
Adopt GG_LOG_TRAIL_SUBSPAN_SCOPE from gg-sdk

### DIFF
--- a/docs/design/log-trail.md
+++ b/docs/design/log-trail.md
@@ -60,11 +60,14 @@ clear, `gg_log_trail_root_begin`, and a scope-guard auto-clear.
 ## Propagation
 
 - **trace_id** is stable across all daemons handling one request.
-- **span_id** is fresh per daemon (generated on entry).
+- **span_id** changes when crossing a daemon boundary via core-bus, and can also
+  change within a single daemon when an explicit sub-span is opened (see
+  Sub-spans below).
 - **parent_span_id** is the caller's span_id, chaining causality.
 
-The span_id does not change within a single daemon; a new child span is created
-only when crossing a daemon boundary via core-bus.
+By default, the span_id does not change within a single daemon; a new child span
+is created only when crossing a daemon boundary via core-bus or when a call site
+explicitly opens a sub-span.
 
 Sender (core-bus client in `ggl_call`): `gg_log_trail_attach_headers` reads TLS
 and writes T/S/P into the outbound frame.
@@ -73,6 +76,30 @@ Receiver (core-bus server dispatch): `GG_LOG_TRAIL_INHERIT_SCOPE(headers)` fires
 a defensive clear, `gg_log_trail_extract_and_apply` (read T/S, generate fresh
 span, set TLS with parent = caller's span), then a scope-guard that auto-clears
 on scope exit.
+
+## Sub-spans
+
+Within a single daemon, `GG_LOG_TRAIL_SUBSPAN_SCOPE()` opens a child span inside
+the currently active trace. It preserves `trace_id`, generates a fresh
+`span_id`, and makes the caller's previous `span_id` the new `parent_span_id`.
+On scope exit, the caller's (trace_id, span_id, parent_span_id) is restored (not
+cleared) via a `cleanup` attribute, so any work following the sub-span continues
+under the original context.
+
+Sub-spans compose with cross-daemon propagation without special handling: if the
+sub-span makes a core-bus call, `gg_log_trail_attach_headers` serializes
+whatever is in TLS at that moment, so the receiving daemon sees the sub-span's
+`span_id` as its parent. This lets one daemon fan out to multiple downstream
+daemons under a single sub-span; every receiver correctly reports the same
+parent, forming a proper tree.
+
+The macro takes no arguments and uses `GG_MODULE` as the sub-span "kind" label,
+which is logged once at DEBUG when the sub-span opens. The random `span_id` plus
+the `file:line` in the log bracket disambiguate multiple sub-spans within one
+daemon; explicit per-call-site naming is not provided.
+
+When no trace is active on the calling thread, the macro is a no-op - it does
+not manufacture a `trace_id` and it does not log the subspan_start line.
 
 ## Mixed-Version Compatibility
 
@@ -96,6 +123,4 @@ excluding incidental hex matches in message bodies.
 
 ## Future Work
 
-- **Intra-daemon subspans** (`GG_TRACE_SUBSPAN()` macro) for finer-grained
-  filtering within a single daemon
 - CLI tree renderer for trace visualization.

--- a/docs/spec/library/log-trail.md
+++ b/docs/spec/library/log-trail.md
@@ -39,8 +39,9 @@ boundaries.
 - [tracing-macros-2] When ON, defines `GG_LOG_TRAIL_ENABLED` for gg-sdk
   translation units and enables all trace API and log bracket formatting.
 - [tracing-macros-3] When OFF, `GG_LOG_TRAIL_SCOPE_GUARD`,
-  `GG_LOG_TRAIL_ROOT_SCOPE`, and `GG_LOG_TRAIL_INHERIT_SCOPE` expand to empty
-  statements. No trace symbols appear in the resulting binary.
+  `GG_LOG_TRAIL_ROOT_SCOPE`, `GG_LOG_TRAIL_INHERIT_SCOPE`, and
+  `GG_LOG_TRAIL_SUBSPAN_SCOPE` expand to empty statements. No trace symbols
+  appear in the resulting binary.
 
 ## Environment Variables
 
@@ -78,6 +79,13 @@ boundaries.
   Generates a fresh span_id, sets TLS to (T, fresh_span, S). Returns true if
   trace context was found and applied; false if no T header present (TLS
   unchanged).
+- [tracing-api-7a]
+  `GgLogTrailState gg_log_trail_subspan_begin(const char *kind)` - reads current
+  TLS into `GgLogTrailState`; if trace_id is 0 returns the zero snapshot without
+  side effects. Otherwise generates a fresh non-zero span_id, sets TLS to
+  (unchanged trace_id, fresh_span, caller's previous span_id), emits one DEBUG
+  `subspan_start: <kind>` log line, and returns the caller's saved state so the
+  scope-cleanup can restore it.
 
 ### Scope Macros (priv_include/gg/log-trail.h)
 
@@ -89,5 +97,12 @@ boundaries.
 - [tracing-api-10] `GG_LOG_TRAIL_INHERIT_SCOPE(headers)` - defensive clear +
   `gg_log_trail_extract_and_apply(headers)` + `GG_LOG_TRAIL_SCOPE_GUARD()`.
   Self-gates: expands to nothing when `GG_LOG_TRAIL_ENABLED` is not defined.
+- [tracing-api-10a] `GG_LOG_TRAIL_SUBSPAN_SCOPE()` - calls
+  `gg_log_trail_subspan_begin(GG_MODULE)` and declares a variable with
+  `__attribute__((cleanup))` that restores the caller's saved (trace_id,
+  span_id, parent_span_id) on scope exit. Preserves trace_id, generates a fresh
+  span_id, and sets caller's previous span_id as the new parent_span_id. No-op
+  if no trace is active. Self-gates: expands to nothing when
+  `GG_LOG_TRAIL_ENABLED` is not defined.
 - [tracing-api-11] Scope macros declare local variables and must appear inside a
   brace block. Mirrors the `GG_MTX_SCOPE_GUARD` idiom.

--- a/fc_deps.json
+++ b/fc_deps.json
@@ -11,8 +11,8 @@
   },
   "gg_sdk": {
     "url": "https://github.com/aws-greengrass/aws-greengrass-component-sdk.git",
-    "rev": "4b7f8fa356ae5fbd6b751a0dee6796616e1cdde0",
-    "hash": "sha256-caiuWkYkLcXsV7Ha7XUzWK0nd86fnCNou37/62G79ds="
+    "rev": "5a87617191729c26c646a56f9ed391f505513cf8",
+    "hash": "sha256-vt4MywGRRyfjzQpW2Jonq/ipeV/FR/oTCpcYYY4BGF4="
   },
   "unity": {
     "url": "https://github.com/ThrowTheSwitch/Unity.git",


### PR DESCRIPTION

## Description

Document the new macro GG_LOG_TRAIL_SUBSPAN_SCOPE

## Related Issue

Fixes #(issue number) or N/A if not applicable

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [x] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [x] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
