### PR TITLE
Policy config interpolation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,10 @@ function(ggl_init_module name)
     target_compile_definitions(${name} PRIVATE "GG_MODULE=(\"${name}\")")
     target_include_directories(${name} PUBLIC ${COMP_ARG_INCDIRS})
     target_link_libraries(${name} PRIVATE ${COMP_ARG_LIBS})
+
+    if(BUILD_TESTING AND NOT COMP_ARG_NO_INLINE_TEST)
+      set_target_properties(${name} PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
+    endif()
   endif()
 
   if(GGL_SYSTEMD_SERVICE_BUILD)

--- a/fc_deps.json
+++ b/fc_deps.json
@@ -11,8 +11,8 @@
   },
   "gg_sdk": {
     "url": "https://github.com/aws-greengrass/aws-greengrass-component-sdk.git",
-    "rev": "5a87617191729c26c646a56f9ed391f505513cf8",
-    "hash": "sha256-vt4MywGRRyfjzQpW2Jonq/ipeV/FR/oTCpcYYY4BGF4="
+    "rev": "4ead4862fefcf96047700d1a7819b0dfa65209e4",
+    "hash": "sha256-3Yylv+GimggRXmssQ9cmbAZX9XDUPN6QM4gj1cbS7cU="
   },
   "unity": {
     "url": "https://github.com/ThrowTheSwitch/Unity.git",

--- a/modules/ggipcd/CMakeLists.txt
+++ b/modules/ggipcd/CMakeLists.txt
@@ -14,4 +14,6 @@ ggl_init_module(
        core-bus-aws-iot-mqtt
        core-bus-gghealthd
        ggipc-auth
-       ggl-socket-server)
+       ggl-socket-server
+       ggl-config-interpolation
+       ggl-json)

--- a/modules/ggipcd/src/ipc_authz.c
+++ b/modules/ggipcd/src/ipc_authz.c
@@ -5,25 +5,152 @@
 #include "ipc_authz.h"
 #include "ipc_service.h"
 #include <assert.h>
+#include <config_reader.h>
 #include <gg/arena.h>
 #include <gg/buffer.h>
 #include <gg/error.h>
 #include <gg/flags.h>
+#include <gg/io.h>
 #include <gg/list.h>
 #include <gg/log.h>
 #include <gg/map.h>
 #include <gg/object.h>
+#include <gg/vector.h>
 #include <ggl/core_bus/gg_config.h>
+#include <ggl/json_pointer.h>
 #include <ggl/policy_validation.h>
-#include <string.h>
+#include <interpolation.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+
+static GgError core_bus_config_reader_impl(
+    void *ctx, GgBuffer json_ptr, GgObjectReceiver writer
+) {
+    GgArena *alloc = ctx;
+
+    GgBuffer key_path_mem[GG_MAX_OBJECT_DEPTH];
+    GgBufVec key_path = GG_BUF_VEC(key_path_mem);
+
+    GgError ret = ggl_gg_config_jsonp_parse(json_ptr, &key_path);
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("Failed to parse json pointer key.");
+        return ret;
+    }
+
+    GgObject result;
+    ret = ggl_gg_config_read(key_path.buf_list, alloc, &result);
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("Failed to read config from core bus.");
+        return ret;
+    }
+
+    return gg_object_receiver_submit(writer, result);
+}
+
+static GgConfigReader core_bus_config_receiver(GgArena *alloc) {
+    return (GgConfigReader) { .ctx = alloc,
+                              .reader = core_bus_config_reader_impl };
+}
+
+/// Maximum length of an interpolated policy resource string.
+#define MAX_INTERPOLATED_RESOURCE_LEN 2048
+
+/// Check if a buffer contains any {...} recipe variable sequences.
+/// Skips ${...} escape sequences (those are handled by the matcher).
+static bool has_recipe_variables(GgBuffer buf) {
+    for (size_t i = 0; i < buf.len; i++) {
+        if (buf.data[i] == (uint8_t) '{') {
+            if ((i > 0) && (buf.data[i - 1] == (uint8_t) '$')) {
+                continue;
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
+/// Interpolate {...} recipe variable sequences in a policy resource string.
+/// Writes the interpolated result into vec.
+/// ${...} escape sequences are passed through literally (not interpolated
+/// here; the matcher handles those separately).
+/// Returns GG_ERR_OK on success.
+static GgError interpolate_policy_resource(
+    GgBuffer policy_resource,
+    GgBuffer component_name,
+    GgBuffer root_path,
+    GgBuffer component_version,
+    GgBuffer thing_name,
+    GgByteVec *vec
+) {
+    GgWriter writer = gg_byte_vec_writer(vec);
+    size_t i = 0;
+
+    while (i < policy_resource.len) {
+        if (policy_resource.data[i] == (uint8_t) '{') {
+            // ${...} is an escape sequence, not a recipe variable.
+            // Pass the '$' and '{' through literally.
+            if ((i > 0) && (policy_resource.data[i - 1] == (uint8_t) '$')) {
+                GgError ret = gg_byte_vec_push(vec, policy_resource.data[i]);
+                if (ret != GG_ERR_OK) {
+                    return ret;
+                }
+                i++;
+                continue;
+            }
+
+            // Found start of recipe variable, find the closing '}'
+            size_t start = i + 1;
+            size_t end = start;
+            while (end < policy_resource.len
+                   && policy_resource.data[end] != (uint8_t) '}') {
+                end++;
+            }
+            if (end >= policy_resource.len) {
+                GG_LOGE("Unterminated recipe variable in policy resource.");
+                return GG_ERR_INVALID;
+            }
+
+            GgBuffer escape_seq = gg_buffer_substr(policy_resource, start, end);
+
+            static uint8_t config_mem[MAX_INTERPOLATED_RESOURCE_LEN];
+            GgArena alloc = gg_arena_init(GG_BUF(config_mem));
+
+            GgError ret = ggl_substitute_escape(
+                writer,
+                escape_seq,
+                root_path,
+                component_name,
+                component_version,
+                thing_name,
+                core_bus_config_receiver(&alloc)
+            );
+            if (ret != GG_ERR_OK) {
+                return ret;
+            }
+
+            i = end + 1; // Skip past '}'
+        } else {
+            GgError ret = gg_byte_vec_push(vec, policy_resource.data[i]);
+            if (ret != GG_ERR_OK) {
+                return ret;
+            }
+            i++;
+        }
+    }
+
+    return GG_ERR_OK;
+}
 
 static GgError policy_match(
     GgMap policy,
     GgBuffer operation,
     GgBuffer resource,
-    GglIpcPolicyResourceMatcher *matcher
+    GglIpcPolicyResourceMatcher *matcher,
+    GgBuffer component_name,
+    GgBuffer root_path,
+    GgBuffer component_version,
+    GgBuffer thing_name
 ) {
     GgObject *operations_obj;
     GgObject *resources_obj;
@@ -59,9 +186,40 @@ static GgError policy_match(
             GG_LIST_FOREACH (policy_resource_obj, policy_resources) {
                 GgBuffer policy_resource
                     = gg_obj_into_buf(*policy_resource_obj);
-                if (gg_buffer_eq(GG_STR("*"), policy_resource)
-                    || matcher(resource, policy_resource)) {
+
+                if (gg_buffer_eq(GG_STR("*"), policy_resource)) {
                     return GG_ERR_OK;
+                }
+
+                // If the policy resource contains recipe variables,
+                // interpolate them before matching.
+                if (has_recipe_variables(policy_resource)) {
+                    static uint8_t
+                        interpolated_mem[MAX_INTERPOLATED_RESOURCE_LEN];
+                    GgByteVec vec = GG_BYTE_VEC(interpolated_mem);
+
+                    ret = interpolate_policy_resource(
+                        policy_resource,
+                        component_name,
+                        root_path,
+                        component_version,
+                        thing_name,
+                        &vec
+                    );
+                    if (ret != GG_ERR_OK) {
+                        GG_LOGW(
+                            "Failed to interpolate policy resource, skipping."
+                        );
+                        continue;
+                    }
+
+                    if (matcher(resource, vec.buf)) {
+                        return GG_ERR_OK;
+                    }
+                } else {
+                    if (matcher(resource, policy_resource)) {
+                        return GG_ERR_OK;
+                    }
                 }
             }
             return GG_ERR_FAILURE;
@@ -114,6 +272,34 @@ GgError ggl_ipc_auth(
         return GG_ERR_CONFIG;
     }
 
+    // Read system config values needed for recipe variable interpolation.
+    static uint8_t root_path_mem[256];
+    GgArena root_path_alloc = gg_arena_init(GG_BUF(root_path_mem));
+    GgBuffer root_path = { 0 };
+    (void) ggl_gg_config_read_str(
+        GG_BUF_LIST(GG_STR("system"), GG_STR("rootPath")),
+        &root_path_alloc,
+        &root_path
+    );
+
+    static uint8_t thing_name_mem[128];
+    GgArena thing_name_alloc = gg_arena_init(GG_BUF(thing_name_mem));
+    GgBuffer thing_name = { 0 };
+    (void) ggl_gg_config_read_str(
+        GG_BUF_LIST(GG_STR("system"), GG_STR("thingName")),
+        &thing_name_alloc,
+        &thing_name
+    );
+
+    static uint8_t version_mem[64];
+    GgArena version_alloc = gg_arena_init(GG_BUF(version_mem));
+    GgBuffer component_version = { 0 };
+    (void) ggl_gg_config_read_str(
+        GG_BUF_LIST(GG_STR("services"), info->component, GG_STR("version")),
+        &version_alloc,
+        &component_version
+    );
+
     GgMap policy_map = gg_obj_into_map(policies);
 
     GG_MAP_FOREACH (policy_kv, policy_map) {
@@ -124,7 +310,14 @@ GgError ggl_ipc_auth(
         }
 
         ret = policy_match(
-            gg_obj_into_map(policy), info->operation, resource, matcher
+            gg_obj_into_map(policy),
+            info->operation,
+            resource,
+            matcher,
+            info->component,
+            root_path,
+            component_version,
+            thing_name
         );
         if (ret == GG_ERR_OK) {
             return GG_ERR_OK;

--- a/modules/ggl-config-interpolation/CMakeLists.txt
+++ b/modules/ggl-config-interpolation/CMakeLists.txt
@@ -2,8 +2,4 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ggl_init_module(
-  recipe-runner
-  NO_INLINE_TEST
-  LIBS gg-sdk ggl-constants ggl-common ggl-json ggl-recipe
-       ggl-config-interpolation)
+ggl_init_module(ggl-config-interpolation LIBS gg-sdk ggl-json)

--- a/modules/ggl-config-interpolation/include/config_reader.h
+++ b/modules/ggl-config-interpolation/include/config_reader.h
@@ -1,0 +1,32 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GGL_CONFIG_READER_H
+#define GGL_CONFIG_READER_H
+
+#include <gg/error.h>
+#include <gg/io.h>
+#include <gg/types.h>
+#include <stddef.h>
+
+/// Abstract config reader
+/// Retrieves the config value of a key and submits it to a receiver
+typedef struct {
+    GgError (*reader)(void *ctx, GgBuffer key, GgObjectReceiver receiver);
+    void *ctx;
+} GgConfigReader;
+
+static inline GgError ggl_config_reader_call(
+    GgConfigReader reader, GgBuffer key, GgObjectReceiver receiver
+) {
+    if (reader.reader == NULL) {
+        return GG_ERR_INVALID;
+    }
+    return reader.reader(reader.ctx, key, receiver);
+}
+
+// Reader that no config values can be read from.
+#define GGL_CONFIG_NULL_READER (GgConfigReader) { 0 }
+
+#endif

--- a/modules/ggl-config-interpolation/include/interpolation.h
+++ b/modules/ggl-config-interpolation/include/interpolation.h
@@ -1,0 +1,35 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GGL_CONFIG_INTERPOLATION_H
+#define GGL_CONFIG_INTERPOLATION_H
+
+#include <config_reader.h>
+#include <gg/error.h>
+#include <gg/io.h>
+#include <gg/types.h>
+
+/// Writes the value of a Greengrass component recipe variable
+/// "<namespace>:<key>" into a GgWriter.
+///
+/// Although recipes uses curly braces {} to denote an escape sequence,
+/// braces must be stripped before calling this function.
+///
+/// For configuration variables i.e. "configuration:<json_ptr>" a config
+/// reader callback is required. Pass GGL_CONFIG_NULL_READER to return an error
+/// if config lookup is not desired.
+///
+/// An error is returned if the escape sequence does not contain a colon or the
+/// namespace-key pair is not recognized.
+GgError ggl_substitute_escape(
+    GgWriter writer,
+    GgBuffer recipe_variable,
+    GgBuffer root_path,
+    GgBuffer component_name,
+    GgBuffer component_version,
+    GgBuffer thing_name,
+    GgConfigReader config_reader
+);
+
+#endif

--- a/modules/ggl-config-interpolation/src/interpolation.c
+++ b/modules/ggl-config-interpolation/src/interpolation.c
@@ -1,0 +1,287 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "interpolation.h"
+#include "gg/json_encode.h"
+#include <config_reader.h>
+#include <gg/attr.h>
+#include <gg/buffer.h>
+#include <gg/error.h>
+#include <gg/io.h>
+#include <gg/log.h>
+#include <gg/object.h>
+#include <gg/types.h>
+#include <stddef.h>
+#include <stdint.h>
+
+NONNULL(1)
+static void ggl_writer_call_chained(
+    GgError *err, GgWriter writer, GgBuffer buf
+) {
+    if (*err == GG_ERR_OK) {
+        *err = gg_writer_call(writer, buf);
+    }
+}
+
+static GgError split_recipe_variable(
+    GgBuffer recipe_variable, GgBuffer *namespace, GgBuffer *key
+) {
+    for (size_t i = 0; i < recipe_variable.len; i++) {
+        if (recipe_variable.data[i] == ':') {
+            *namespace = gg_buffer_substr(recipe_variable, 0, i);
+            *key = gg_buffer_substr(recipe_variable, i + 1, SIZE_MAX);
+            return GG_ERR_OK;
+        }
+    }
+
+    GG_LOGE("No : found in recipe variable.");
+    return GG_ERR_FAILURE;
+}
+
+static GgError write_object_as_buffer(void *ctx, GgObject object) {
+    GgWriter *writer = ctx;
+    if (gg_obj_type(object) == GG_TYPE_BUF) {
+        return gg_writer_call(*writer, gg_obj_into_buf(object));
+    }
+
+    return gg_json_encode(object, *writer);
+}
+
+GgError ggl_substitute_escape(
+    GgWriter writer,
+    GgBuffer recipe_variable,
+    GgBuffer root_path,
+    GgBuffer component_name,
+    GgBuffer component_version,
+    GgBuffer thing_name,
+    GgConfigReader config_reader
+) {
+    GgBuffer namespace;
+    GgBuffer key;
+    GgError ret = split_recipe_variable(recipe_variable, &namespace, &key);
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+
+    GG_LOGT(
+        "Current variable substitution: %.*s. type = %.*s; arg = %.*s",
+        (int) recipe_variable.len,
+        recipe_variable.data,
+        (int) namespace.len,
+        namespace.data,
+        (int) key.len,
+        key.data
+    );
+
+    if (gg_buffer_eq(namespace, GG_STR("kernel"))) {
+        if (gg_buffer_eq(key, GG_STR("rootPath"))) {
+            return gg_writer_call(writer, root_path);
+        }
+    } else if (gg_buffer_eq(namespace, GG_STR("iot"))) {
+        if (gg_buffer_eq(key, GG_STR("thingName"))) {
+            return gg_writer_call(writer, thing_name);
+        }
+    } else if (gg_buffer_eq(namespace, GG_STR("work"))) {
+        if (gg_buffer_eq(key, GG_STR("path"))) {
+            ggl_writer_call_chained(&ret, writer, root_path);
+            ggl_writer_call_chained(&ret, writer, GG_STR("/work/"));
+            ggl_writer_call_chained(&ret, writer, component_name);
+            ggl_writer_call_chained(&ret, writer, GG_STR("/"));
+            return ret;
+        }
+    } else if (gg_buffer_eq(namespace, GG_STR("artifacts"))) {
+        if (gg_buffer_eq(key, GG_STR("path"))) {
+            ggl_writer_call_chained(&ret, writer, root_path);
+            ggl_writer_call_chained(&ret, writer, GG_STR("/packages/"));
+            ggl_writer_call_chained(&ret, writer, GG_STR("artifacts/"));
+            ggl_writer_call_chained(&ret, writer, component_name);
+            ggl_writer_call_chained(&ret, writer, GG_STR("/"));
+            ggl_writer_call_chained(&ret, writer, component_version);
+            ggl_writer_call_chained(&ret, writer, GG_STR("/"));
+            return ret;
+        }
+        if (gg_buffer_eq(key, GG_STR("decompressedPath"))) {
+            ggl_writer_call_chained(&ret, writer, root_path);
+            ggl_writer_call_chained(&ret, writer, GG_STR("/packages/"));
+            ggl_writer_call_chained(
+                &ret, writer, GG_STR("artifacts-unarchived/")
+            );
+            ggl_writer_call_chained(&ret, writer, component_name);
+            ggl_writer_call_chained(&ret, writer, GG_STR("/"));
+            ggl_writer_call_chained(&ret, writer, component_version);
+            ggl_writer_call_chained(&ret, writer, GG_STR("/"));
+            return ret;
+        }
+    } else if (gg_buffer_eq(namespace, GG_STR("configuration"))) {
+        GgObjectReceiver object_writer
+            = { .ctx = &writer, .submit = write_object_as_buffer };
+        return ggl_config_reader_call(config_reader, key, object_writer);
+    }
+
+    GG_LOGE(
+        "Unhandled variable substitution: %.*s.",
+        (int) recipe_variable.len,
+        recipe_variable.data
+    );
+    return GG_ERR_FAILURE;
+}
+
+#ifdef GG_SDK_TESTING
+
+#include <gg/test.h>
+#include <gg/vector.h>
+#include <unity.h>
+
+#define TEST_ROOT_PATH GG_STR("/greengrass/v2")
+#define TEST_COMPONENT GG_STR("com.example.MyComponent")
+#define TEST_VERSION GG_STR("1.2.3")
+#define TEST_THING_NAME GG_STR("MyThingName")
+
+static GgError dummy_config_reader_call(
+    void *ctx, GgBuffer key, GgObjectReceiver receiver
+) {
+    (void) ctx;
+    (void) key;
+    return gg_object_receiver_submit(
+        receiver, gg_obj_buf(GG_STR("dummy_config_value"))
+    );
+}
+
+static GgConfigReader dummy_config_reader(void) {
+    return (GgConfigReader) { .reader = dummy_config_reader_call };
+}
+
+static GgBuffer run_substitute(GgBuffer escape_seq) {
+    static uint8_t buf[512];
+    GgByteVec vec = GG_BYTE_VEC(buf);
+    GgError ret = ggl_substitute_escape(
+        gg_byte_vec_writer(&vec),
+        escape_seq,
+        TEST_ROOT_PATH,
+        TEST_COMPONENT,
+        TEST_VERSION,
+        TEST_THING_NAME,
+        dummy_config_reader()
+    );
+    TEST_ASSERT_EQUAL_INT(GG_ERR_OK, ret);
+    return vec.buf;
+}
+
+GG_TEST_DEFINE(substitute_kernel_root_path) {
+    GgBuffer result = run_substitute(GG_STR("kernel:rootPath"));
+    GG_TEST_ASSERT_BUF_EQUAL(GG_STR("/greengrass/v2"), result);
+}
+
+GG_TEST_DEFINE(substitute_iot_thing_name) {
+    GgBuffer result = run_substitute(GG_STR("iot:thingName"));
+    GG_TEST_ASSERT_BUF_EQUAL(GG_STR("MyThingName"), result);
+}
+
+GG_TEST_DEFINE(substitute_work_path) {
+    GgBuffer result = run_substitute(GG_STR("work:path"));
+    GG_TEST_ASSERT_BUF_EQUAL(
+        GG_STR("/greengrass/v2/work/com.example.MyComponent/"), result
+    );
+}
+
+GG_TEST_DEFINE(substitute_artifacts_path) {
+    GgBuffer result = run_substitute(GG_STR("artifacts:path"));
+    GG_TEST_ASSERT_BUF_EQUAL(
+        GG_STR(
+            "/greengrass/v2/packages/artifacts/com.example.MyComponent/1.2.3/"
+        ),
+        result
+    );
+}
+
+GG_TEST_DEFINE(substitute_artifacts_decompressed_path) {
+    GgBuffer result = run_substitute(GG_STR("artifacts:decompressedPath"));
+    GG_TEST_ASSERT_BUF_EQUAL(
+        GG_STR("/greengrass/v2/packages/artifacts-unarchived/"
+               "com.example.MyComponent/1.2.3/"),
+        result
+    );
+}
+
+GG_TEST_DEFINE(substitute_configuration_uses_reader) {
+    GgBuffer result = run_substitute(GG_STR("configuration:/some/key"));
+    GG_TEST_ASSERT_BUF_EQUAL(GG_STR("dummy_config_value"), result);
+}
+
+GG_TEST_DEFINE(substitute_configuration_null_reader_fails) {
+    static uint8_t buf[64];
+    GgByteVec vec = GG_BYTE_VEC(buf);
+    GgError ret = ggl_substitute_escape(
+        gg_byte_vec_writer(&vec),
+        GG_STR("configuration:/key"),
+        TEST_ROOT_PATH,
+        TEST_COMPONENT,
+        TEST_VERSION,
+        TEST_THING_NAME,
+        GGL_CONFIG_NULL_READER
+    );
+    TEST_ASSERT_NOT_EQUAL(GG_ERR_OK, ret);
+}
+
+GG_TEST_DEFINE(substitute_no_colon_fails) {
+    static uint8_t buf[64];
+    GgByteVec vec = GG_BYTE_VEC(buf);
+    GgError ret = ggl_substitute_escape(
+        gg_byte_vec_writer(&vec),
+        GG_STR("invalid"),
+        TEST_ROOT_PATH,
+        TEST_COMPONENT,
+        TEST_VERSION,
+        TEST_THING_NAME,
+        dummy_config_reader()
+    );
+    TEST_ASSERT_NOT_EQUAL(GG_ERR_OK, ret);
+}
+
+GG_TEST_DEFINE(substitute_unknown_type_fails) {
+    static uint8_t buf[64];
+    GgByteVec vec = GG_BYTE_VEC(buf);
+    GgError ret = ggl_substitute_escape(
+        gg_byte_vec_writer(&vec),
+        GG_STR("unknown:something"),
+        TEST_ROOT_PATH,
+        TEST_COMPONENT,
+        TEST_VERSION,
+        TEST_THING_NAME,
+        dummy_config_reader()
+    );
+    TEST_ASSERT_NOT_EQUAL(GG_ERR_OK, ret);
+}
+
+GG_TEST_DEFINE(substitute_kernel_unknown_arg_fails) {
+    static uint8_t buf[64];
+    GgByteVec vec = GG_BYTE_VEC(buf);
+    GgError ret = ggl_substitute_escape(
+        gg_byte_vec_writer(&vec),
+        GG_STR("kernel:unknown"),
+        TEST_ROOT_PATH,
+        TEST_COMPONENT,
+        TEST_VERSION,
+        TEST_THING_NAME,
+        dummy_config_reader()
+    );
+    TEST_ASSERT_NOT_EQUAL(GG_ERR_OK, ret);
+}
+
+GG_TEST_DEFINE(substitute_iot_unknown_arg_fails) {
+    static uint8_t buf[64];
+    GgByteVec vec = GG_BYTE_VEC(buf);
+    GgError ret = ggl_substitute_escape(
+        gg_byte_vec_writer(&vec),
+        GG_STR("iot:unknown"),
+        TEST_ROOT_PATH,
+        TEST_COMPONENT,
+        TEST_VERSION,
+        TEST_THING_NAME,
+        dummy_config_reader()
+    );
+    TEST_ASSERT_NOT_EQUAL(GG_ERR_OK, ret);
+}
+
+#endif

--- a/modules/recipe-runner/src/runner.c
+++ b/modules/recipe-runner/src/runner.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "runner.h"
+#include <config_reader.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <gg/arena.h>
@@ -12,11 +13,11 @@
 #include <gg/eventstream/types.h>
 #include <gg/file.h>
 #include <gg/flags.h>
+#include <gg/io.h>
 #include <gg/ipc/client.h>
 #include <gg/ipc/client_priv.h>
 #include <gg/ipc/client_raw.h>
 #include <gg/ipc/limits.h>
-#include <gg/json_encode.h>
 #include <gg/log.h>
 #include <gg/map.h>
 #include <gg/object.h>
@@ -25,6 +26,7 @@
 #include <ggl/json_pointer.h>
 #include <ggl/nucleus/constants.h>
 #include <ggl/recipe.h>
+#include <interpolation.h>
 #include <limits.h>
 #include <recipe-runner.h>
 #include <string.h>
@@ -34,11 +36,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-
-#define MAX_SCRIPT_LENGTH 10000
-#define MAX_THING_NAME_LEN 128
-
-pid_t child_pid = -1; // To store child process ID
 
 static GgError write_escaped_char(int out_fd, uint8_t c, bool single_quote) {
     if (single_quote) {
@@ -69,10 +66,29 @@ static GgError write_escaped_value(
     return GG_ERR_OK;
 }
 
-static GgError insert_config_value(
-    int out_fd, GgBuffer json_ptr, bool single_quote
+typedef struct {
+    int fd;
+    bool single_quote;
+} FdEscapedWriterCtx;
+
+static GgError fd_escaped_writer_impl(void *ctx, GgBuffer buf) {
+    FdEscapedWriterCtx *context = ctx;
+    if ((context == NULL) || (context->fd < 0)) {
+        return GG_ERR_INVALID;
+    }
+
+    return write_escaped_value(context->fd, buf, context->single_quote);
+}
+
+static GgWriter fd_escaped_writer(FdEscapedWriterCtx *context) {
+    return (GgWriter) { .ctx = context, .write = fd_escaped_writer_impl };
+}
+
+static GgError ipc_config_receiver_impl(
+    void *ctx, GgBuffer json_ptr, GgObjectReceiver receiver
 ) {
-    static GgBuffer key_path_mem[GG_MAX_OBJECT_DEPTH];
+    (void) ctx;
+    GgBuffer key_path_mem[GG_MAX_OBJECT_DEPTH];
     GgBufVec key_path = GG_BUF_VEC(key_path_mem);
 
     GgError ret = ggl_gg_config_jsonp_parse(json_ptr, &key_path);
@@ -81,166 +97,17 @@ static GgError insert_config_value(
         return ret;
     }
 
-    static uint8_t config_value[10000];
-    static uint8_t copy_config_value[10000];
-    GgObject result = { 0 };
-    ret = ggipc_get_config(
-        key_path.buf_list, NULL, GG_BUF(config_value), &result
-    );
-    if (ret != GG_ERR_OK) {
-        GG_LOGE("Failed to get config value for substitution.");
-        return ret;
-    }
-    GgBuffer final_result = GG_BUF(copy_config_value);
-
-    if (gg_obj_type(result) != GG_TYPE_BUF) {
-        GgByteVec vec = gg_byte_vec_init(final_result);
-        ret = gg_json_encode(result, gg_byte_vec_writer(&vec));
-        if (ret != GG_ERR_OK) {
-            GG_LOGE("Failed to encode result as JSON.");
-            return ret;
-        }
-        final_result = vec.buf;
-    } else {
-        final_result = gg_obj_into_buf(result);
-    }
-
-    return write_escaped_value(out_fd, final_result, single_quote);
+    return ggipc_get_config_receive(key_path.buf_list, NULL, receiver);
 }
 
-static GgError split_escape_seq(
-    GgBuffer escape_seq, GgBuffer *left, GgBuffer *right
-) {
-    for (size_t i = 0; i < escape_seq.len; i++) {
-        if (escape_seq.data[i] == ':') {
-            *left = gg_buffer_substr(escape_seq, 0, i);
-            *right = gg_buffer_substr(escape_seq, i + 1, SIZE_MAX);
-            return GG_ERR_OK;
-        }
-    }
-
-    GG_LOGE("No : found in recipe escape sequence.");
-    return GG_ERR_FAILURE;
+static GgConfigReader ipc_config_receiver(void) {
+    return (GgConfigReader) { .reader = ipc_config_receiver_impl };
 }
 
-// TODO: Simplify this code
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
-static GgError substitute_escape(
-    int out_fd,
-    GgBuffer escape_seq,
-    GgBuffer root_path,
-    GgBuffer component_name,
-    GgBuffer component_version,
-    GgBuffer thing_name,
-    bool single_quote
-) {
-    GgBuffer type;
-    GgBuffer arg;
-    GgError ret = split_escape_seq(escape_seq, &type, &arg);
-    if (ret != GG_ERR_OK) {
-        return ret;
-    }
+#define MAX_SCRIPT_LENGTH 10000
+#define MAX_THING_NAME_LEN 128
 
-    GG_LOGT(
-        "Current variable substitution: %.*s. type = %.*s; arg = %.*s",
-        (int) escape_seq.len,
-        escape_seq.data,
-        (int) type.len,
-        type.data,
-        (int) arg.len,
-        arg.data
-    );
-
-    if (gg_buffer_eq(type, GG_STR("kernel"))) {
-        if (gg_buffer_eq(arg, GG_STR("rootPath"))) {
-            return gg_file_write(out_fd, root_path);
-        }
-    } else if (gg_buffer_eq(type, GG_STR("iot"))) {
-        if (gg_buffer_eq(arg, GG_STR("thingName"))) {
-            return gg_file_write(out_fd, thing_name);
-        }
-    } else if (gg_buffer_eq(type, GG_STR("work"))) {
-        if (gg_buffer_eq(arg, GG_STR("path"))) {
-            ret = gg_file_write(out_fd, root_path);
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            ret = gg_file_write(out_fd, GG_STR("/work/"));
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            ret = gg_file_write(out_fd, component_name);
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            return gg_file_write(out_fd, GG_STR("/"));
-        }
-    } else if (gg_buffer_eq(type, GG_STR("artifacts"))) {
-        if (gg_buffer_eq(arg, GG_STR("path"))) {
-            ret = gg_file_write(out_fd, root_path);
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            ret = gg_file_write(out_fd, GG_STR("/packages/"));
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            ret = gg_file_write(out_fd, GG_STR("artifacts/"));
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            ret = gg_file_write(out_fd, component_name);
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            ret = gg_file_write(out_fd, GG_STR("/"));
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            ret = gg_file_write(out_fd, component_version);
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            return gg_file_write(out_fd, GG_STR("/"));
-        }
-        if (gg_buffer_eq(arg, GG_STR("decompressedPath"))) {
-            ret = gg_file_write(out_fd, root_path);
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            ret = gg_file_write(out_fd, GG_STR("/packages/"));
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            ret = gg_file_write(out_fd, GG_STR("artifacts-unarchived/"));
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            ret = gg_file_write(out_fd, component_name);
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            ret = gg_file_write(out_fd, GG_STR("/"));
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            ret = gg_file_write(out_fd, component_version);
-            if (ret != GG_ERR_OK) {
-                return ret;
-            }
-            return gg_file_write(out_fd, GG_STR("/"));
-        }
-    } else if (gg_buffer_eq(type, GG_STR("configuration"))) {
-        return insert_config_value(out_fd, arg, single_quote);
-    }
-
-    GG_LOGE(
-        "Unhandled variable substitution: %.*s.",
-        (int) escape_seq.len,
-        escape_seq.data
-    );
-    return GG_ERR_FAILURE;
-}
+pid_t child_pid = -1; // To store child process ID
 
 static GgError handle_escape(
     int out_fd,
@@ -269,14 +136,15 @@ static GgError handle_escape(
             (*current_pointer)++;
         } else {
             (*current_pointer)++;
-            return substitute_escape(
-                out_fd,
+            return ggl_substitute_escape(
+                fd_escaped_writer(&(FdEscapedWriterCtx
+                ) { .fd = out_fd, .single_quote = single_quote }),
                 vec.buf,
                 root_path,
                 component_name,
                 component_version,
                 thing_name,
-                single_quote
+                ipc_config_receiver()
             );
         }
     }


### PR DESCRIPTION
## Description

* Move recipe-runner's variable interpolation logic into its own module
* remove 40KB of buffers from recipe-runner
* ggipc authz uses variable interpolation inside policies (handles {...} escaping as well as existing ${...} escaping)
* Disable compile command generation for library targets when inline testing targets are built.


## Related Issue

#1063

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [x] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
