### PR TITLE
Forward Nucleus config IPC lookups to NucleusLite

### DIFF
--- a/docs/spec/executable/ggconfigd.md
+++ b/docs/spec/executable/ggconfigd.md
@@ -82,6 +82,13 @@ error.
 
 See [the supported IPC commands in the README](../../../README.md).
 
+For classic-Nucleus compatibility, component configuration requests
+(`GetConfiguration` and `SubscribeToConfigurationUpdate`) that target
+`aws.greengrass.Nucleus` are transparently forwarded to the
+`aws.greengrass.NucleusLite` configuration tree, and events/responses are
+reported under the requested `aws.greengrass.Nucleus` name. See
+[the GetConfiguration IPC command](../library/ipc_commands/getconfiguration_ipc.md).
+
 ## Implementation
 
 See [the ggconfigd design](../../design/ggconfigd.md).

--- a/docs/spec/executable/ggconfigd.md
+++ b/docs/spec/executable/ggconfigd.md
@@ -82,17 +82,21 @@ error.
 
 See [the supported IPC commands in the README](../../../README.md).
 
-At the IPC boundary, `GetConfiguration` and `SubscribeToConfigurationUpdate`
-requests that target `aws.greengrass.Nucleus` use the
-`aws.greengrass.NucleusLite` configuration tree. Responses and events retain the
-requested `aws.greengrass.Nucleus` name. This aliases only the component name:
-Greengrass Lite returns its stored configuration schema and does not translate
-or synthesize Classic nucleus keys. Deployment `configurationUpdate` entries are
-outside this IPC alias and must name `aws.greengrass.NucleusLite` to update the
-Greengrass Lite nucleus configuration. See the
-[GetConfiguration](../library/ipc_commands/getconfiguration_ipc.md) and
-[SubscribeToConfigurationUpdate](../library/ipc_commands/subscribetoconfigurationupdate_ipc.md)
-IPC commands.
+- [ggconfigd-ipc-alias-1] At the IPC boundary, `GetConfiguration` and
+  `SubscribeToConfigurationUpdate` requests that target `aws.greengrass.Nucleus`
+  use the `aws.greengrass.NucleusLite` configuration tree. Responses and events
+  retain the requested `aws.greengrass.Nucleus` name.
+- [ggconfigd-ipc-alias-2] The alias is exact and one-way, and changes only the
+  component name used for storage. Greengrass Lite returns its stored
+  configuration schema and does not translate or synthesize Classic nucleus
+  keys.
+- [ggconfigd-ipc-alias-3] The alias does not apply to `UpdateConfiguration`,
+  which remains scoped to the calling component, or to deployment configuration
+  updates, which use component names verbatim.
+
+See the [GetConfiguration](../library/ipc_commands/getconfiguration_ipc.md),
+[SubscribeToConfigurationUpdate](../library/ipc_commands/subscribetoconfigurationupdate_ipc.md),
+and [deployment](ggdeploymentd.md) specifications.
 
 ## Implementation
 

--- a/docs/spec/executable/ggconfigd.md
+++ b/docs/spec/executable/ggconfigd.md
@@ -82,12 +82,17 @@ error.
 
 See [the supported IPC commands in the README](../../../README.md).
 
-For classic-Nucleus compatibility, component configuration requests
-(`GetConfiguration` and `SubscribeToConfigurationUpdate`) that target
-`aws.greengrass.Nucleus` are transparently forwarded to the
-`aws.greengrass.NucleusLite` configuration tree, and events/responses are
-reported under the requested `aws.greengrass.Nucleus` name. See
-[the GetConfiguration IPC command](../library/ipc_commands/getconfiguration_ipc.md).
+At the IPC boundary, `GetConfiguration` and `SubscribeToConfigurationUpdate`
+requests that target `aws.greengrass.Nucleus` use the
+`aws.greengrass.NucleusLite` configuration tree. Responses and events retain the
+requested `aws.greengrass.Nucleus` name. This aliases only the component name:
+Greengrass Lite returns its stored configuration schema and does not translate
+or synthesize Classic nucleus keys. Deployment `configurationUpdate` entries are
+outside this IPC alias and must name `aws.greengrass.NucleusLite` to update the
+Greengrass Lite nucleus configuration. See the
+[GetConfiguration](../library/ipc_commands/getconfiguration_ipc.md) and
+[SubscribeToConfigurationUpdate](../library/ipc_commands/subscribetoconfigurationupdate_ipc.md)
+IPC commands.
 
 ## Implementation
 

--- a/docs/spec/executable/ggdeploymentd.md
+++ b/docs/spec/executable/ggdeploymentd.md
@@ -94,6 +94,10 @@ the following requirements.
      configuration.
    - [ggdeploymentd-3.2] The deployment service may handle configuration updates
      and merge/reset configuration from a deployment document.
+     - [ggdeploymentd-3.2.1] Component names associated with
+       `configurationUpdate` entries are used verbatim. To update the Greengrass
+       Lite nucleus configuration, a deployment must target
+       `aws.greengrass.NucleusLite`; `aws.greengrass.Nucleus` is not redirected.
    - [ggdeploymentd-3.3] The deployment service rejects deployments whose
      `accessControl` policy resources are malformed. See the public docs for
      [IPC authorization policies](https://docs.aws.amazon.com/greengrass/v2/developerguide/interprocess-communication.html#ipc-authorization-policies)
@@ -221,6 +225,10 @@ deployment and can specify deployment parameters.
     buffer (configuration updates to be made).
     - [ggdeploymentd-bus-createlocaldeployment-5.2] Configuration update values
       must be in valid JSON format.
+  - [ggdeploymentd-bus-createlocaldeployment-5.3] Component-name keys are used
+    verbatim. A local deployment must use `aws.greengrass.NucleusLite`, not
+    `aws.greengrass.Nucleus`, to update the Greengrass Lite nucleus
+    configuration.
 - [ggdeploymentd-bus-createlocaldeployment-6] group_name is an optional
   parameter of type buffer.
   - [ggdeploymentd-bus-createlocaldeployment-6.1] When provided, the deployment

--- a/docs/spec/library/ipc_commands/getconfiguration_ipc.md
+++ b/docs/spec/library/ipc_commands/getconfiguration_ipc.md
@@ -9,6 +9,12 @@ at the nucleus level using the `gg_config` core-bus interface.
 - [get-config-3] It does not require access control policy in recipe to work.
 - [get-config-4] It cannot retrieve any values under the `system` section of
   nucleus config.
+- [get-config-5] A request with `componentName` `aws.greengrass.Nucleus` is
+  served from the `aws.greengrass.NucleusLite` configuration tree (a
+  classic-compatibility alias), and the response echoes the requested
+  `componentName`. This lets components read nucleus configuration using a
+  single, nucleus-agnostic name on both the Greengrass nucleus and Greengrass
+  Lite. The same alias applies to `SubscribeToConfigurationUpdate`.
 
 ## Parameters
 
@@ -122,6 +128,18 @@ Case 6: Get Configuration key path does not exist.
   `{"componentName": "com.example.ConfigUpdater", "keyPath": ["randomKey"]}`
 - Response:
   `{"message":"Key not found","_service":"aws.greengrass#GreengrassCoreIPC","_message":"Key not found","_errorCode":"ResourceNotFoundError"}`
+
+Case 7: Get Configuration forwarded from the classic Nucleus name
+
+Nucleus configuration on Greengrass Lite is stored under
+`aws.greengrass.NucleusLite`. A request using the classic
+`aws.greengrass.Nucleus` name is served from the `aws.greengrass.NucleusLite`
+tree, and the response echoes the requested name.
+
+- Request:
+  `{"componentName": "aws.greengrass.Nucleus", "keyPath": ["iotDataEndpoint"]}`
+- Response:
+  `{"componentName":"aws.greengrass.Nucleus","value":{"iotDataEndpoint":"example-ats.iot.us-east-1.amazonaws.com"}}`
 
 ### RAW on wire:
 

--- a/docs/spec/library/ipc_commands/getconfiguration_ipc.md
+++ b/docs/spec/library/ipc_commands/getconfiguration_ipc.md
@@ -11,10 +11,15 @@ at the nucleus level using the `gg_config` core-bus interface.
   nucleus config.
 - [get-config-5] A request with `componentName` `aws.greengrass.Nucleus` is
   served from the `aws.greengrass.NucleusLite` configuration tree (a
-  classic-compatibility alias), and the response echoes the requested
-  `componentName`. This lets components read nucleus configuration using a
-  single, nucleus-agnostic name on both the Greengrass nucleus and Greengrass
-  Lite. The same alias applies to `SubscribeToConfigurationUpdate`.
+  component-name alias), and the response echoes the requested `componentName`.
+  The same alias applies to
+  [`SubscribeToConfigurationUpdate`](subscribetoconfigurationupdate_ipc.md).
+  - [get-config-5.1] The alias does not translate configuration schemas or
+    synthesize Classic nucleus keys. The response contains the configuration
+    available in the `aws.greengrass.NucleusLite` tree.
+  - [get-config-5.2] A requested key that is not present in the
+    `aws.greengrass.NucleusLite` tree returns `ResourceNotFoundError`, including
+    keys that exist only in the Classic nucleus schema.
 
 ## Parameters
 
@@ -134,7 +139,9 @@ Case 7: Get Configuration forwarded from the classic Nucleus name
 Nucleus configuration on Greengrass Lite is stored under
 `aws.greengrass.NucleusLite`. A request using the classic
 `aws.greengrass.Nucleus` name is served from the `aws.greengrass.NucleusLite`
-tree, and the response echoes the requested name.
+tree, and the response echoes the requested name. This example uses a key
+available in both schemas; the name alias does not make other Classic nucleus
+keys available on Greengrass Lite.
 
 - Request:
   `{"componentName": "aws.greengrass.Nucleus", "keyPath": ["iotDataEndpoint"]}`

--- a/docs/spec/library/ipc_commands/subscribetoconfigurationupdate_ipc.md
+++ b/docs/spec/library/ipc_commands/subscribetoconfigurationupdate_ipc.md
@@ -1,0 +1,54 @@
+# `SubscribeToConfigurationUpdate` IPC command
+
+The `SubscribeToConfigurationUpdate` IPC command subscribes to changes in a
+component's configuration through the `gg_config` core-bus interface.
+
+- [subscribe-config-1] It is invoked with the topic
+  `SubscribeToConfigurationUpdate`.
+- [subscribe-config-2] It subscribes to the requested key and its descendants.
+- [subscribe-config-3] A request with `componentName` `aws.greengrass.Nucleus`
+  subscribes to the `aws.greengrass.NucleusLite` configuration tree. Events
+  retain the requested `aws.greengrass.Nucleus` component name.
+  - [subscribe-config-3.1] The alias changes only the component name. It does
+    not translate configuration schemas or synthesize Classic nucleus keys.
+  - [subscribe-config-3.2] A requested key that is not present in the
+    `aws.greengrass.NucleusLite` tree returns `ResourceNotFoundError`, including
+    keys that exist only in the Classic nucleus schema.
+
+## Parameters
+
+- [subscribe-config-params-1] `componentName` is an optional string.
+  - [subscribe-config-params-1.1] If omitted, the calling component's name is
+    used.
+- [subscribe-config-params-2] `keyPath` is an optional list of strings.
+  - [subscribe-config-params-2.1] Each string identifies one level in the
+    configuration hierarchy.
+  - [subscribe-config-params-2.2] If omitted or empty, the subscription covers
+    the component's entire configuration.
+
+## Response and events
+
+- [subscribe-config-resp-1] On success, the initial response is empty.
+- [subscribe-config-resp-2] Each configuration change produces a
+  `ConfigurationUpdateEvents` message containing a `configurationUpdateEvent`
+  map.
+  - [subscribe-config-resp-2.1] `componentName` identifies the requested
+    component.
+  - [subscribe-config-resp-2.2] `keyPath` identifies the changed configuration
+    path.
+- [subscribe-config-resp-3] On failure, `ResourceNotFoundError` is returned when
+  the requested path does not exist. Other subscription failures return
+  `ServiceError`.
+
+## Example
+
+Nucleus configuration on Greengrass Lite is stored under
+`aws.greengrass.NucleusLite`. The following subscription uses the Classic
+nucleus component name for a key that is available in the Greengrass Lite
+schema:
+
+- Request:
+  `{"componentName":"aws.greengrass.Nucleus","keyPath":["iotDataEndpoint"]}`
+- Initial response: `{}`
+- Update event:
+  `{"configurationUpdateEvent":{"componentName":"aws.greengrass.Nucleus","keyPath":["iotDataEndpoint"]}}`

--- a/docs/spec/library/ipc_commands/subscribetoconfigurationupdate_ipc.md
+++ b/docs/spec/library/ipc_commands/subscribetoconfigurationupdate_ipc.md
@@ -29,13 +29,19 @@ component's configuration through the `gg_config` core-bus interface.
 ## Response and events
 
 - [subscribe-config-resp-1] On success, the initial response is empty.
-- [subscribe-config-resp-2] Each configuration change produces a
-  `ConfigurationUpdateEvents` message containing a `configurationUpdateEvent`
-  map.
+- [subscribe-config-resp-2] Each notification delivered by the `gg_config`
+  subscription produces a `ConfigurationUpdateEvents` message containing a
+  `configurationUpdateEvent` map.
   - [subscribe-config-resp-2.1] `componentName` identifies the requested
     component.
-  - [subscribe-config-resp-2.2] `keyPath` identifies the changed configuration
-    path.
+  - [subscribe-config-resp-2.2] `keyPath` contains the path reported by the
+    `gg_config` notification.
+  - [subscribe-config-resp-2.3] Notification generation and subscription
+    lifetime follow the
+    [`gg_config` interface](../../core-bus-interface/gg_config.md). A write that
+    emits no core-bus notification emits no IPC event. Deleting a key removes
+    affected underlying subscriptions without an update event, while restoring a
+    backup can notify a subscription even if its value did not change.
 - [subscribe-config-resp-3] On failure, `ResourceNotFoundError` is returned when
   the requested path does not exist. Other subscription failures return
   `ServiceError`.

--- a/modules/ggipcd/src/ipc_subscriptions.c
+++ b/modules/ggipcd/src/ipc_subscriptions.c
@@ -22,28 +22,50 @@
 
 static_assert(
     GGL_IPC_MAX_SUBSCRIPTIONS <= GGL_COREBUS_CLIENT_MAX_SUBSCRIPTIONS,
-    "IPC max subscriptions exceededs core bus max subscriptions."
+    "IPC subscription maximum exceeds core bus maximum."
 );
 
-static uint32_t subs_resp_handle[GGL_IPC_MAX_SUBSCRIPTIONS];
-static int32_t subs_stream_id[GGL_IPC_MAX_SUBSCRIPTIONS];
-static uint32_t subs_recv_handle[GGL_IPC_MAX_SUBSCRIPTIONS];
-static void *subs_ctx[GGL_IPC_MAX_SUBSCRIPTIONS];
+typedef struct {
+    uint32_t resp_handle;
+    int32_t stream_id;
+    uint32_t recv_handle;
+    GglIpcSubscribeCallback on_response;
+    void *ctx;
+    bool binding;
+    bool close_requested;
+    bool core_closed;
+} IpcSubscriptionSlot;
+
+static IpcSubscriptionSlot subscriptions[GGL_IPC_MAX_SUBSCRIPTIONS];
 static pthread_mutex_t subs_state_mtx = PTHREAD_MUTEX_INITIALIZER;
 
-static GgError init_subs_index(
-    uint32_t resp_handle, int32_t stream_id, void *ctx, size_t *index
+static void reset_sub_slot(IpcSubscriptionSlot *slot) {
+    *slot = (IpcSubscriptionSlot) { 0 };
+}
+
+static GgError reserve_sub_slot(
+    uint32_t resp_handle,
+    int32_t stream_id,
+    GglIpcSubscribeCallback on_response,
+    void *ctx,
+    IpcSubscriptionSlot **result
 ) {
     assert(resp_handle != 0);
+    assert(on_response != NULL);
 
     GG_MTX_SCOPE_GUARD(&subs_state_mtx);
 
     for (size_t i = 0; i < GGL_IPC_MAX_SUBSCRIPTIONS; i++) {
-        if (subs_resp_handle[i] == 0) {
-            subs_resp_handle[i] = resp_handle;
-            subs_stream_id[i] = stream_id;
-            subs_ctx[i] = ctx;
-            *index = i;
+        IpcSubscriptionSlot *slot = &subscriptions[i];
+        if (slot->resp_handle == 0) {
+            *slot = (IpcSubscriptionSlot) {
+                .resp_handle = resp_handle,
+                .stream_id = stream_id,
+                .on_response = on_response,
+                .ctx = ctx,
+                .binding = true,
+            };
+            *result = slot;
             return GG_ERR_OK;
         }
     }
@@ -52,63 +74,47 @@ static GgError init_subs_index(
     return GG_ERR_NOMEM;
 }
 
-static void release_subs_index(size_t index, uint32_t resp_handle) {
+static void release_binding_slot(IpcSubscriptionSlot *slot) {
     GG_MTX_SCOPE_GUARD(&subs_state_mtx);
 
-    if (subs_resp_handle[index] == resp_handle) {
-        subs_resp_handle[index] = 0;
-        subs_stream_id[index] = 0;
-        subs_recv_handle[index] = 0;
-        subs_ctx[index] = NULL;
-    } else {
-        GG_LOGD("Releasing subscription state failed; already released.");
-    }
-}
-
-static GgError subs_set_recv_handle(
-    size_t index, uint32_t resp_handle, uint32_t recv_handle
-) {
-    assert(resp_handle != 0);
-    assert(recv_handle != 0);
-
-    GG_MTX_SCOPE_GUARD(&subs_state_mtx);
-
-    if (subs_resp_handle[index] == resp_handle) {
-        subs_recv_handle[index] = recv_handle;
-        return GG_ERR_OK;
-    }
-
-    GG_LOGD("Setting subscription recv handle failed; state already released.");
-    return GG_ERR_FAILURE;
+    assert(slot->binding);
+    reset_sub_slot(slot);
 }
 
 static GgError subscription_on_response(
     void *ctx, uint32_t recv_handle, GgObject data
 ) {
-    // coverity[bad_initializer_type]
-    GglIpcSubscribeCallback on_response = ctx;
+    IpcSubscriptionSlot *slot = ctx;
 
     uint32_t resp_handle = 0;
     int32_t stream_id = -1;
+    GglIpcSubscribeCallback on_response = NULL;
     void *user_ctx = NULL;
-    bool found = false;
 
     {
         GG_MTX_SCOPE_GUARD(&subs_state_mtx);
-        for (size_t i = 0; i < GGL_IPC_MAX_SUBSCRIPTIONS; i++) {
-            if (recv_handle == subs_recv_handle[i]) {
-                found = true;
-                resp_handle = subs_resp_handle[i];
-                stream_id = subs_stream_id[i];
-                user_ctx = subs_ctx[i];
-                break;
-            }
-        }
-    }
 
-    if (!found) {
-        GG_LOGD("Received response on released subscription.");
-        return GG_ERR_FAILURE;
+        if (slot->resp_handle == 0) {
+            GG_LOGD("Received response on released subscription.");
+            return GG_ERR_FAILURE;
+        }
+
+        if (slot->recv_handle == 0) {
+            slot->recv_handle = recv_handle;
+        } else if (slot->recv_handle != recv_handle) {
+            GG_LOGE("Unexpected subscription response handle.");
+            return GG_ERR_FAILURE;
+        }
+
+        if (slot->close_requested || slot->core_closed) {
+            GG_LOGD("Received response while subscription is closing.");
+            return GG_ERR_FAILURE;
+        }
+
+        resp_handle = slot->resp_handle;
+        stream_id = slot->stream_id;
+        on_response = slot->on_response;
+        user_ctx = slot->ctx;
     }
 
     static uint8_t resp_mem
@@ -119,20 +125,37 @@ static GgError subscription_on_response(
 }
 
 static void subscription_on_close(void *ctx, uint32_t recv_handle) {
-    (void) ctx;
+    IpcSubscriptionSlot *slot = ctx;
+
     GG_MTX_SCOPE_GUARD(&subs_state_mtx);
 
-    for (size_t i = 0; i < GGL_COREBUS_CLIENT_MAX_SUBSCRIPTIONS; i++) {
-        if (recv_handle == subs_recv_handle[i]) {
-            subs_resp_handle[i] = 0;
-            subs_stream_id[i] = 0;
-            subs_recv_handle[i] = 0;
-            subs_ctx[i] = NULL;
-            return;
-        }
+    if (slot->resp_handle == 0) {
+        GG_LOGD("Already released subscription closed.");
+        return;
     }
 
-    GG_LOGD("Already released subscription closed.");
+    if ((slot->recv_handle != 0) && (slot->recv_handle != recv_handle)) {
+        GG_LOGE("Closed an unexpected subscription handle.");
+        // No further close will arrive for this slot; release it rather than
+        // leak it permanently. Mirrors the normal close path below, without
+        // adopting the mismatched handle.
+        slot->close_requested = true;
+        slot->core_closed = true;
+        if (!slot->binding) {
+            reset_sub_slot(slot);
+        }
+        return;
+    }
+
+    slot->recv_handle = recv_handle;
+    slot->close_requested = true;
+    slot->core_closed = true;
+
+    // ggl_subscribe may invoke this callback before returning the handle. Keep
+    // the slot reserved until the binding call no longer holds its pointer.
+    if (!slot->binding) {
+        reset_sub_slot(slot);
+    }
 }
 
 GgError ggl_ipc_bind_subscription(
@@ -145,8 +168,9 @@ GgError ggl_ipc_bind_subscription(
     void *ctx,
     GgError *error
 ) {
-    size_t subs_index = 0;
-    GgError ret = init_subs_index(resp_handle, stream_id, ctx, &subs_index);
+    IpcSubscriptionSlot *slot = NULL;
+    GgError ret
+        = reserve_sub_slot(resp_handle, stream_id, on_response, ctx, &slot);
     if (ret != GG_ERR_OK) {
         return ret;
     }
@@ -158,29 +182,53 @@ GgError ggl_ipc_bind_subscription(
         params,
         subscription_on_response,
         subscription_on_close,
-        on_response,
+        slot,
         error,
         &recv_handle
     );
     if (ret != GG_ERR_OK) {
-        release_subs_index(subs_index, resp_handle);
+        release_binding_slot(slot);
         return ret;
     }
 
-    (void) subs_set_recv_handle(subs_index, resp_handle, recv_handle);
+    bool close_requested = false;
+    bool core_closed = false;
+    {
+        GG_MTX_SCOPE_GUARD(&subs_state_mtx);
+
+        assert(slot->binding);
+        assert((slot->recv_handle == 0) || (slot->recv_handle == recv_handle));
+
+        slot->recv_handle = recv_handle;
+        slot->binding = false;
+        close_requested = slot->close_requested;
+        core_closed = slot->core_closed;
+
+        if (core_closed) {
+            reset_sub_slot(slot);
+        }
+    }
+
+    if (close_requested && !core_closed) {
+        ggl_client_sub_close(recv_handle);
+    }
 
     return GG_ERR_OK;
 }
 
 GgError ggl_ipc_release_subscriptions_for_conn(uint32_t resp_handle) {
-    for (size_t i = 0; i < GGL_COREBUS_CLIENT_MAX_SUBSCRIPTIONS; i++) {
+    for (size_t i = 0; i < GGL_IPC_MAX_SUBSCRIPTIONS; i++) {
         uint32_t recv_handle = 0;
 
         {
             GG_MTX_SCOPE_GUARD(&subs_state_mtx);
 
-            if (subs_resp_handle[i] == resp_handle) {
-                recv_handle = subs_recv_handle[i];
+            IpcSubscriptionSlot *slot = &subscriptions[i];
+            if (slot->resp_handle == resp_handle) {
+                slot->close_requested = true;
+                if (!slot->core_closed) {
+                    recv_handle = slot->recv_handle;
+                }
             }
         }
 
@@ -193,15 +241,19 @@ GgError ggl_ipc_release_subscriptions_for_conn(uint32_t resp_handle) {
 }
 
 void ggl_ipc_terminate_stream(uint32_t resp_handle, int32_t stream_id) {
-    for (size_t i = 0; i < GGL_COREBUS_CLIENT_MAX_SUBSCRIPTIONS; i++) {
+    for (size_t i = 0; i < GGL_IPC_MAX_SUBSCRIPTIONS; i++) {
         uint32_t recv_handle = 0;
 
         {
             GG_MTX_SCOPE_GUARD(&subs_state_mtx);
 
-            if ((subs_resp_handle[i] == resp_handle)
-                && (subs_stream_id[i] == stream_id)) {
-                recv_handle = subs_recv_handle[i];
+            IpcSubscriptionSlot *slot = &subscriptions[i];
+            if ((slot->resp_handle == resp_handle)
+                && (slot->stream_id == stream_id)) {
+                slot->close_requested = true;
+                if (!slot->core_closed) {
+                    recv_handle = slot->recv_handle;
+                }
             }
         }
 

--- a/modules/ggipcd/src/ipc_subscriptions.c
+++ b/modules/ggipcd/src/ipc_subscriptions.c
@@ -28,10 +28,11 @@ static_assert(
 static uint32_t subs_resp_handle[GGL_IPC_MAX_SUBSCRIPTIONS];
 static int32_t subs_stream_id[GGL_IPC_MAX_SUBSCRIPTIONS];
 static uint32_t subs_recv_handle[GGL_IPC_MAX_SUBSCRIPTIONS];
+static void *subs_ctx[GGL_IPC_MAX_SUBSCRIPTIONS];
 static pthread_mutex_t subs_state_mtx = PTHREAD_MUTEX_INITIALIZER;
 
 static GgError init_subs_index(
-    uint32_t resp_handle, int32_t stream_id, size_t *index
+    uint32_t resp_handle, int32_t stream_id, void *ctx, size_t *index
 ) {
     assert(resp_handle != 0);
 
@@ -41,6 +42,7 @@ static GgError init_subs_index(
         if (subs_resp_handle[i] == 0) {
             subs_resp_handle[i] = resp_handle;
             subs_stream_id[i] = stream_id;
+            subs_ctx[i] = ctx;
             *index = i;
             return GG_ERR_OK;
         }
@@ -57,6 +59,7 @@ static void release_subs_index(size_t index, uint32_t resp_handle) {
         subs_resp_handle[index] = 0;
         subs_stream_id[index] = 0;
         subs_recv_handle[index] = 0;
+        subs_ctx[index] = NULL;
     } else {
         GG_LOGD("Releasing subscription state failed; already released.");
     }
@@ -87,6 +90,7 @@ static GgError subscription_on_response(
 
     uint32_t resp_handle = 0;
     int32_t stream_id = -1;
+    void *user_ctx = NULL;
     bool found = false;
 
     {
@@ -96,6 +100,7 @@ static GgError subscription_on_response(
                 found = true;
                 resp_handle = subs_resp_handle[i];
                 stream_id = subs_stream_id[i];
+                user_ctx = subs_ctx[i];
                 break;
             }
         }
@@ -110,7 +115,7 @@ static GgError subscription_on_response(
         [sizeof(GgObject[GG_MAX_OBJECT_SUBOBJECTS]) + GGL_IPC_MAX_MSG_LEN];
     GgArena alloc = gg_arena_init(GG_BUF(resp_mem));
 
-    return on_response(data, resp_handle, stream_id, &alloc);
+    return on_response(user_ctx, data, resp_handle, stream_id, &alloc);
 }
 
 static void subscription_on_close(void *ctx, uint32_t recv_handle) {
@@ -122,6 +127,7 @@ static void subscription_on_close(void *ctx, uint32_t recv_handle) {
             subs_resp_handle[i] = 0;
             subs_stream_id[i] = 0;
             subs_recv_handle[i] = 0;
+            subs_ctx[i] = NULL;
             return;
         }
     }
@@ -136,10 +142,11 @@ GgError ggl_ipc_bind_subscription(
     GgBuffer method,
     GgMap params,
     GglIpcSubscribeCallback on_response,
+    void *ctx,
     GgError *error
 ) {
     size_t subs_index = 0;
-    GgError ret = init_subs_index(resp_handle, stream_id, &subs_index);
+    GgError ret = init_subs_index(resp_handle, stream_id, ctx, &subs_index);
     if (ret != GG_ERR_OK) {
         return ret;
     }

--- a/modules/ggipcd/src/ipc_subscriptions.h
+++ b/modules/ggipcd/src/ipc_subscriptions.h
@@ -21,8 +21,11 @@ typedef GgError (*GglIpcSubscribeCallback)(
     GgArena *arena
 );
 
-/// Wrapper around ggl_subscribe for IPC handlers. `ctx` is an optional
-/// per-subscription context passed to `on_response` on each event.
+/// Wrapper around ggl_subscribe for IPC handlers.
+///
+/// `ctx` is an optional per-subscription context passed to `on_response` on
+/// each event. Caller-owned context must remain valid until the subscription is
+/// closed.
 GgError ggl_ipc_bind_subscription(
     uint32_t resp_handle,
     int32_t stream_id,

--- a/modules/ggipcd/src/ipc_subscriptions.h
+++ b/modules/ggipcd/src/ipc_subscriptions.h
@@ -10,12 +10,19 @@
 #include <gg/types.h>
 #include <stdint.h>
 
-/// Callback for whenever a subscription is closed.
+/// Callback for whenever a subscription event is received.
+/// `ctx` is the per-subscription context provided to
+/// `ggl_ipc_bind_subscription`.
 typedef GgError (*GglIpcSubscribeCallback)(
-    GgObject data, uint32_t resp_handle, int32_t stream_id, GgArena *arena
+    void *ctx,
+    GgObject data,
+    uint32_t resp_handle,
+    int32_t stream_id,
+    GgArena *arena
 );
 
-/// Wrapper around ggl_subscribe for IPC handlers.
+/// Wrapper around ggl_subscribe for IPC handlers. `ctx` is an optional
+/// per-subscription context passed to `on_response` on each event.
 GgError ggl_ipc_bind_subscription(
     uint32_t resp_handle,
     int32_t stream_id,
@@ -23,6 +30,7 @@ GgError ggl_ipc_bind_subscription(
     GgBuffer method,
     GgMap params,
     GglIpcSubscribeCallback on_response,
+    void *ctx,
     GgError *error
 );
 

--- a/modules/ggipcd/src/services/config/config_path_object.c
+++ b/modules/ggipcd/src/services/config/config_path_object.c
@@ -14,16 +14,25 @@
 // e.g. `myComponent`'s config path in the database
 #define GGL_MAX_COMPONENT_CONFIG_DEPTH (GG_MAX_OBJECT_DEPTH - 3)
 
-GgBuffer ggl_alias_component_name(GgBuffer component_name) {
-    // Classic Greengrass stores nucleus configuration under
-    // "aws.greengrass.Nucleus", whereas Greengrass Lite uses
-    // "aws.greengrass.NucleusLite". Forward requests for the classic name to
-    // the Lite tree so a component can read nucleus configuration using a
-    // single, nucleus-agnostic name on both runtimes.
-    if (gg_buffer_eq(component_name, GG_STR("aws.greengrass.Nucleus"))) {
-        return GG_STR("aws.greengrass.NucleusLite");
+static const GglConfigComponentAlias COMPONENT_ALIASES[] = {
+    {
+        .requested_name = GG_STR("aws.greengrass.Nucleus"),
+        .storage_name = GG_STR("aws.greengrass.NucleusLite"),
+    },
+};
+
+const GglConfigComponentAlias *ggl_config_component_alias(
+    GgBuffer requested_name
+) {
+    for (size_t i = 0;
+         i < (sizeof(COMPONENT_ALIASES) / sizeof(COMPONENT_ALIASES[0]));
+         i++) {
+        if (gg_buffer_eq(requested_name, COMPONENT_ALIASES[i].requested_name)) {
+            return &COMPONENT_ALIASES[i];
+        }
     }
-    return component_name;
+
+    return NULL;
 }
 
 GgError ggl_make_config_path_object(

--- a/modules/ggipcd/src/services/config/config_path_object.c
+++ b/modules/ggipcd/src/services/config/config_path_object.c
@@ -14,6 +14,18 @@
 // e.g. `myComponent`'s config path in the database
 #define GGL_MAX_COMPONENT_CONFIG_DEPTH (GG_MAX_OBJECT_DEPTH - 3)
 
+GgBuffer ggl_alias_component_name(GgBuffer component_name) {
+    // Classic Greengrass stores nucleus configuration under
+    // "aws.greengrass.Nucleus", whereas Greengrass Lite uses
+    // "aws.greengrass.NucleusLite". Forward requests for the classic name to
+    // the Lite tree so a component can read nucleus configuration using a
+    // single, nucleus-agnostic name on both runtimes.
+    if (gg_buffer_eq(component_name, GG_STR("aws.greengrass.Nucleus"))) {
+        return GG_STR("aws.greengrass.NucleusLite");
+    }
+    return component_name;
+}
+
 GgError ggl_make_config_path_object(
     GgBuffer component_name, GgList key_path, GgBufList *result
 ) {

--- a/modules/ggipcd/src/services/config/config_path_object.h
+++ b/modules/ggipcd/src/services/config/config_path_object.h
@@ -8,11 +8,17 @@
 #include <gg/error.h>
 #include <gg/types.h>
 
-/// Returns the configuration component name to use for a request, applying the
-/// classic-compatibility alias: a request for "aws.greengrass.Nucleus" is
-/// served from the "aws.greengrass.NucleusLite" configuration tree. Any other
-/// name is returned unchanged.
-GgBuffer ggl_alias_component_name(GgBuffer component_name);
+/// Maps an IPC component name to the component name used for config storage.
+typedef struct {
+    GgBuffer requested_name;
+    GgBuffer storage_name;
+} GglConfigComponentAlias;
+
+/// Returns the static alias descriptor for `requested_name`, or NULL when the
+/// component name is not aliased.
+const GglConfigComponentAlias *ggl_config_component_alias(
+    GgBuffer requested_name
+);
 
 /// Combine the component name and key path and returns a new configuration path
 /// result uses static memory owned by this function which is valid until the

--- a/modules/ggipcd/src/services/config/config_path_object.h
+++ b/modules/ggipcd/src/services/config/config_path_object.h
@@ -8,6 +8,12 @@
 #include <gg/error.h>
 #include <gg/types.h>
 
+/// Returns the configuration component name to use for a request, applying the
+/// classic-compatibility alias: a request for "aws.greengrass.Nucleus" is
+/// served from the "aws.greengrass.NucleusLite" configuration tree. Any other
+/// name is returned unchanged.
+GgBuffer ggl_alias_component_name(GgBuffer component_name);
+
 /// Combine the component name and key path and returns a new configuration path
 /// result uses static memory owned by this function which is valid until the
 /// next call. Not re-entrant.

--- a/modules/ggipcd/src/services/config/get_configuration.c
+++ b/modules/ggipcd/src/services/config/get_configuration.c
@@ -69,8 +69,15 @@ GgError ggl_handle_get_configuration(
         component_name = gg_obj_into_buf(*component_name_obj);
     }
 
+    // Forward classic "aws.greengrass.Nucleus" lookups to the Lite nucleus
+    // configuration tree. The response still echoes the requested name, so the
+    // alias is transparent to the caller.
+    GgBuffer resolved_component_name = ggl_alias_component_name(component_name);
+
     GgBufList full_key_path;
-    ret = ggl_make_config_path_object(component_name, key_path, &full_key_path);
+    ret = ggl_make_config_path_object(
+        resolved_component_name, key_path, &full_key_path
+    );
     if (ret != GG_ERR_OK) {
         *ipc_error = (GglIpcError
         ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,

--- a/modules/ggipcd/src/services/config/get_configuration.c
+++ b/modules/ggipcd/src/services/config/get_configuration.c
@@ -69,14 +69,14 @@ GgError ggl_handle_get_configuration(
         component_name = gg_obj_into_buf(*component_name_obj);
     }
 
-    // Forward classic "aws.greengrass.Nucleus" lookups to the Lite nucleus
-    // configuration tree. The response still echoes the requested name, so the
-    // alias is transparent to the caller.
-    GgBuffer resolved_component_name = ggl_alias_component_name(component_name);
+    const GglConfigComponentAlias *alias
+        = ggl_config_component_alias(component_name);
+    GgBuffer storage_component_name
+        = (alias == NULL) ? component_name : alias->storage_name;
 
     GgBufList full_key_path;
     ret = ggl_make_config_path_object(
-        resolved_component_name, key_path, &full_key_path
+        storage_component_name, key_path, &full_key_path
     );
     if (ret != GG_ERR_OK) {
         *ipc_error = (GglIpcError

--- a/modules/ggipcd/src/services/config/subscribe_to_configuration_update.c
+++ b/modules/ggipcd/src/services/config/subscribe_to_configuration_update.c
@@ -20,8 +20,19 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// When a request for "aws.greengrass.Nucleus" is forwarded to the
+// "aws.greengrass.NucleusLite" configuration tree, this is passed as the
+// subscription context so update events are reported under the requested name.
+static const GgBuffer NUCLEUS_REQUESTED_COMPONENT_NAME
+    = { .data = (uint8_t *) "aws.greengrass.Nucleus",
+        .len = sizeof("aws.greengrass.Nucleus") - 1 };
+
 static GgError subscribe_to_configuration_update_callback(
-    GgObject data, uint32_t resp_handle, int32_t stream_id, GgArena *alloc
+    void *ctx,
+    GgObject data,
+    uint32_t resp_handle,
+    int32_t stream_id,
+    GgArena *alloc
 ) {
     (void) alloc;
 
@@ -38,6 +49,13 @@ static GgError subscribe_to_configuration_update_callback(
     );
     if (err != GG_ERR_OK) {
         return err;
+    }
+
+    // If this subscription was created via the Nucleus alias, report the
+    // component name the caller subscribed to instead of the underlying
+    // aws.greengrass.NucleusLite key.
+    if (ctx != NULL) {
+        component_name = *(const GgBuffer *) ctx;
     }
 
     GgMap ipc_response = GG_MAP(
@@ -122,8 +140,20 @@ GgError ggl_handle_subscribe_to_configuration_update(
         component_name = gg_obj_into_buf(*component_name_obj);
     }
 
+    // Forward classic "aws.greengrass.Nucleus" subscriptions to the Lite
+    // nucleus configuration tree. When forwarding, pass the requested name as
+    // the subscription context so update events are reported under the name the
+    // component subscribed to (transparent aliasing).
+    GgBuffer resolved_component_name = ggl_alias_component_name(component_name);
+    void *sub_ctx = NULL;
+    if (!gg_buffer_eq(resolved_component_name, component_name)) {
+        sub_ctx = (void *) &NUCLEUS_REQUESTED_COMPONENT_NAME;
+    }
+
     GgBufList full_key_path;
-    ret = ggl_make_config_path_object(component_name, key_path, &full_key_path);
+    ret = ggl_make_config_path_object(
+        resolved_component_name, key_path, &full_key_path
+    );
     if (ret != GG_ERR_OK) {
         GG_LOGE("Config path depth larger than supported.");
         *ipc_error = (GglIpcError
@@ -156,6 +186,7 @@ GgError ggl_handle_subscribe_to_configuration_update(
         GG_STR("subscribe"),
         call_args,
         subscribe_to_configuration_update_callback,
+        sub_ctx,
         &remote_err
     );
     if (ret != GG_ERR_OK) {

--- a/modules/ggipcd/src/services/config/subscribe_to_configuration_update.c
+++ b/modules/ggipcd/src/services/config/subscribe_to_configuration_update.c
@@ -20,13 +20,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// When a request for "aws.greengrass.Nucleus" is forwarded to the
-// "aws.greengrass.NucleusLite" configuration tree, this is passed as the
-// subscription context so update events are reported under the requested name.
-static const GgBuffer NUCLEUS_REQUESTED_COMPONENT_NAME
-    = { .data = (uint8_t *) "aws.greengrass.Nucleus",
-        .len = sizeof("aws.greengrass.Nucleus") - 1 };
-
 static GgError subscribe_to_configuration_update_callback(
     void *ctx,
     GgObject data,
@@ -51,11 +44,9 @@ static GgError subscribe_to_configuration_update_callback(
         return err;
     }
 
-    // If this subscription was created via the Nucleus alias, report the
-    // component name the caller subscribed to instead of the underlying
-    // aws.greengrass.NucleusLite key.
-    if (ctx != NULL) {
-        component_name = *(const GgBuffer *) ctx;
+    const GglConfigComponentAlias *alias = ctx;
+    if (alias != NULL) {
+        component_name = alias->requested_name;
     }
 
     GgMap ipc_response = GG_MAP(
@@ -140,19 +131,14 @@ GgError ggl_handle_subscribe_to_configuration_update(
         component_name = gg_obj_into_buf(*component_name_obj);
     }
 
-    // Forward classic "aws.greengrass.Nucleus" subscriptions to the Lite
-    // nucleus configuration tree. When forwarding, pass the requested name as
-    // the subscription context so update events are reported under the name the
-    // component subscribed to (transparent aliasing).
-    GgBuffer resolved_component_name = ggl_alias_component_name(component_name);
-    void *sub_ctx = NULL;
-    if (!gg_buffer_eq(resolved_component_name, component_name)) {
-        sub_ctx = (void *) &NUCLEUS_REQUESTED_COMPONENT_NAME;
-    }
+    const GglConfigComponentAlias *alias
+        = ggl_config_component_alias(component_name);
+    GgBuffer storage_component_name
+        = (alias == NULL) ? component_name : alias->storage_name;
 
     GgBufList full_key_path;
     ret = ggl_make_config_path_object(
-        resolved_component_name, key_path, &full_key_path
+        storage_component_name, key_path, &full_key_path
     );
     if (ret != GG_ERR_OK) {
         GG_LOGE("Config path depth larger than supported.");
@@ -186,7 +172,7 @@ GgError ggl_handle_subscribe_to_configuration_update(
         GG_STR("subscribe"),
         call_args,
         subscribe_to_configuration_update_callback,
-        sub_ctx,
+        (void *) alias,
         &remote_err
     );
     if (ret != GG_ERR_OK) {

--- a/modules/ggipcd/src/services/config/update_configuration.c
+++ b/modules/ggipcd/src/services/config/update_configuration.c
@@ -101,6 +101,8 @@ GgError ggl_handle_update_configuration(
     int64_t timestamp = (int64_t) (gg_obj_into_f64(*timestamp_obj) * 1000.0);
     GG_LOGT("Timestamp is %" PRId64, timestamp);
 
+    // UpdateConfiguration is caller-scoped, so the cross-component aliases
+    // used by GetConfiguration and SubscribeToConfigurationUpdate do not apply.
     GgBufList full_key_path;
     ret = ggl_make_config_path_object(
         info->component, key_path, &full_key_path

--- a/modules/ggipcd/src/services/mqttproxy/subscribe_to_iot_core.c
+++ b/modules/ggipcd/src/services/mqttproxy/subscribe_to_iot_core.c
@@ -22,8 +22,13 @@
 #include <stdlib.h>
 
 static GgError subscribe_to_iot_core_callback(
-    GgObject data, uint32_t resp_handle, int32_t stream_id, GgArena *alloc
+    void *ctx,
+    GgObject data,
+    uint32_t resp_handle,
+    int32_t stream_id,
+    GgArena *alloc
 ) {
+    (void) ctx;
     GgBuffer topic;
     GgBuffer payload;
 
@@ -146,6 +151,7 @@ GgError ggl_handle_subscribe_to_iot_core(
         GG_STR("subscribe"),
         call_args,
         subscribe_to_iot_core_callback,
+        NULL,
         NULL
     );
     if (ret != GG_ERR_OK) {

--- a/modules/ggipcd/src/services/pubsub/subscribe_to_topic.c
+++ b/modules/ggipcd/src/services/pubsub/subscribe_to_topic.c
@@ -21,8 +21,13 @@
 #include <stdlib.h>
 
 static GgError subscribe_to_topic_callback(
-    GgObject data, uint32_t resp_handle, int32_t stream_id, GgArena *alloc
+    void *ctx,
+    GgObject data,
+    uint32_t resp_handle,
+    int32_t stream_id,
+    GgArena *alloc
 ) {
+    (void) ctx;
     (void) alloc;
 
     if (gg_obj_type(data) != GG_TYPE_MAP) {
@@ -136,6 +141,7 @@ GgError ggl_handle_subscribe_to_topic(
         GG_STR("subscribe"),
         call_args,
         subscribe_to_topic_callback,
+        NULL,
         NULL
     );
     if (ret != GG_ERR_OK) {


### PR DESCRIPTION
## Description

Components that run on both classic Greengrass and Greengrass Lite need
nucleus configuration (IoT endpoints, proxy settings). On classic this lives
under `aws.greengrass.Nucleus`; on Lite under `aws.greengrass.NucleusLite`,
forcing components to probe both names and fork code paths per runtime.

This PR adds a component-name alias at the IPC boundary: `GetConfiguration`
and `SubscribeToConfigurationUpdate` requests naming `aws.greengrass.Nucleus`
are served from the `aws.greengrass.NucleusLite` configuration tree, while
responses and update events retain the requested name. A component can now use
a single nucleus-agnostic name on both runtimes.

Commits:

1. `Forward Nucleus config IPC lookups to NucleusLite` — the alias for reads
   and subscriptions, with transparent name echo/relabeling via a
   per-subscription context on the IPC subscription wrapper.
2. `Harden IPC subscription binding state` — replaces the parallel
   subscription-state arrays with a slot struct passed directly as the
   core-bus callback context. This also fixes a pre-existing race where an
   event arriving between epoll registration and handle recording failed the
   lookup and closed a fresh subscription.
3. `Centralize Nucleus config IPC alias policy` — a single static alias
   descriptor (`{requested_name, storage_name}`) drives both routing and
   event relabeling; documents the alias and adds a dedicated
   SubscribeToConfigurationUpdate spec.
4. `Clarify Nucleus configuration alias behavior in specs` — req-tags the
   contract (exact, one-way, name-only aliasing) and documents that
   `UpdateConfiguration` and deployment `configurationUpdate` entries use
   component names verbatim.

The alias deliberately does not apply to writes: `UpdateConfiguration` is
caller-scoped (it has no `componentName` parameter), and deployment
configuration updates must target `aws.greengrass.NucleusLite`.

## Related Issue

N/A — requested by an internal component team that runs the same component on
both runtimes.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [x] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [x] **Documentation updated** (if applicable)
- [x] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/pull/new/dev/nucleusconfigforward)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [x] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

New/updated specs: `docs/spec/library/ipc_commands/getconfiguration_ipc.md`,
`docs/spec/library/ipc_commands/subscribetoconfigurationupdate_ipc.md` (new),
`docs/spec/executable/ggconfigd.md`, `docs/spec/executable/ggdeploymentd.md`.

## Testing

- [x] Existing tests pass
- [x] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/pull/new/dev/nucleusconfigforward)
- [x] New functionality is covered by tests

`test_Component_30_T0` (companion aws-greengrass-testing branch
`dev/nucleusconfigforward`) verifies end to end on a real IoT Core account,
run in a podman systemd container:

- A `GetConfiguration` read via `aws.greengrass.Nucleus` returns the same
  value as a direct `aws.greengrass.NucleusLite` read, and the response
  echoes the requested name.
- Subscribing via `aws.greengrass.Nucleus` is accepted, and a NucleusLite
  configuration change (driven by a cloud deployment merging a probe key) is
  delivered with the event relabeled to `aws.greengrass.Nucleus`.
- No event ever exposes the underlying `aws.greengrass.NucleusLite` name.

Latest run: `1 passed in 72.02s`.

## Additional Notes

- Internal daemons are unaffected: they read config via explicit core-bus
  paths, not the IPC resolver.
- The subscription-state refactor (commit 2) fixes a pre-existing first-event
  race in ggipcd, surfaced while adding the per-subscription callback context;
  it is split into its own commit for reviewability.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
