### PR TITLE
Add SubscribeToIoTCoreConnectionStatus IPC operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,19 +66,20 @@ caution in production environments.
 IPC support is provided by ggipcd. The support translates the IPC command to
 corebus. This table identifies the corebus component that does the work.
 
-| Feature                        | Daemon that provides support |
-| :----------------------------- | :--------------------------- |
-| SubscribeToTopic               | ggpubsubd                    |
-| PublishToTopic                 | ggpubsubd                    |
-| PublishToIoTCore               | iotcored                     |
-| SubscribeToIoTCore             | iotcored                     |
-| GetConfiguration               | ggconfigd                    |
-| UpdateConfiguration            | ggconfigd                    |
-| SubscribeToConfigurationUpdate | ggconfigd                    |
-| CreateLocalDeployment          | ggdeploymentd                |
-| ValidateAuthorizationToken     | ggipcd                       |
-| RestartComponent               | gghealthd                    |
-| UpdateState                    | gghealthd                    |
+| Feature                            | Daemon that provides support |
+| :--------------------------------- | :--------------------------- |
+| SubscribeToTopic                   | ggpubsubd                    |
+| PublishToTopic                     | ggpubsubd                    |
+| PublishToIoTCore                   | iotcored                     |
+| SubscribeToIoTCore                 | iotcored                     |
+| SubscribeToIoTCoreConnectionStatus | iotcored                     |
+| GetConfiguration                   | ggconfigd                    |
+| UpdateConfiguration                | ggconfigd                    |
+| SubscribeToConfigurationUpdate     | ggconfigd                    |
+| CreateLocalDeployment              | ggdeploymentd                |
+| ValidateAuthorizationToken         | ggipcd                       |
+| RestartComponent                   | gghealthd                    |
+| UpdateState                        | gghealthd                    |
 
 Additional IPC commands will be supported in future releases.
 

--- a/docs/spec/library/ipc_commands/subscribetoiotcoreconnectionstatus_ipc.md
+++ b/docs/spec/library/ipc_commands/subscribetoiotcoreconnectionstatus_ipc.md
@@ -1,0 +1,111 @@
+# `SubscribeToIoTCoreConnectionStatus` IPC command
+
+The `SubscribeToIoTCoreConnectionStatus` IPC command subscribes a component to
+the status of the AWS IoT Core MQTT connection using the `connection_status`
+method of the `aws_iot_mqtt` core-bus interface provided by `iotcored`.
+
+- [subscribe-to-iot-core-connection-status-1] It will be invoked with the topic
+  `SubscribeToIoTCoreConnectionStatus`.
+- [subscribe-to-iot-core-connection-status-2] It does not require an access
+  control policy in the recipe to work, as it is an informational local-only
+  operation which exposes no MQTT topic data.
+- [subscribe-to-iot-core-connection-status-3] The current connection status is
+  delivered as the first stream event immediately after the subscription is
+  accepted.
+- [subscribe-to-iot-core-connection-status-4] A stream event is delivered on
+  each subsequent connect/disconnect transition of the MQTT connection.
+- [subscribe-to-iot-core-connection-status-5] The operation response is sent
+  before any stream event, per the eventstream protocol requirements.
+
+## Parameters
+
+This operation takes no parameters; the request payload is an empty object.
+
+## Response
+
+- [subscribe-to-iot-core-connection-status-resp-1] On success, returns an empty
+  `SubscribeToIoTCoreConnectionStatusResponse`, followed by a stream of
+  `IoTCoreConnectionStatusEvent` events.
+  - [subscribe-to-iot-core-connection-status-resp-1.1] Each stream event is a
+    map containing a `connectionStatusEvent` key, whose value is a map
+    containing a `status` key.
+  - [subscribe-to-iot-core-connection-status-resp-1.2] `status` is a buffer
+    containing either `CONNECTED` or `DISCONNECTED`.
+- [subscribe-to-iot-core-connection-status-resp-2] On failure, returns a map
+  containing `message`, `_service`, `_message` and `_errorCode`.
+  - [subscribe-to-iot-core-connection-status-resp-2.1] `ServiceError` is
+    returned if the core-bus subscription cannot be established.
+
+## On the wire
+
+```
+structure SubscribeToIoTCoreConnectionStatusRequest {
+}
+
+structure SubscribeToIoTCoreConnectionStatusResponse {
+}
+
+structure ConnectionStatusEvent {
+    /// The connection status: CONNECTED or DISCONNECTED.
+    @required
+    status: String
+}
+
+union IoTCoreConnectionStatusEvent {
+    /// The connection status event.
+    connectionStatusEvent: ConnectionStatusEvent
+}
+
+operation SubscribeToIoTCoreConnectionStatus {
+    input: SubscribeToIoTCoreConnectionStatusRequest,
+    output: SubscribeToIoTCoreConnectionStatusResponse (streaming: IoTCoreConnectionStatusEvent),
+    errors: [ServiceError]
+}
+```
+
+## Examples
+
+Case 1: Subscribe while the device is connected to AWS IoT Core
+
+- Request: `{}`
+- Response: `{}`
+- First stream event (current status):
+  `{"connectionStatusEvent":{"status":"CONNECTED"}}`
+
+Case 2: MQTT connection is interrupted after subscribing
+
+- Stream event: `{"connectionStatusEvent":{"status":"DISCONNECTED"}}`
+
+Case 3: MQTT connection resumes
+
+- Stream event: `{"connectionStatusEvent":{"status":"CONNECTED"}}`
+
+### RAW on wire:
+
+```shell
+Packet from client:
+  Headers:
+    [:content-type] => String(StrBytes { bytes: b"application/json" })
+    [service-model-type] => String(StrBytes { bytes: b"aws.greengrass#SubscribeToIoTCoreConnectionStatusRequest" })
+    [:message-type] => Int32(0)
+    [:message-flags] => Int32(0)
+    [:stream-id] => Int32(1)
+    [operation] => String(StrBytes { bytes: b"aws.greengrass#SubscribeToIoTCoreConnectionStatus" })
+  Value: {}
+Packet from server (response):
+  Headers:
+    [:content-type] => String(StrBytes { bytes: b"application/json" })
+    [service-model-type] => String(StrBytes { bytes: b"aws.greengrass#SubscribeToIoTCoreConnectionStatusResponse" })
+    [:message-type] => Int32(0)
+    [:message-flags] => Int32(0)
+    [:stream-id] => Int32(1)
+  Value: {}
+Packet from server (stream event):
+  Headers:
+    [:content-type] => String(StrBytes { bytes: b"application/json" })
+    [service-model-type] => String(StrBytes { bytes: b"aws.greengrass#IoTCoreConnectionStatusEvent" })
+    [:message-type] => Int32(0)
+    [:message-flags] => Int32(0)
+    [:stream-id] => Int32(1)
+  Value: {"connectionStatusEvent":{"status":"CONNECTED"}}
+```

--- a/modules/ggipcd/src/services/mqttproxy/mqttproxy.c
+++ b/modules/ggipcd/src/services/mqttproxy/mqttproxy.c
@@ -19,6 +19,10 @@ static GglIpcOperation operations[] = {
         GG_STR("aws.greengrass#SubscribeToIoTCore"),
         ggl_handle_subscribe_to_iot_core,
     },
+    {
+        GG_STR("aws.greengrass#SubscribeToIoTCoreConnectionStatus"),
+        ggl_handle_subscribe_to_iot_core_connection_status,
+    },
 };
 
 GglIpcService ggl_ipc_service_mqttproxy = {

--- a/modules/ggipcd/src/services/mqttproxy/mqttproxy.h
+++ b/modules/ggipcd/src/services/mqttproxy/mqttproxy.h
@@ -10,6 +10,7 @@
 
 GglIpcOperationHandler ggl_handle_publish_to_iot_core;
 GglIpcOperationHandler ggl_handle_subscribe_to_iot_core;
+GglIpcOperationHandler ggl_handle_subscribe_to_iot_core_connection_status;
 
 GglIpcPolicyResourceMatcher ggl_ipc_mqtt_policy_matcher;
 

--- a/modules/ggipcd/src/services/mqttproxy/subscribe_to_iot_core_connection_status.c
+++ b/modules/ggipcd/src/services/mqttproxy/subscribe_to_iot_core_connection_status.c
@@ -1,0 +1,120 @@
+// aws-greengrass-lite - AWS IoT Greengrass runtime for constrained devices
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../../ipc_error.h"
+#include "../../ipc_server.h"
+#include "../../ipc_service.h"
+#include "../../ipc_subscriptions.h"
+#include "mqttproxy.h"
+#include <gg/arena.h>
+#include <gg/buffer.h>
+#include <gg/error.h>
+#include <gg/log.h>
+#include <gg/map.h>
+#include <gg/object.h>
+#include <gg/types.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/// Translates core-bus boolean connection status into the IPC stream event.
+/// Wire format: {"connectionStatusEvent": {"status":
+/// "CONNECTED"|"DISCONNECTED"}}
+static GgError connection_status_callback(
+    GgObject data, uint32_t resp_handle, int32_t stream_id, GgArena *alloc
+) {
+    (void) alloc;
+
+    if (gg_obj_type(data) != GG_TYPE_BOOLEAN) {
+        GG_LOGE("Unexpected non-boolean connection status object; skipping.");
+        return GG_ERR_OK;
+    }
+
+    bool connected = gg_obj_into_bool(data);
+
+    GgBuffer status_str
+        = connected ? GG_STR("CONNECTED") : GG_STR("DISCONNECTED");
+
+    GgMap response = GG_MAP(gg_kv(
+        GG_STR("connectionStatusEvent"),
+        gg_obj_map(GG_MAP(gg_kv(GG_STR("status"), gg_obj_buf(status_str))))
+    ));
+
+    GgError ret = ggl_ipc_response_send(
+        resp_handle,
+        stream_id,
+        GG_STR("aws.greengrass#IoTCoreConnectionStatusEvent"),
+        response
+    );
+    if (ret != GG_ERR_OK) {
+        GG_LOGE(
+            "Failed to send connection status event (error %s); "
+            "closing subscription.",
+            gg_strerror(ret)
+        );
+        return ret;
+    }
+
+    return GG_ERR_OK;
+}
+
+GgError ggl_handle_subscribe_to_iot_core_connection_status(
+    const GglIpcOperationInfo *info,
+    GgMap args,
+    uint32_t handle,
+    int32_t stream_id,
+    GglIpcError *ipc_error,
+    GgArena *alloc
+) {
+    (void) info;
+    (void) args;
+    (void) alloc;
+
+    // No authorization check: connection status is informational and
+    // local-only.
+
+    // Send the operation response BEFORE binding the core-bus subscription.
+    // iotcored publishes the current connection status immediately upon
+    // subscription accept, on a separate core-bus subscription thread.
+    // If we bound first, we could:
+    //   (a) violate the eventstream protocol by emitting a stream event
+    //       before the operation response, or
+    //   (b) lose the first event due to the recv_handle registration gap
+    //       inside ggl_ipc_bind_subscription.
+    GgError ret = ggl_ipc_response_send(
+        handle,
+        stream_id,
+        GG_STR("aws.greengrass#SubscribeToIoTCoreConnectionStatusResponse"),
+        (GgMap) { 0 }
+    );
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("Failed to send subscription response.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_SERVICE_ERROR,
+            .message = GG_STR("Failed to send subscription response.") };
+        return ret;
+    }
+
+    ret = ggl_ipc_bind_subscription(
+        handle,
+        stream_id,
+        GG_STR("aws_iot_mqtt"),
+        GG_STR("connection_status"),
+        (GgMap) { 0 },
+        connection_status_callback,
+        NULL
+    );
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("Failed to bind connection status subscription after response "
+                "sent; terminating stream.");
+        ggl_ipc_terminate_stream(handle, stream_id);
+        // Return GG_ERR_OK because the success response was already sent.
+        // Returning non-OK here would cause handle_operation (ipc_server.c)
+        // to call send_stream_error, sending a second error frame on an
+        // already-responded stream.
+        return GG_ERR_OK;
+    }
+
+    return GG_ERR_OK;
+}


### PR DESCRIPTION
## Description

Add the `aws.greengrass#SubscribeToIoTCoreConnectionStatus` IPC operation to ggipcd, bridging the existing iotcored `connection_status` core-bus subscription to IPC clients. Components can subscribe and receive the IoT Core MQTT connection status as a stream of `IoTCoreConnectionStatusEvent` messages (`{"connectionStatusEvent":{"status":"CONNECTED"|"DISCONNECTED"}}`), wire-compatible with the Greengrass nucleus implementation and the Java/Python device SDKs.

Design notes:

- The operation response is sent **before** binding the core-bus subscription: iotcored emits the current status immediately on subscription accept, on the core-bus subscription thread, so binding first could emit a stream event before the operation response (an eventstream protocol violation) or lose the first event.
- The current status is delivered as the first stream event immediately after subscribing; subsequent events fire on each connect/disconnect transition.
- No authorization required: informational local-only operation exposing no MQTT topic data, matching the nucleus design (same pattern as `SubscribeToConfigurationUpdate`).
- The stream-event callback tolerates unknown future status values and self-heals (closes the core-bus subscription) if the IPC client connection dies.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [x] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [x] Updated README.md if needed
- [x] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [x] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

Build verified clean (ggipcd compiles with zero warnings, clang-formatted). The operation spec including the on-the-wire format is documented in `docs/spec/library/ipc_commands/subscribetoiotcoreconnectionstatus_ipc.md`. A matching client API is implemented in aws-greengrass-sdk-lite (separate PR to follow), and the same wire contract was verified end-to-end against the Greengrass nucleus implementation of this operation.

## Additional Notes

The corresponding server-side feature in the classic nucleus is aws-greengrass/aws-greengrass-nucleus#1813. Follow-up candidate (pre-existing, out of scope): `ggl_ipc_bind_subscription` has a recv_handle registration gap that can drop the first event of any core-bus method that emits immediately on accept.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
