### PR TITLE
Leave unresolvable configuration recipe variables as-is (#867)

### DIFF
--- a/modules/ggl-config-interpolation/include/interpolation.h
+++ b/modules/ggl-config-interpolation/include/interpolation.h
@@ -20,6 +20,9 @@
 /// reader callback is required. Pass GGL_CONFIG_NULL_READER to return an error
 /// if config lookup is not desired.
 ///
+/// If a configuration variable refers to a value that does not exist, the
+/// recipe variable is written back unchanged, braces included.
+///
 /// An error is returned if the escape sequence does not contain a colon or the
 /// namespace-key pair is not recognized.
 GgError ggl_substitute_escape(

--- a/modules/ggl-config-interpolation/src/interpolation.c
+++ b/modules/ggl-config-interpolation/src/interpolation.c
@@ -116,7 +116,16 @@ GgError ggl_substitute_escape(
     } else if (gg_buffer_eq(namespace, GG_STR("configuration"))) {
         GgObjectReceiver object_writer
             = { .ctx = &writer, .submit = write_object_as_buffer };
-        return ggl_config_reader_call(config_reader, key, object_writer);
+        GgError config_ret
+            = ggl_config_reader_call(config_reader, key, object_writer);
+        if (config_ret == GG_ERR_NOENTRY) {
+            // Config value does not exist; leave the recipe variable as-is.
+            ggl_writer_call_chained(&ret, writer, GG_STR("{"));
+            ggl_writer_call_chained(&ret, writer, recipe_variable);
+            ggl_writer_call_chained(&ret, writer, GG_STR("}"));
+            return ret;
+        }
+        return config_ret;
     }
 
     GG_LOGE(
@@ -150,6 +159,32 @@ static GgError dummy_config_reader_call(
 
 static GgConfigReader dummy_config_reader(void) {
     return (GgConfigReader) { .reader = dummy_config_reader_call };
+}
+
+static GgError missing_config_reader_call(
+    void *ctx, GgBuffer key, GgObjectReceiver receiver
+) {
+    (void) ctx;
+    (void) key;
+    (void) receiver;
+    return GG_ERR_NOENTRY;
+}
+
+static GgConfigReader missing_config_reader(void) {
+    return (GgConfigReader) { .reader = missing_config_reader_call };
+}
+
+static GgError failing_config_reader_call(
+    void *ctx, GgBuffer key, GgObjectReceiver receiver
+) {
+    (void) ctx;
+    (void) key;
+    (void) receiver;
+    return GG_ERR_FAILURE;
+}
+
+static GgConfigReader failing_config_reader(void) {
+    return (GgConfigReader) { .reader = failing_config_reader_call };
 }
 
 static GgBuffer run_substitute(GgBuffer escape_seq) {
@@ -207,6 +242,37 @@ GG_TEST_DEFINE(substitute_artifacts_decompressed_path) {
 GG_TEST_DEFINE(substitute_configuration_uses_reader) {
     GgBuffer result = run_substitute(GG_STR("configuration:/some/key"));
     GG_TEST_ASSERT_BUF_EQUAL(GG_STR("dummy_config_value"), result);
+}
+
+GG_TEST_DEFINE(substitute_missing_configuration_left_as_is) {
+    static uint8_t buf[512];
+    GgByteVec vec = GG_BYTE_VEC(buf);
+    GgError ret = ggl_substitute_escape(
+        gg_byte_vec_writer(&vec),
+        GG_STR("configuration:/missing/key"),
+        TEST_ROOT_PATH,
+        TEST_COMPONENT,
+        TEST_VERSION,
+        TEST_THING_NAME,
+        missing_config_reader()
+    );
+    TEST_ASSERT_EQUAL_INT(GG_ERR_OK, ret);
+    GG_TEST_ASSERT_BUF_EQUAL(GG_STR("{configuration:/missing/key}"), vec.buf);
+}
+
+GG_TEST_DEFINE(substitute_configuration_read_error_fails) {
+    static uint8_t buf[64];
+    GgByteVec vec = GG_BYTE_VEC(buf);
+    GgError ret = ggl_substitute_escape(
+        gg_byte_vec_writer(&vec),
+        GG_STR("configuration:/key"),
+        TEST_ROOT_PATH,
+        TEST_COMPONENT,
+        TEST_VERSION,
+        TEST_THING_NAME,
+        failing_config_reader()
+    );
+    TEST_ASSERT_NOT_EQUAL(GG_ERR_OK, ret);
 }
 
 GG_TEST_DEFINE(substitute_configuration_null_reader_fails) {


### PR DESCRIPTION
> *Authored by an AI agent running the issue-resolution pipeline. Human review is required before merge; this PR is not self-approved.*

## Issue

https://github.com/aws-greengrass/aws-greengrass-lite/issues/867 — Recipe variable
interpolation does not ignore invalid configuration interpolations
Reported by: @patrzhan

## Problem

A `{configuration:<json_pointer>}` recipe variable that points at a configuration
value which does not exist is not left as-is. In practice the outcome is worse than
the issue's wording suggests: the config reader's `GG_ERR_NOENTRY` propagates out of
`ggl_substitute_escape` unchanged, nothing is written to the output at all, and the
error aborts interpolation of the **entire containing string** — so one unresolvable
variable fails generation of a whole lifecycle script (`recipe-runner/src/runner.c`
returns on non-OK), or causes a policy resource to be skipped
(`ggipcd/src/ipc_authz.c`).

Expected behaviour is the third of the three JSON-pointer resolution outcomes in the
[AWS IoT Greengrass V2 component recipe reference](https://docs.aws.amazon.com/greengrass/v2/developerguide/component-recipe-reference.html#recipe-variables):
a value node is replaced with its string form, an object node with its serialized
JSON, and — *"No node. AWS IoT Greengrass Core doesn't replace the recipe variable."*
Nucleus lite implements the first two and has no third path.

### Acceptance criteria

All four are **DERIVED** — the issue body is one sentence and states no criteria, so
these were derived from the reported behaviour plus the V2 recipe reference above,
which is the compatibility contract this project targets (`README.md`).

| # | Criterion | Met | How |
|---|-----------|-----|-----|
| 1 | A `{configuration:<ptr>}` naming a value that does not exist is emitted unchanged, braces included | Yes | The new `GG_ERR_NOENTRY` branch writes `{` + `recipe_variable` + `}`. Asserted byte-for-byte by `substitute_missing_configuration_left_as_is` |
| 2 | Interpolation does not fail merely because a config variable does not resolve; surrounding text and sibling variables still interpolate, and the call reports success | Yes (module layer; see note) | The branch returns `GG_ERR_OK`. Asserted by the same test's first assertion |
| 3 | A config-lookup failure that is **not** not-found still propagates | Yes | Gate is `== GG_ERR_NOENTRY`, never `!= GG_ERR_OK`. Asserted by the new `substitute_configuration_read_error_fails` (`GG_ERR_FAILURE` reader → non-OK), plus the pre-existing `substitute_configuration_null_reader_fails` (`GG_ERR_INVALID`) |
| 4 | Existing behaviour unchanged for resolvable lookups and for `kernel:`/`iot:`/`work:`/`artifacts:` | Yes | No other branch touched. All 11 pre-existing tests in the module still pass |

Note on criterion 2: the "surrounding text still interpolates" half lives in the
caller loops, which were verified by reading (`runner.c` `handle_escape` and
`ipc_authz.c:128-132` both advance past `}` independently of the return value and
only bail on non-OK). It is **not** covered by a test, because neither
`modules/recipe-runner` nor `modules/ggipcd` has a unit-test harness — there is no
`GG_TEST_DEFINE` in either. Adding one was judged out of scope for a bugfix.

Deliberately out of scope, for precision: unknown namespaces (`{unknown:x}`),
unknown keys in known namespaces (`{kernel:unknown}`), and colon-less escapes
(`{invalid}`) all keep returning errors — existing tests assert that, and the issue
is scoped to "a configuration value that does not exist". The three-part
`{dep:configuration:/ptr}` form also still errors, because `split_recipe_variable`
splits on the first colon; `docs/RECIPE_SUPPORT_CHANGES.md` already documents
dependency-name prefixes as unsupported.

## Root cause

The `configuration` branch of `ggl_substitute_escape` was a bare tail-call that
returned **every** reader status verbatim, `GG_ERR_NOENTRY` included:

```c
// modules/ggl-config-interpolation/src/interpolation.c:119 (before)
return ggl_config_reader_call(config_reader, key, object_writer);
```

Chain to the observed failure: `split_recipe_variable`
(`interpolation.c:27-40`) succeeds; the `kernel`/`iot`/`work`/`artifacts`
comparisons miss; the `configuration` branch calls the reader, which reports
not-found **without ever invoking the receiver**, so `write_object_as_buffer`
(`interpolation.c:42-49`) never runs and the output buffer stays empty; the error
returns unchanged.

Two structural facts pin the fix to this function rather than to its callers:

- Only this function knows the namespace, and criterion 4 requires leave-as-is to
  apply to `configuration` **only**. A caller-side "on any error, emit the literal"
  rule would also swallow the errors that four existing negative tests assert on.
- Braces are already stripped by the time the module is called
  (`include/interpolation.h:16-18`; `runner.c` consumes `{` and `}` itself,
  `ipc_authz.c:114` slices exclusive of `}`), so this is the only place that still
  holds both the writer and the un-stripped variable text and can reconstruct the
  literal.

**This is a long-standing omission, not a regression from the recent refactor.**
`git show 7e82ae3c -- modules/recipe-runner/src/runner.c` shows the pre-refactor
`insert_config_value` returned on any config-read failure; "Refactor variable
interpolation into module" preserved that behaviour verbatim.

Localization ran two blind workers; both reached this mechanism independently, and
the merged prediction — *"capture the reader status, and when it is exactly
`GG_ERR_NOENTRY` write `{` + `recipe_variable` + `}` through the same writer, and
the oracle passes with zero edits to `runner.c` or `ipc_authz.c`"* — held exactly,
green on the first attempt.

Set aside, one line each:

- **Fix in the callers** — cannot express criterion 4 (no namespace knowledge),
  duplicates the rule per consumer, and would regress four negative tests.
- **Fix in the readers** (swallow not-found, submit null) — readers see only the
  JSON pointer, not the namespace, so they cannot reproduce `{configuration:…}`;
  would emit JSON `null` instead.
- **Unknown-namespace fall-through at `interpolation.c:130-135`** — returns
  `GG_ERR_FAILURE` (1), not the observed 12, and its log line never fires for this
  input.
- **Key mangling in `split_recipe_variable` / pointer parsing** — a parse failure
  surfaces as `GG_ERR_FAILURE` (1), not 12.
- **Writer/arena exhaustion** — `GG_ERR_NOMEM` is 9, and no write is attempted.

## The fix

Two files, both in `modules/ggl-config-interpolation/`. **10 added and 1 removed
line of production code**; the rest is tests and a doc comment.

| File | Role |
|------|------|
| `src/interpolation.c` | The fix (10 lines, one branch of one function) + two test stubs and two tests |
| `include/interpolation.h` | 3-line doc-comment update recording the new third outcome |

```c
GgError config_ret
    = ggl_config_reader_call(config_reader, key, object_writer);
if (config_ret == GG_ERR_NOENTRY) {
    // Config value does not exist; leave the recipe variable as-is.
    ggl_writer_call_chained(&ret, writer, GG_STR("{"));
    ggl_writer_call_chained(&ret, writer, recipe_variable);
    ggl_writer_call_chained(&ret, writer, GG_STR("}"));
    return ret;
}
return config_ret;
```

Why this is minimal:

- **Gated on `== GG_ERR_NOENTRY`, never `!= GG_ERR_OK`** — required by criterion 3,
  and it keeps `substitute_configuration_null_reader_fails` (which relies on
  `GG_ERR_INVALID`) green.
- **Written through the caller's own `writer`**, never around it, so
  recipe-runner's shell-escaping writer still neutralizes `$`, backtick, `"`, and
  `\` in a JSON pointer before it reaches the generated `/bin/sh` script.
- **Reuses the existing `ggl_writer_call_chained` helper** (`interpolation.c:18-25`)
  and reuses `ret`, exactly as the sibling `work:` and `artifacts:` branches do, so
  the new branch reads like its neighbours. Reusing `ret` is safe: the function
  returns early if `split_recipe_variable` fails, so `ret == GG_ERR_OK` on entry,
  and writer errors such as `GG_ERR_NOMEM` still propagate.
- **The emitted literal is byte-for-byte the same length as the input substring**,
  so it cannot overflow a buffer sized for the input.
- No caller changes, no new includes, no refactoring —
  `docs/CONTRIBUTING.md` asks contributors not to widen the diff.

## Evidence

**Oracle** — the failing test that now passes:

- Test: `modules/ggl-config-interpolation/src/interpolation.c` ::
  `substitute_missing_configuration_left_as_is`
- Command: `cmake --build build --target ggl-config-interpolation-inline-test && ./build/bin/ggl-config-interpolation-inline-test`
- Before the patch:

  ```
  modules/ggl-config-interpolation/src/interpolation.c:237:test_gg_substitute_missing_configuration_left_as_is:FAIL: Expected 0 Was 12

  -----------------------
  12 Tests 1 Failures 0 Ignored
  FAIL
  ```

  `Expected 0 Was 12` is `GG_ERR_OK` vs `GG_ERR_NOENTRY` (`gg/error.h`). The
  assertion that fails is the return-code one, so Unity never even reached the
  buffer-content assertion.

- After the patch: passes, and the buffer assertion is now reached and passes too.
  `grep -c "Expected 0 Was 12"` over the run output returns 0.

  ```
  -----------------------
  13 Tests 0 Failures 0 Ignored
  OK
  ```

Test placement follows the module's existing inline-test convention
(`#ifdef GG_SDK_TESTING` in the module's own `.c`, compiled to
`<module>-inline-test` by `CMakeLists.txt:366-378`), modelled on the neighbouring
`substitute_configuration_uses_reader` and
`substitute_configuration_null_reader_fails`. No new framework, file, or directory.

**Regression run** — exactly the commands recorded at intake:

| Check | Command | Result |
|-------|---------|--------|
| Test suite | `ctest --test-dir build --output-on-failure` | **7/7 targets pass** (13/13 within the patched module) |
| Build | `cmake --build build` | Patched module clean, 0 warnings. Whole tree fails identically to baseline (below) |
| Lint | `nix flake check -L` | **NOT RUN — `nix` unavailable on the build host** (below) |

- **Patch-induced failures: none.**
- **Pre-existing failures at base revision `b33c3682`, deliberately left alone** —
  all are host library-version gaps on an Amazon Linux 2 box (glibc 2.26, gcc 7.3.1),
  not code defects, and all reproduce with the patch stashed:

  | Module | Error | Cause |
  |--------|-------|-------|
  | `modules/ggl-uri/src/gghttp_uri.c` | 12 errors: `UriMemoryManager` incomplete, `uriParseSingleUriExMmA`/`uriFreeUriMembersMmA` undeclared | uriparser < 0.9 |
  | `modules/ggl-http/{aws_sigv4.c, gghttp_util.c, digest.h}` | 3 errors: `openssl/types.h: No such file or directory` | OpenSSL < 3.0 |
  | vendored `gg-sdk` `src/ipc/client.c` | `gettid` implicitly declared | glibc < 2.30 — worked around out-of-tree via `CMAKE_C_FLAGS="-include <shim>"`; no repository file modified |

  These transitively block `ggl-uri-inline-test`, `ggdeploymentd-inline-test`, and
  `ggl-docker-client-inline-test`, which therefore could not be run either before or
  after. Fixing them here would widen the diff. Two of the three dependent targets
  reported more errors post-patch (12 → 15) purely because `make` aborts at the first
  failure and reached further on that run; this was checked by diffing the unique
  `file:line` error sets and by reproducing the extra 3 with the patch stashed.

- Reproduction rate: 100% deterministic — the test uses a stub reader with no I/O.

### CI checks that could NOT be run locally

`nix` and `clang-format` are not installed on the build host, so the repository's
own CI entrypoint `nix flake check -L` could not run. **Unverified locally:**
`clang-tidy`, `iwyu`, `cmake-lint`, `spelling` (cspell), `shellcheck`,
`build-clang`, `build-musl-pi`. Please rely on CI for these. Hand substitutes
applied: every added line is within the 80-column `.editorconfig` limit, 4-space
indent for `.c`/`.h`, no new `#include` (so no new `iwyu` surface — `GG_ERR_NOENTRY`
comes from the already-included `gg/error.h`), and the assertion added at
`interpolation.c` was reflowed to the single-line form that `clang-format` produces
at `ColumnLimit: 80` so the formatter should be a no-op.

## Reviewer verdict

| Field | Value |
|-------|-------|
| Verdict | `concur` |
| Confidence | Medium |
| Outcome applied | Patch preserved |

The review was independent — a separate agent, given the diff, the criteria, both
localization hypotheses (including the one not chosen), and the regression results,
and explicitly instructed not to treat the patcher's self-assessment as authority.
Two of its findings were acted on before submitting: the assertion was reflowed for
`clang-format`, and `substitute_configuration_read_error_fails` was added because
criterion 3 had no direct test. It also corrected two overstatements in the internal
analysis, which are therefore **not** repeated above: only **one** end-to-end
`GG_ERR_NOENTRY` conflation actually exists (`modules/core-bus/src/server.c:324`,
"No handler for method"; the SDK stale-stream-handle path is reachable only from
`ggipc_close_subscription` and is not on the config path), and it is **not** true
that both recipe-runner call sites sit inside shell quoting — the script-body
quoting context is chosen by the recipe author.

## ⚠️ This changes IPC authorization behaviour — please decide before merging

Disclosed deliberately rather than fixed, because no acceptance criterion asks for
it and there is no test for it.

At `modules/ggipcd/src/ipc_authz.c`, a policy resource containing an unresolvable
`{configuration:/…}` previously failed interpolation and the entry was **skipped**
(`GG_LOGW("Failed to interpolate policy resource, skipping.")` + `continue`,
`ipc_authz.c:205-214`) — fail-closed. With this fix, interpolation succeeds and the
resource becomes a literal pattern containing braces, which now participates in
matching.

In the common case the component merely gains rights over a resource literally named
`{configuration:/missing/key}`, which is not a real resource — practical impact
close to nil. But there is a narrower escalation path, verified in source: bare `{`
is legal in a request resource (`modules/ggl-policy-validation/src/policy_validation.c:12-48`),
and `ggl_ipc_default_policy_matcher` **deletes `${…}` spans from the pattern it is
given** — and it is given the *interpolated output*, whereas
`interpolate_policy_resource` only tests for `${` against the *input*. So a policy
resource like `{configuration:/a}{configuration:/missing}*`, where `/a` resolves to
a value ending in `$`, produces `${…}` in the output; the matcher strips it, the
pattern shortens, and it can over-match where pre-patch the entry was skipped
outright. Contrived — it needs two adjacent variables, the first resolving to a
`$`-terminated value and the second missing — but real.

**Suggested remedy if you want the old fail-closed posture preserved** (3 lines, and
it reuses a helper that already exists at `ipc_authz.c:61`): in `policy_match`, after
a successful `interpolate_policy_resource`, skip the entry when anything was left
as-is —

```c
if (has_recipe_variables(vec.buf)) {
    GG_LOGW("Policy resource has unresolved recipe variables, skipping.");
    continue;
}
```

Happy to add this to this PR, or to submit it separately, whichever you prefer.

## For the human reviewer

In priority order:

1. **The authorization decision above.** This is the one judgment call deliberately
   left to you. It was not applied unilaterally because it is a third file, has no
   oracle test, and is justified by a side effect rather than by the root cause.
2. **Is leave-as-is the behaviour you actually want here?** The fix follows the V2
   recipe reference literally. A reasonable alternative view is that nucleus lite
   should fail loudly on an unresolvable config variable rather than silently ship a
   script containing `{configuration:/…}`. That is a product call about
   Greengrass-compatibility strictness, and domain knowledge changes the answer.
3. **The one remaining `GG_ERR_NOENTRY` conflation.** `modules/core-bus/src/server.c:324`
   answers "No handler for method" with `GG_ERR_NOENTRY`, so that fault is
   indistinguishable from "key missing" at the fix site and will now be silently
   left as-is instead of erroring. Pre-existing ambiguity whose consequence this
   change widens. If it matters, the clean fix is a distinct error code in core-bus —
   not loosening this gate. Note an unreachable ggconfigd still yields
   `GG_ERR_NOCONN` and still propagates.
4. **An unenforced invariant this fix now relies on**: "a reader returning
   `GG_ERR_NOENTRY` must not have submitted anything to the receiver." Both real
   readers satisfy it (`ipc_authz.c:27-47` and `runner.c:85-101` both return errors
   before submitting), but nothing enforces it, and a future reader that submits then
   fails would concatenate garbage. Worth one sentence in
   `include/config_reader.h`; not added here to keep the diff to the root cause.
5. **CI is the only lint signal.** See the unrun-checks list above.

Two things NOT in this diff that a reviewer might expect: no update to
`docs/RECIPE_SUPPORT_CHANGES.md` (line 55, "Limited configuration:json_pointer
support", is still accurate, and line 59 concerns interpolation *inside component
configuration values* — the classic `interpolateComponentConfiguration` option — a
different feature); and no test for criterion 2's caller-loop behaviour, which would
require a new harness in a module that has none.

**Branch**: `wt/LiAllanPersonalAICapabilities-t5` — base revision `b33c3682`

Note on branch naming: `docs/CONTRIBUTING.md` asks internal developers to use a
`dev/` prefix on branches **in this repository**. This PR comes from a fork, so that
convention does not bind; the branch name is the one its worktree was provisioned
with. Happy to rename if you would prefer.
