### PR TITLE
Remove stale lifecycle unit files on recipe revision

### DIFF
--- a/modules/recipe2unit/CMakeLists.txt
+++ b/modules/recipe2unit/CMakeLists.txt
@@ -2,7 +2,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ggl_init_module(
-  recipe2unit
-  NO_INLINE_TEST
-  LIBS gg-sdk ggl-yaml ggl-recipe ggl-semver core-bus core-bus-gg-config)
+ggl_init_module(recipe2unit LIBS gg-sdk ggl-yaml ggl-recipe ggl-semver core-bus
+                                 core-bus-gg-config)

--- a/modules/recipe2unit/src/parser.c
+++ b/modules/recipe2unit/src/parser.c
@@ -5,6 +5,7 @@
 #include "unit_file_generator.h"
 #include "validate_args.h"
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <gg/arena.h>
 #include <gg/buffer.h>
@@ -20,15 +21,18 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #define MAX_UNIT_FILE_BUF_SIZE 2048
 #define MAX_COMPONENT_FILE_NAME 1024
 
-static GgError create_unit_file(
+// Builds the unit file path for a lifecycle phase. The returned path borrows a
+// static buffer, so it is only valid until the next call.
+static GgError unit_file_path(
     Recipe2UnitArgs *args,
     GgObject **component_name,
     PhaseSelection phase,
-    GgBuffer *response_buffer
+    GgBuffer *path
 ) {
     static uint8_t file_name_array[MAX_COMPONENT_FILE_NAME];
     GgBuffer file_name_buffer = (GgBuffer
@@ -60,10 +64,62 @@ static GgError create_unit_file(
         return ret;
     }
 
+    *path = file_name_vector.buf;
+    return GG_ERR_OK;
+}
+
+// Remove the unit file of a phase the recipe no longer declares, so that a
+// phase dropped by a recipe revision does not leave a stale unit behind.
+static GgError remove_unit_file(
+    Recipe2UnitArgs *args, GgObject **component_name, PhaseSelection phase
+) {
+    GgBuffer path = { 0 };
+    GgError ret = unit_file_path(args, component_name, phase, &path);
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+
+    if ((remove((const char *) path.data) != 0) && (errno != ENOENT)) {
+        // Do nothing. The absence of file is okay.
+        GG_LOGE("Failed to remove stale unit file: %d.", errno);
+        return GG_ERR_FAILURE;
+    }
+
+    return GG_ERR_OK;
+}
+
+// A revised recipe may drop a phase that a previous revision declared. Remove
+// those unit files, otherwise the stale phase is still run. Run/startup is
+// deliberately excluded: its unit is the only one carrying
+// WantedBy=greengrass-lite.target, so removing the file without also dropping
+// that enablement would leave a dangling symlink behind.
+static void remove_stale_unit_files(
+    Recipe2UnitArgs *args,
+    GgObject **component_name,
+    const HasPhase *existing_phases
+) {
+    if (!existing_phases->has_bootstrap) {
+        (void) remove_unit_file(args, component_name, BOOTSTRAP);
+    }
+    if (!existing_phases->has_install) {
+        (void) remove_unit_file(args, component_name, INSTALL);
+    }
+}
+
+static GgError create_unit_file(
+    Recipe2UnitArgs *args,
+    GgObject **component_name,
+    PhaseSelection phase,
+    GgBuffer *response_buffer
+) {
+    GgBuffer file_name = { 0 };
+    GgError ret = unit_file_path(args, component_name, phase, &file_name);
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+
     int fd = -1;
-    ret = gg_file_open(
-        file_name_vector.buf, O_WRONLY | O_CREAT | O_TRUNC, 0644, &fd
-    );
+    ret = gg_file_open(file_name, O_WRONLY | O_CREAT | O_TRUNC, 0644, &fd);
     GG_CLEANUP(cleanup_close, fd);
 
     if (ret != GG_ERR_OK) {
@@ -88,6 +144,7 @@ GgError convert_to_unit(
 ) {
     GgError ret;
     *component_name = NULL;
+    *existing_phases = (HasPhase) { 0 };
 
     ret = validate_args(args);
     if (ret != GG_ERR_OK) {
@@ -208,5 +265,160 @@ GgError convert_to_unit(
         return GG_ERR_INVALID;
     }
 
+    remove_stale_unit_files(args, component_name, existing_phases);
+
     return GG_ERR_OK;
 }
+
+#ifdef GG_SDK_TESTING
+
+#include <ftw.h>
+#include <gg/test.h>
+#include <limits.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <unity.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TEST_COMPONENT "com.example.StalePhase"
+
+static int test_unlink_cb(
+    const char *path, const struct stat *sb, int type, struct FTW *ftw
+) {
+    (void) sb;
+    (void) type;
+    (void) ftw;
+    return remove(path);
+}
+
+static void remove_test_root(const char *root_dir) {
+    (void) nftw(root_dir, test_unlink_cb, 8, FTW_DEPTH | FTW_PHYS);
+}
+
+static void make_test_root(char *root_dir, size_t len) {
+    (void) snprintf(root_dir, len, "/tmp/ggl-recipe2unit-XXXXXX");
+    TEST_ASSERT_NOT_NULL(mkdtemp(root_dir));
+}
+
+static bool test_unit_exists(const char *root_dir, const char *suffix) {
+    char path[PATH_MAX];
+    (void) snprintf(
+        path,
+        sizeof(path),
+        "%s/ggl." TEST_COMPONENT "%s.service",
+        root_dir,
+        suffix
+    );
+    return access(path, F_OK) == 0;
+}
+
+// Generates one unit file per phase, as a first deployment of a recipe
+// declaring bootstrap, install and run would.
+static void write_all_test_units(Recipe2UnitArgs *args, GgObject **name) {
+    GgBuffer content = GG_STR("[Unit]\nDescription=test\n");
+    GG_TEST_ASSERT_OK(create_unit_file(args, name, BOOTSTRAP, &content));
+    GG_TEST_ASSERT_OK(create_unit_file(args, name, INSTALL, &content));
+    GG_TEST_ASSERT_OK(create_unit_file(args, name, RUN_STARTUP, &content));
+    TEST_ASSERT_TRUE(test_unit_exists(args->root_dir, ".bootstrap"));
+    TEST_ASSERT_TRUE(test_unit_exists(args->root_dir, ".install"));
+    TEST_ASSERT_TRUE(test_unit_exists(args->root_dir, ""));
+}
+
+// The phases a revised recipe declares drive which units survive. Mirrors the
+// issue's scenario: install dropped, run replaced by startup.
+GG_TEST_DEFINE(stale_units_removed_for_phases_absent_from_recipe) {
+    char root_dir[PATH_MAX];
+    make_test_root(root_dir, sizeof(root_dir));
+
+    static Recipe2UnitArgs args;
+    args = (Recipe2UnitArgs) { 0 };
+    memcpy(args.root_dir, root_dir, strlen(root_dir) + 1);
+
+    GgObject name_obj = gg_obj_buf(GG_STR(TEST_COMPONENT));
+    GgObject *name = &name_obj;
+    write_all_test_units(&args, &name);
+
+    HasPhase revised = { .has_run_startup = true };
+    remove_stale_unit_files(&args, &name, &revised);
+
+    TEST_ASSERT_FALSE(test_unit_exists(root_dir, ".install"));
+    TEST_ASSERT_FALSE(test_unit_exists(root_dir, ".bootstrap"));
+    TEST_ASSERT_TRUE(test_unit_exists(root_dir, ""));
+
+    remove_test_root(root_dir);
+}
+
+// Units of phases the revised recipe still declares must be left in place.
+GG_TEST_DEFINE(units_kept_for_phases_present_in_recipe) {
+    char root_dir[PATH_MAX];
+    make_test_root(root_dir, sizeof(root_dir));
+
+    static Recipe2UnitArgs args;
+    args = (Recipe2UnitArgs) { 0 };
+    memcpy(args.root_dir, root_dir, strlen(root_dir) + 1);
+
+    GgObject name_obj = gg_obj_buf(GG_STR(TEST_COMPONENT));
+    GgObject *name = &name_obj;
+    write_all_test_units(&args, &name);
+
+    HasPhase unchanged = { .has_bootstrap = true,
+                           .has_install = true,
+                           .has_run_startup = true };
+    remove_stale_unit_files(&args, &name, &unchanged);
+
+    TEST_ASSERT_TRUE(test_unit_exists(root_dir, ".bootstrap"));
+    TEST_ASSERT_TRUE(test_unit_exists(root_dir, ".install"));
+    TEST_ASSERT_TRUE(test_unit_exists(root_dir, ""));
+
+    remove_test_root(root_dir);
+}
+
+// Dropping run/startup must NOT remove its unit: that unit is the only one
+// carrying WantedBy=greengrass-lite.target, and the enablement symlink is not
+// cleaned up here.
+GG_TEST_DEFINE(run_startup_unit_kept_even_when_phase_absent) {
+    char root_dir[PATH_MAX];
+    make_test_root(root_dir, sizeof(root_dir));
+
+    static Recipe2UnitArgs args;
+    args = (Recipe2UnitArgs) { 0 };
+    memcpy(args.root_dir, root_dir, strlen(root_dir) + 1);
+
+    GgObject name_obj = gg_obj_buf(GG_STR(TEST_COMPONENT));
+    GgObject *name = &name_obj;
+    write_all_test_units(&args, &name);
+
+    HasPhase install_only = { .has_install = true };
+    remove_stale_unit_files(&args, &name, &install_only);
+
+    TEST_ASSERT_TRUE(test_unit_exists(root_dir, ""));
+    TEST_ASSERT_TRUE(test_unit_exists(root_dir, ".install"));
+    TEST_ASSERT_FALSE(test_unit_exists(root_dir, ".bootstrap"));
+
+    remove_test_root(root_dir);
+}
+
+// Removal tolerates units that were never generated.
+GG_TEST_DEFINE(removing_absent_unit_files_succeeds) {
+    char root_dir[PATH_MAX];
+    make_test_root(root_dir, sizeof(root_dir));
+
+    static Recipe2UnitArgs args;
+    args = (Recipe2UnitArgs) { 0 };
+    memcpy(args.root_dir, root_dir, strlen(root_dir) + 1);
+
+    GgObject name_obj = gg_obj_buf(GG_STR(TEST_COMPONENT));
+    GgObject *name = &name_obj;
+
+    HasPhase none = { .has_run_startup = true };
+    remove_stale_unit_files(&args, &name, &none);
+
+    TEST_ASSERT_FALSE(test_unit_exists(root_dir, ".install"));
+    TEST_ASSERT_FALSE(test_unit_exists(root_dir, ".bootstrap"));
+
+    remove_test_root(root_dir);
+}
+
+#endif

--- a/modules/recipe2unit/src/parser.c
+++ b/modules/recipe2unit/src/parser.c
@@ -89,10 +89,7 @@ static GgError remove_unit_file(
 }
 
 // A revised recipe may drop a phase that a previous revision declared. Remove
-// those unit files, otherwise the stale phase is still run. Run/startup is
-// deliberately excluded: its unit is the only one carrying
-// WantedBy=greengrass-lite.target, so removing the file without also dropping
-// that enablement would leave a dangling symlink behind.
+// those unit files, otherwise the stale phase is still run.
 static void remove_stale_unit_files(
     Recipe2UnitArgs *args,
     GgObject **component_name,
@@ -103,6 +100,15 @@ static void remove_stale_unit_files(
     }
     if (!existing_phases->has_install) {
         (void) remove_unit_file(args, component_name, INSTALL);
+    }
+    // Run and startup share ggl.<component>.service, so a revision swapping one
+    // for the other keeps the phase and is not reached here; only a revision
+    // dropping both is, and then the file is stale. Its enablement symlink is
+    // not cleaned up here, so removing the file leaves that symlink dangling —
+    // still preferable to keeping a unit ggdeploymentd would relink, enable and
+    // start for a phase the recipe no longer declares.
+    if (!existing_phases->has_run_startup) {
+        (void) remove_unit_file(args, component_name, RUN_STARTUP);
     }
 }
 
@@ -375,10 +381,11 @@ GG_TEST_DEFINE(units_kept_for_phases_present_in_recipe) {
     remove_test_root(root_dir);
 }
 
-// Dropping run/startup must NOT remove its unit: that unit is the only one
-// carrying WantedBy=greengrass-lite.target, and the enablement symlink is not
-// cleaned up here.
-GG_TEST_DEFINE(run_startup_unit_kept_even_when_phase_absent) {
+// A revision dropping run/startup while keeping install must not leave the
+// suffix-less unit behind. This branch is reached only when the recipe declares
+// neither run nor startup, so that unit is stale; ggdeploymentd would otherwise
+// relink, enable and start it.
+GG_TEST_DEFINE(run_startup_unit_removed_when_phase_absent) {
     char root_dir[PATH_MAX];
     make_test_root(root_dir, sizeof(root_dir));
 
@@ -393,7 +400,7 @@ GG_TEST_DEFINE(run_startup_unit_kept_even_when_phase_absent) {
     HasPhase install_only = { .has_install = true };
     remove_stale_unit_files(&args, &name, &install_only);
 
-    TEST_ASSERT_TRUE(test_unit_exists(root_dir, ""));
+    TEST_ASSERT_FALSE(test_unit_exists(root_dir, ""));
     TEST_ASSERT_TRUE(test_unit_exists(root_dir, ".install"));
     TEST_ASSERT_FALSE(test_unit_exists(root_dir, ".bootstrap"));
 


### PR DESCRIPTION
## Description

Unit generation in `recipe2unit` was create-only: `convert_to_unit()` wrote a unit per lifecycle phase but never removed one whose phase had gone. Units are named by component with no version, so a dropped phase's unit sat at exactly the path the new revision would use — `O_TRUNC` refreshed survivors and ignored the vanished. The orphan is then read back as recipe truth and the dropped phase keeps being linked, enabled and started, which is the reporter's error.

`remove_stale_unit_files()` reconciles on-disk units against the declared phases, called **after** the "no valid lifecycle step" gate so a recipe failing validation cannot take down the previous revision's units. `run`/`startup` is included — that branch is reached only when a revision declares neither phase, so the unit is stale by construction.

## Related Issue

Fixes #746

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] `nix flake check -L` — not runnable here; `cmake --build` + `ctest` run at CI's configuration. Please rely on this PR's CI.
- [ ] Documentation updated — no user-facing behaviour change.
- [ ] Tests in [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing) — not done; belongs in that repository.

## Documentation Updates

- [ ] README.md — not needed.
- [ ] `docs/` — not needed.
- [ ] Public documentation (aws internal only) — not applicable.

## Testing

- [x] Existing tests pass
- [ ] Added tests to [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [x] New functionality is covered by tests

Four inline tests in `modules/recipe2unit/src/parser.c` under `#ifdef GG_SDK_TESTING`. `NO_INLINE_TEST` was dropped from that module's `CMakeLists.txt` to make them run.

| Test | Verifies |
|---|---|
| `stale_units_removed_for_phases_absent_from_recipe` | dropping `install`+`bootstrap` removes both units |
| `units_kept_for_phases_present_in_recipe` | all three phases declared, nothing removed |
| `run_startup_unit_removed_when_phase_absent` | dropping `run`/`startup` removes its unit; `.install` survives |
| `removing_absent_unit_files_succeeds` | tolerates units never generated |

`4 Tests 0 Failures`; suite 8 passing, up from 7. An oracle, not a restatement — commenting out the `remove_unit_file()` calls turns them red with `Expected FALSE Was TRUE`, the original symptom.

**Verified on a device** — EC2 `c6i.xlarge`, Ubuntu 24.04, real systemd:

| Revision | This branch | Base `b33c3682` |
|---|---|---|
| v1.0.0 `install`+`run` | both units generated | same |
| v1.0.1 `run` only | `.install` removed | persists, stale |
| v1.0.2 `install` only | `.service` removed, `.install` survives | persists, stale |

On the base the stale unit is `enabled`, `active` and `running` with `ExecStart=/usr/bin/recipe-runner … -p run` — running a phase the recipe no longer declares.

## Additional Notes


_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
