### PR TITLE
Leave unresolvable configuration recipe variables as-is (#867)

### DIFF
--- a/modules/ggipcd/src/ipc_authz.c
+++ b/modules/ggipcd/src/ipc_authz.c
@@ -40,6 +40,10 @@ static GgError core_bus_config_reader_impl(
 
     GgObject result;
     ret = ggl_gg_config_read(key_path.buf_list, alloc, &result);
+    if (ret == GG_ERR_NOENTRY) {
+        GG_LOGE("Config key in policy resource does not exist.");
+        return GG_ERR_CONFIG;
+    }
     if (ret != GG_ERR_OK) {
         GG_LOGE("Failed to read config from core bus.");
         return ret;

--- a/modules/ggl-config-interpolation/include/interpolation.h
+++ b/modules/ggl-config-interpolation/include/interpolation.h
@@ -18,7 +18,8 @@
 ///
 /// For configuration variables i.e. "configuration:<json_ptr>" a config
 /// reader callback is required. Pass GGL_CONFIG_NULL_READER to return an error
-/// if config lookup is not desired.
+/// if config lookup is not desired. If the config value does not exist, the
+/// recipe variable is written back unchanged, braces included.
 ///
 /// An error is returned if the escape sequence does not contain a colon or the
 /// namespace-key pair is not recognized.

--- a/modules/ggl-config-interpolation/src/interpolation.c
+++ b/modules/ggl-config-interpolation/src/interpolation.c
@@ -116,7 +116,16 @@ GgError ggl_substitute_escape(
     } else if (gg_buffer_eq(namespace, GG_STR("configuration"))) {
         GgObjectReceiver object_writer
             = { .ctx = &writer, .submit = write_object_as_buffer };
-        return ggl_config_reader_call(config_reader, key, object_writer);
+        GgError config_ret
+            = ggl_config_reader_call(config_reader, key, object_writer);
+        if (config_ret != GG_ERR_NOENTRY) {
+            return config_ret;
+        }
+        // No such config value; write the variable back unchanged.
+        ggl_writer_call_chained(&ret, writer, GG_STR("{"));
+        ggl_writer_call_chained(&ret, writer, recipe_variable);
+        ggl_writer_call_chained(&ret, writer, GG_STR("}"));
+        return ret;
     }
 
     GG_LOGE(
@@ -150,6 +159,32 @@ static GgError dummy_config_reader_call(
 
 static GgConfigReader dummy_config_reader(void) {
     return (GgConfigReader) { .reader = dummy_config_reader_call };
+}
+
+static GgError missing_config_reader_call(
+    void *ctx, GgBuffer key, GgObjectReceiver receiver
+) {
+    (void) ctx;
+    (void) key;
+    (void) receiver;
+    return GG_ERR_NOENTRY;
+}
+
+static GgConfigReader missing_config_reader(void) {
+    return (GgConfigReader) { .reader = missing_config_reader_call };
+}
+
+static GgError failing_config_reader_call(
+    void *ctx, GgBuffer key, GgObjectReceiver receiver
+) {
+    (void) ctx;
+    (void) key;
+    (void) receiver;
+    return GG_ERR_FAILURE;
+}
+
+static GgConfigReader failing_config_reader(void) {
+    return (GgConfigReader) { .reader = failing_config_reader_call };
 }
 
 static GgBuffer run_substitute(GgBuffer escape_seq) {
@@ -207,6 +242,37 @@ GG_TEST_DEFINE(substitute_artifacts_decompressed_path) {
 GG_TEST_DEFINE(substitute_configuration_uses_reader) {
     GgBuffer result = run_substitute(GG_STR("configuration:/some/key"));
     GG_TEST_ASSERT_BUF_EQUAL(GG_STR("dummy_config_value"), result);
+}
+
+GG_TEST_DEFINE(substitute_missing_configuration_left_as_is) {
+    static uint8_t buf[512];
+    GgByteVec vec = GG_BYTE_VEC(buf);
+    GgError ret = ggl_substitute_escape(
+        gg_byte_vec_writer(&vec),
+        GG_STR("configuration:/missing/key"),
+        TEST_ROOT_PATH,
+        TEST_COMPONENT,
+        TEST_VERSION,
+        TEST_THING_NAME,
+        missing_config_reader()
+    );
+    TEST_ASSERT_EQUAL_INT(GG_ERR_OK, ret);
+    GG_TEST_ASSERT_BUF_EQUAL(GG_STR("{configuration:/missing/key}"), vec.buf);
+}
+
+GG_TEST_DEFINE(substitute_configuration_read_error_fails) {
+    static uint8_t buf[64];
+    GgByteVec vec = GG_BYTE_VEC(buf);
+    GgError ret = ggl_substitute_escape(
+        gg_byte_vec_writer(&vec),
+        GG_STR("configuration:/key"),
+        TEST_ROOT_PATH,
+        TEST_COMPONENT,
+        TEST_VERSION,
+        TEST_THING_NAME,
+        failing_config_reader()
+    );
+    TEST_ASSERT_NOT_EQUAL(GG_ERR_OK, ret);
 }
 
 GG_TEST_DEFINE(substitute_configuration_null_reader_fails) {


### PR DESCRIPTION
Fixes #867. 

## Problem

A `{configuration:<json_pointer>}` recipe variable naming a value that does not exist
propagates `GG_ERR_NOENTRY` out of `ggl_substitute_escape`. The error returns
mid-write, so `recipe-runner` truncates the generated lifecycle script there. The
symptom depends on quoting:

- **unquoted** — the truncated line still runs and emits an empty value (`FOO=`), and
  every following line is silently dropped;
- **quoted** — the unterminated string makes the shell reject the script, and the
  component fails `status=2/INVALIDARGUMENT`.

Per the [V2 recipe reference](https://docs.aws.amazon.com/greengrass/v2/developerguide/component-recipe-reference.html#recipe-variables),
a JSON pointer resolving to no node should leave the recipe variable unreplaced. Lite
implemented the value-node and object-node cases but had no third path.

## Fix

```c
GgError config_ret
    = ggl_config_reader_call(config_reader, key, object_writer);
if (config_ret != GG_ERR_NOENTRY) {
    return config_ret;
}
// No such config value; write the variable back unchanged.
ggl_writer_call_chained(&ret, writer, GG_STR("{"));
ggl_writer_call_chained(&ret, writer, recipe_variable);
ggl_writer_call_chained(&ret, writer, GG_STR("}"));
return ret;
```

Gated on `== GG_ERR_NOENTRY` only, so malformed pointers, transport errors and a NULL
reader still propagate. Written through the caller's own writer, so recipe-runner's
shell escaping still applies. Only the `configuration` namespace changes — unknown
namespaces, unknown keys and colon-less escapes still error, as existing tests assert.

**`ipc_authz.c` (4 lines) is not scope creep.** Returning success for a missing value
would let an unresolved `{configuration:/…}` in a policy resource become a literal
match pattern, where an `*` in the missing key acts as a wildcard. Translating an
absent key to `GG_ERR_CONFIG` in `core_bus_config_reader_impl` keeps authorization
fail-closed exactly as before. Ported from an orphaned branch (`fe54b352`).

## Verification

**Unit** — 3 inline tests added, suite 13/13. The oracle fails at base with
`Expected 0 Was 12` (`GG_ERR_OK` vs `GG_ERR_NOENTRY`) and passes here.

**CI** — 16/16 non-UAT checks green, including `clang-tidy`, `iwyu`, `formatting`,
`build-clang`, `build-musl-pi`, `unit-tests`.

**Device** — EC2 `c6i.xlarge`, Ubuntu 24.04, `.deb` built on the device, provenance
asserted at binary level, health gated per-unit with `NRestarts=0`. Same components
deployed to both builds:

| | base `da1728c3` | patched |
|---|---|---|
| resolvable pointer | `helloworld` | `helloworld` |
| unresolvable, unquoted | `FOO=` (blank) | `FOO={configuration:/DoesNotExist}` |
| unresolvable, quoted | fails `2/INVALIDARGUMENT` | left as-is |
| line after the variable | dropped | written |

**UAT** — https://github.com/aws-greengrass/aws-greengrass-testing/pull/324/changes

