### PR TITLE
Restart component when a revision changes its generated unit

### DIFF
--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -3619,10 +3619,10 @@ static void handle_deployment(
 
         // A revision can keep the component version while changing something a
         // generated unit encodes, such as RequiresPrivilege mapping to the
-        // unit's User= and Group=. The version comparison above cannot see that,
-        // so without phases.unit_changed the rewritten unit is never adopted:
-        // the component is skipped, systemd is never reloaded, and the process
-        // keeps running under the old identity.
+        // unit's User= and Group=. The version comparison above cannot see
+        // that, so without phases.unit_changed the rewritten unit is never
+        // adopted: the component is skipped, systemd is never reloaded, and the
+        // process keeps running under the old identity.
         if (component_updated || phases.unit_changed
             || is_component_config_updated(deployment, gg_kv_key(*pair))) {
             ret = gg_kv_vec_push(

--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -3617,7 +3617,13 @@ static void handle_deployment(
             return;
         }
 
-        if (component_updated
+        // A revision can keep the component version while changing something a
+        // generated unit encodes, such as RequiresPrivilege mapping to the
+        // unit's User= and Group=. The version comparison above cannot see that,
+        // so without phases.unit_changed the rewritten unit is never adopted:
+        // the component is skipped, systemd is never reloaded, and the process
+        // keeps running under the old identity.
+        if (component_updated || phases.unit_changed
             || is_component_config_updated(deployment, gg_kv_key(*pair))) {
             ret = gg_kv_vec_push(
                 &components_to_deploy, gg_kv(gg_kv_key(*pair), *gg_kv_val(pair))

--- a/modules/recipe2unit/include/ggl/recipe2unit.h
+++ b/modules/recipe2unit/include/ggl/recipe2unit.h
@@ -15,6 +15,12 @@ typedef struct {
     bool has_install;
     bool has_run_startup;
     bool has_bootstrap;
+    /// Whether generating the units changed any unit file that was already on
+    /// disk, or wrote one that was not there before. A revision that alters
+    /// something a unit encodes only takes effect once the component is
+    /// restarted, so a caller that skips redeployment for an unchanged
+    /// component version needs this to tell the two cases apart.
+    bool unit_changed;
 } HasPhase;
 
 typedef struct {
@@ -34,7 +40,8 @@ typedef struct {
 /// @param[out] recipe_obj The object containing the recipe in a map format
 /// @param[out] component_name The name of the component as provided by the
 /// recipe
-/// @param[out] existing_phases Status of which phases are present
+/// @param[out] existing_phases Status of which phases are present, and whether
+/// any unit file's content changed
 /// @return GG_ERR_OK on success. Failure otherwise.
 GgError convert_to_unit(
     Recipe2UnitArgs *args,

--- a/modules/recipe2unit/src/parser.c
+++ b/modules/recipe2unit/src/parser.c
@@ -173,6 +173,23 @@ static GgError create_unit_file(
     return GG_ERR_OK;
 }
 
+// Writes a phase's unit file and records whether that changed what was already
+// on disk. The two belong together: a phase written without recording the
+// change would leave the caller unable to tell that the component has to be
+// restarted for the new unit to take effect.
+static GgError write_unit_file(
+    Recipe2UnitArgs *args,
+    GgObject **component_name,
+    PhaseSelection phase,
+    GgBuffer *content,
+    HasPhase *existing_phases
+) {
+    if (unit_content_differs(args, component_name, phase, *content)) {
+        existing_phases->unit_changed = true;
+    }
+    return create_unit_file(args, component_name, phase, content);
+}
+
 GgError convert_to_unit(
     Recipe2UnitArgs *args,
     GgArena *alloc,
@@ -227,13 +244,12 @@ GgError convert_to_unit(
     } else if (ret != GG_ERR_OK) {
         return ret;
     } else {
-        if (unit_content_differs(
-                args, component_name, BOOTSTRAP, bootstrap_response_buffer
-            )) {
-            existing_phases->unit_changed = true;
-        }
-        ret = create_unit_file(
-            args, component_name, BOOTSTRAP, &bootstrap_response_buffer
+        ret = write_unit_file(
+            args,
+            component_name,
+            BOOTSTRAP,
+            &bootstrap_response_buffer,
+            existing_phases
         );
         if (ret != GG_ERR_OK) {
             GG_LOGE("Failed to create the bootstrap unit file.");
@@ -262,13 +278,12 @@ GgError convert_to_unit(
     } else if (ret != GG_ERR_OK) {
         return ret;
     } else {
-        if (unit_content_differs(
-                args, component_name, INSTALL, install_response_buffer
-            )) {
-            existing_phases->unit_changed = true;
-        }
-        ret = create_unit_file(
-            args, component_name, INSTALL, &install_response_buffer
+        ret = write_unit_file(
+            args,
+            component_name,
+            INSTALL,
+            &install_response_buffer,
+            existing_phases
         );
         if (ret != GG_ERR_OK) {
             GG_LOGE("Failed to create the install unit file.");
@@ -289,13 +304,12 @@ GgError convert_to_unit(
     } else if (ret != GG_ERR_OK) {
         return ret;
     } else {
-        if (unit_content_differs(
-                args, component_name, RUN_STARTUP, run_startup_response_buffer
-            )) {
-            existing_phases->unit_changed = true;
-        }
-        ret = create_unit_file(
-            args, component_name, RUN_STARTUP, &run_startup_response_buffer
+        ret = write_unit_file(
+            args,
+            component_name,
+            RUN_STARTUP,
+            &run_startup_response_buffer,
+            existing_phases
         );
         if (ret != GG_ERR_OK) {
             GG_LOGE("Failed to create the run or startup unit file.");
@@ -501,14 +515,12 @@ GG_TEST_DEFINE(revised_unit_content_reported_as_changed) {
     TEST_ASSERT_TRUE(
         unit_content_differs(&args, &name, RUN_STARTUP, unprivileged)
     );
-    GG_TEST_ASSERT_OK(
-        create_unit_file(&args, &name, RUN_STARTUP, &unprivileged)
+    GG_TEST_ASSERT_OK(create_unit_file(&args, &name, RUN_STARTUP, &unprivileged)
     );
     TEST_ASSERT_TRUE(test_unit_exists(root_dir, ""));
 
     // The revision: same component, same phase, privileged this time.
-    TEST_ASSERT_TRUE(
-        unit_content_differs(&args, &name, RUN_STARTUP, privileged)
+    TEST_ASSERT_TRUE(unit_content_differs(&args, &name, RUN_STARTUP, privileged)
     );
 
     remove_test_root(root_dir);

--- a/modules/recipe2unit/src/parser.c
+++ b/modules/recipe2unit/src/parser.c
@@ -112,6 +112,38 @@ static void remove_stale_unit_files(
     }
 }
 
+// Whether the unit file already on disk for a phase differs from the content
+// about to be written for it. create_unit_file opens with O_TRUNC, so the two
+// versions coexist only until it runs and the comparison has to happen first:
+// nothing persists a digest of a component's units between deployments, so once
+// the old bytes are gone no caller can recover them. A phase with no unit file
+// yet counts as differing, since generating one is itself the change.
+static bool unit_content_differs(
+    Recipe2UnitArgs *args,
+    GgObject **component_name,
+    PhaseSelection phase,
+    GgBuffer content
+) {
+    GgBuffer path = { 0 };
+    if (unit_file_path(args, component_name, phase, &path) != GG_ERR_OK) {
+        return true;
+    }
+
+    int fd = -1;
+    if (gg_file_open(path, O_RDONLY, 0, &fd) != GG_ERR_OK) {
+        return true;
+    }
+    GG_CLEANUP(cleanup_close, fd);
+
+    static uint8_t existing_content[MAX_UNIT_FILE_BUF_SIZE];
+    GgBuffer existing = GG_BUF(existing_content);
+    if (gg_file_read(fd, &existing) != GG_ERR_OK) {
+        return true;
+    }
+
+    return !gg_buffer_eq(existing, content);
+}
+
 static GgError create_unit_file(
     Recipe2UnitArgs *args,
     GgObject **component_name,
@@ -195,6 +227,11 @@ GgError convert_to_unit(
     } else if (ret != GG_ERR_OK) {
         return ret;
     } else {
+        if (unit_content_differs(
+                args, component_name, BOOTSTRAP, bootstrap_response_buffer
+            )) {
+            existing_phases->unit_changed = true;
+        }
         ret = create_unit_file(
             args, component_name, BOOTSTRAP, &bootstrap_response_buffer
         );
@@ -225,6 +262,11 @@ GgError convert_to_unit(
     } else if (ret != GG_ERR_OK) {
         return ret;
     } else {
+        if (unit_content_differs(
+                args, component_name, INSTALL, install_response_buffer
+            )) {
+            existing_phases->unit_changed = true;
+        }
         ret = create_unit_file(
             args, component_name, INSTALL, &install_response_buffer
         );
@@ -247,6 +289,11 @@ GgError convert_to_unit(
     } else if (ret != GG_ERR_OK) {
         return ret;
     } else {
+        if (unit_content_differs(
+                args, component_name, RUN_STARTUP, run_startup_response_buffer
+            )) {
+            existing_phases->unit_changed = true;
+        }
         ret = create_unit_file(
             args, component_name, RUN_STARTUP, &run_startup_response_buffer
         );
@@ -424,6 +471,69 @@ GG_TEST_DEFINE(removing_absent_unit_files_succeeds) {
 
     TEST_ASSERT_FALSE(test_unit_exists(root_dir, ".install"));
     TEST_ASSERT_FALSE(test_unit_exists(root_dir, ".bootstrap"));
+
+    remove_test_root(root_dir);
+}
+
+// A revision that changes RequiresPrivilege changes the unit's User=/Group=.
+// Rewriting the file does nothing to a process already running under the old
+// identity, so the caller has to be told the unit changed in order to restart
+// the component. The comparison has to happen before create_unit_file's O_TRUNC
+// destroys the previous content, which is what makes this a property of unit
+// generation rather than something the caller could work out for itself.
+GG_TEST_DEFINE(revised_unit_content_reported_as_changed) {
+    char root_dir[PATH_MAX];
+    make_test_root(root_dir, sizeof(root_dir));
+
+    static Recipe2UnitArgs args;
+    args = (Recipe2UnitArgs) { 0 };
+    memcpy(args.root_dir, root_dir, strlen(root_dir) + 1);
+
+    GgObject name_obj = gg_obj_buf(GG_STR(TEST_COMPONENT));
+    GgObject *name = &name_obj;
+
+    GgBuffer unprivileged = GG_STR("[Service]\nUser=ggcore\nGroup=ggcore\n");
+    GgBuffer privileged = GG_STR("[Service]\nUser=root\nGroup=root\n");
+
+    // Gate the first deployment as a hard precondition. Without it, the
+    // assertion below could report "changed" because no unit was ever written,
+    // which is the expected answer for entirely the wrong reason.
+    TEST_ASSERT_TRUE(
+        unit_content_differs(&args, &name, RUN_STARTUP, unprivileged)
+    );
+    GG_TEST_ASSERT_OK(
+        create_unit_file(&args, &name, RUN_STARTUP, &unprivileged)
+    );
+    TEST_ASSERT_TRUE(test_unit_exists(root_dir, ""));
+
+    // The revision: same component, same phase, privileged this time.
+    TEST_ASSERT_TRUE(
+        unit_content_differs(&args, &name, RUN_STARTUP, privileged)
+    );
+
+    remove_test_root(root_dir);
+}
+
+// A deployment that changes nothing about a component must not report a change,
+// because the caller restarts on this signal and restarting a healthy running
+// component for no reason is a regression rather than a fix.
+GG_TEST_DEFINE(unrevised_unit_content_reported_as_unchanged) {
+    char root_dir[PATH_MAX];
+    make_test_root(root_dir, sizeof(root_dir));
+
+    static Recipe2UnitArgs args;
+    args = (Recipe2UnitArgs) { 0 };
+    memcpy(args.root_dir, root_dir, strlen(root_dir) + 1);
+
+    GgObject name_obj = gg_obj_buf(GG_STR(TEST_COMPONENT));
+    GgObject *name = &name_obj;
+
+    GgBuffer content = GG_STR("[Service]\nUser=ggcore\nGroup=ggcore\n");
+
+    GG_TEST_ASSERT_OK(create_unit_file(&args, &name, RUN_STARTUP, &content));
+    TEST_ASSERT_TRUE(test_unit_exists(root_dir, ""));
+
+    TEST_ASSERT_FALSE(unit_content_differs(&args, &name, RUN_STARTUP, content));
 
     remove_test_root(root_dir);
 }


### PR DESCRIPTION
## Description

A component revision that keeps the same version but edits the recipe rewrites the generated systemd
unit and then never applies it. `RequiresPrivilege` is the visible case, since it maps to the unit's
`User=`/`Group=`: the file on disk gets `User=root`, the process keeps running as `ggcore`, and the
deployment reports success.

**Root cause.** `convert_to_unit()` (`deployment_handler.c:3607`) regenerates units unconditionally,
*above* the redeploy gate. The gate at `:3620` was `component_updated || is_component_config_updated(...)`,
where `component_updated` is decided by version-string equality alone (`:3310-3334`, next to a TODO
naming this exact gap) and `is_component_config_updated()` inspects only the deployment document's
`configurationUpdate`. Neither consults the recipe. On a same-version revision both are false,
gghealthd reports the component `RUNNING`, and `:3674` logs `"Component ... is already running. Will
not redeploy."` — so the component never enters `components_to_deploy` and everything behind
`if (components_to_deploy.map.len != 0)` is skipped as a set: the `systemctl stop`, the `link`, the
`enable`, and the only `daemon-reload`. The trailing `systemctl start greengrass-lite.target` is a
no-op on an already-active unit.

This also explains the reporter's workaround: removing the component deletes `services/<name>` wholesale
(`stale_component.c:207`), so the next deployment finds no previous version and treats it as new.

**The change.** `convert_to_unit()` now reports whether generating the units actually changed any unit
file, via a new `HasPhase.unit_changed`, and the gate honours it. The comparison must happen inside unit
generation because `create_unit_file()` opens with `O_TRUNC`: old and new content coexist only until it
runs, and nothing persists a digest between deployments, so afterwards no caller could recover it.

Everything the issue asks for — regenerate, `daemon-reload`, restart — is then done by code that already
existed and was simply unreached. The production change is **one conditional**, one comparison helper,
and one struct field.

Keying on "did the generated unit change?" rather than on `RequiresPrivilege` specifically is both
smaller and more general: it covers every recipe field the unit encodes, and it makes the no-op case
free, because an unchanged recipe generates byte-identical content and so restarts nothing.

## Related Issue

Fixes #954

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] Code passes all the quality test. Can try `nix flake check -L` locally
      — **could not be run**: `nix` is not installed on the dev host, nor are `clang-format`,
      `clang-tidy`, `cmake-format`, `gersemi`, `prettier`, `cspell` or `shellcheck`. So `clang-tidy`,
      `iwyu`, `cmake-lint`, `spelling`, `build-clang`, `build-musl-pi`, the formatter check and UAT run
      here in CI for the first time. Style was conformed to `.editorconfig` and surrounding code by
      inspection. Flagging rather than ticking.
- [ ] **Documentation updated** (if applicable) — not applicable, verified rather than assumed: no prose
      documentation describes the redeploy decision or `RequiresPrivilege` adoption semantics.
      `RequiresPrivilege` appears only in three example fixtures under
      `docs/examples/supported_lifecyle_types/`, and `docs/design/ggdeploymentd-design.md` has no
      description of restart or redeploy behaviour.
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable) — not added there. Two inline unit tests ship in this PR, and the end-to-end
      behaviour was verified on a device (below). Happy to add a UAT case if you'd prefer it there.

## Documentation Updates

- [ ] Updated README.md if needed — not needed; no README statement is affected.
- [ ] Updated relevant documentation in `docs/` folder — not needed; see above.
- [ ] Requested to update public documentation if applicable (aws internal only) — not requested. If the
      reboot consequence below is accepted as intended behaviour, it may deserve a public-doc note.

## Testing

- [x] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [x] New functionality is covered by tests

**Unit** — two inline tests in `modules/recipe2unit/src/parser.c`; `recipe2unit-inline-test` goes 4 → 6
tests, 0 failures. `revised_unit_content_reported_as_changed` covers the reported case and gates the
first deployment as a hard precondition, so it cannot pass because no unit was ever written.
`unrevised_unit_content_reported_as_unchanged` covers the no-op case.

Each test was verified to bind one direction of the behaviour: neutralising the comparison to always
report changed fails only the second test, and to never report changed fails only the first. Full suite
and build are unchanged from base — the same 3 pre-existing `Not Run` targets and the same 13
pre-existing failed objects, all missing system libraries on the dev host (OpenSSL 3.x headers,
`systemd/sd-bus.h`, old `uriparser`). Zero diagnostics in the touched files.

**On a device** (EC2, Ubuntu 24.04, both `.deb`s built on the host, torn down afterwards). Same version
`1.0.0` both steps, recipe edited in place, component deployed alone:

| | unit file | process owner | MainPID |
|---|---|---|---|
| base `d3c2fa3f` step 1 | `User=ggcore` | ggcore | 14441 |
| base `d3c2fa3f` step 2 | `User=root` | **ggcore** | **14441** |
| patched step 1 | `User=ggcore` | ggcore | 2494 |
| patched step 2 | `User=root` | **root** | **2884** |

The MainPID is the discriminator: unchanged on base proves the process was never restarted; changed on
the patched build proves it was. Both directions passed the same precondition gate, and the running
`ggdeploymentd` binary was asserted by hash against the expected artifact in each.

Note for anyone reproducing: a **version bump** does not reproduce this. It leaves `component_updated`
true and routes around the defect entirely.

## Additional Notes

**Two consequences worth your decision, neither hidden:**

1. **A same-version recipe edit can now reboot the device, for components that declare a `bootstrap`
   phase.** Entering `components_to_deploy` means `process_bootstrap_phase()` runs, and it ends in
   `systemctl reboot` when it counts any bootstrap component (`bootstrap_manager.c:632`). Since
   `ComponentDescription` is embedded in the unit as `Description=`, even a cosmetic edit qualifies. A
   version bump on such a component already reboots today, so this makes same-version edits behave like
   version bumps — but it is a policy call about how aggressively lite should adopt a revision, and it's
   yours, not mine. The narrower alternative is to exclude cosmetic fields from the comparison; I did
   not take it because it needs a field allowlist that is silently wrong the moment a field is added.
2. **The signal is not idempotent across a failed-then-retried deployment.** `services/<name>/version`
   is written unconditionally at `:3384`, well before the gate, so if a deployment fails *after* unit
   generation, a retry sees a matching version and matching on-disk units and skips the component again.
   This is not introduced here — at base the same-version case never worked at all — but it bounds the
   fix. The robust form persists a digest of the generated units alongside the version, which belongs
   with the standing TODO at `:3709` about `HasPhase` being populated and then ignored.

**One question for you:** `HasPhase.unit_changed` puts a field that is not about phases on a type called
`HasPhase`. I chose it over a new out-param because `HasPhase` is already the out-param bundle the
caller declares, so no signature change is needed and the `test_modules/recipe2unit-test` example driver
keeps compiling (verified with `-DBUILD_EXAMPLES=1`). Happy to rename the type if you'd rather.

**Correctness note:** the comparison uses `gg_file_read`, which returns the true byte count at EOF. The
sibling `gg_file_read_exact` would have made every sub-2048-byte unit report "changed", silently turning
this into "restart everything on every deployment". Failure directions are all conservative — an absent
or unreadable unit counts as changed — so the fix can cause an unnecessary restart but never miss a real
change. This does rely on unit generation being deterministic for a fixed recipe, which it is today
(no timestamp, pid or ordering dependence); a future non-deterministic field would break the no-op case.

**Out of scope, filed separately in spirit:** `unit_file_generator.c:761` `fchown`s a component's work
directory to the configured `posixUser` unconditionally, never consulting `is_root`, so a privileged
component runs as root with a `ggcore`-owned work directory. That is the second half of what #954
reports, but it is wrong on a *first* deployment too, so it is an independent defect and folding it in
would have widened this diff.

_This PR was prepared with AI assistance; every claim above was verified by execution on the device or
in the test suite._

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
