### PR TITLE
Enabled greengrass components to receive direct message by opting for RECEIVE_ONLY mode

### DIFF
--- a/docs/spec/core-bus-interface/aws_iot_mqtt.md
+++ b/docs/spec/core-bus-interface/aws_iot_mqtt.md
@@ -57,8 +57,27 @@ the subscription responses.
     provided.
   - [aws-iot-mqtt-subscribe-3.3] QoS 0 and 1 are supported (AWS IoT Core does
     not support QoS 2).
+- [aws-iot-mqtt-subscribe-4] `virtual` is an optional parameter of type boolean.
+  - [aws-iot-mqtt-subscribe-4.1] `virtual` registers the topic filters for
+    on-device routing only. No MQTT subscribe is sent to AWS IoT Core.
+  - [aws-iot-mqtt-subscribe-4.2] `false` is the default when `virtual` is not
+    provided.
+  - [aws-iot-mqtt-subscribe-4.3] A virtual subscription receives any message
+    that reaches the device on a matching topic. This covers messages that AWS
+    IoT Core delivers without a subscription, such as direct messages addressed
+    to the device by client ID, and responses sent automatically in reply to a
+    publish.
+  - [aws-iot-mqtt-subscribe-4.4] `qos` has no effect when `virtual` is `true`.
+  - [aws-iot-mqtt-subscribe-4.5] Closing a virtual subscription sends no MQTT
+    unsubscribe.
+  - [aws-iot-mqtt-subscribe-4.6] A virtual subscription is not subscribed again
+    after an MQTT reconnection. It continues to receive without any action,
+    because it never depended on an MQTT subscription.
+  - [aws-iot-mqtt-subscribe-4.7] A virtual subscription does not keep an MQTT
+    subscription alive for a topic filter it shares with a non-virtual
+    subscription.
 
 ### Response
 
-- [aws-iot-mqtt-subscribe-4] Subscription responses are maps containing `topic`
+- [aws-iot-mqtt-subscribe-5] Subscription responses are maps containing `topic`
   and `payload` keys, each of which have values of type buffer.

--- a/modules/ggipcd/src/services/mqttproxy/subscribe_to_iot_core.c
+++ b/modules/ggipcd/src/services/mqttproxy/subscribe_to_iot_core.c
@@ -18,6 +18,7 @@
 #include <gg/object.h>
 #include <gg/types.h>
 #include <ggl/core_bus/aws_iot_mqtt.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -68,6 +69,48 @@ static GgError subscribe_to_iot_core_callback(
     return GG_ERR_OK;
 }
 
+/// Parse the optional subscriptionMode field.
+///
+/// RECEIVE_ONLY sets `receive_only`: the topic filter is registered for
+/// on-device routing only, with no cloud subscription. This is how a
+/// component receives AWS IoT Core direct messages.
+///
+/// Absent, null, and SUBSCRIBE_AND_RECEIVE all mean a normal cloud subscribe.
+/// Any other value is rejected instead of silently creating a cloud
+/// subscription.
+static GgError parse_subscription_mode(
+    GgObject *mode_obj, GglIpcError *ipc_error, bool *receive_only
+) {
+    *receive_only = false;
+
+    if ((mode_obj == NULL) || (gg_obj_type(*mode_obj) == GG_TYPE_NULL)) {
+        return GG_ERR_OK;
+    }
+
+    if (gg_obj_type(*mode_obj) != GG_TYPE_BUF) {
+        GG_LOGE("Key subscriptionMode of invalid type.");
+        *ipc_error = (GglIpcError
+        ) { .error_code = GGL_IPC_ERR_INVALID_ARGUMENTS,
+            .message = GG_STR("Key subscriptionMode of invalid type.") };
+        return GG_ERR_INVALID;
+    }
+
+    GgBuffer mode = gg_obj_into_buf(*mode_obj);
+    if (gg_buffer_eq(mode, GG_STR("RECEIVE_ONLY"))) {
+        *receive_only = true;
+        return GG_ERR_OK;
+    }
+    if (gg_buffer_eq(mode, GG_STR("SUBSCRIBE_AND_RECEIVE"))) {
+        return GG_ERR_OK;
+    }
+
+    GG_LOGE("'subscriptionMode' not a valid value.");
+    *ipc_error = (GglIpcError
+    ) { .error_code = GGL_IPC_ERR_INVALID_ARGUMENTS,
+        .message = GG_STR("'subscriptionMode' not a valid value.") };
+    return GG_ERR_INVALID;
+}
+
 GgError ggl_handle_subscribe_to_iot_core(
     const GglIpcOperationInfo *info,
     GgMap args,
@@ -80,11 +123,16 @@ GgError ggl_handle_subscribe_to_iot_core(
 
     GgObject *topic_name_obj;
     GgObject *qos_obj;
+    GgObject *subscription_mode_obj;
     GgError ret = gg_map_validate(
         args,
         GG_MAP_SCHEMA(
             { GG_STR("topicName"), GG_REQUIRED, GG_TYPE_BUF, &topic_name_obj },
             { GG_STR("qos"), GG_OPTIONAL, GG_TYPE_NULL, &qos_obj },
+            { GG_STR("subscriptionMode"),
+              GG_OPTIONAL,
+              GG_TYPE_NULL,
+              &subscription_mode_obj },
         )
     );
     if (ret != GG_ERR_OK) {
@@ -96,8 +144,18 @@ GgError ggl_handle_subscribe_to_iot_core(
     }
     GgBuffer topic_name = gg_obj_into_buf(*topic_name_obj);
 
+    bool receive_only;
+    ret = parse_subscription_mode(
+        subscription_mode_obj, ipc_error, &receive_only
+    );
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+
+    // qos configures the cloud subscription. RECEIVE_ONLY creates none, so qos
+    // is ignored in that mode and is neither parsed nor validated.
     int64_t qos = 0;
-    if (qos_obj != NULL) {
+    if (!receive_only && (qos_obj != NULL)) {
         switch (gg_obj_type(*qos_obj)) {
         case GG_TYPE_BUF:
             ret = gg_str_to_int64(gg_obj_into_buf(*qos_obj), &qos);
@@ -139,9 +197,12 @@ GgError ggl_handle_subscribe_to_iot_core(
         return GG_ERR_INVALID;
     }
 
+    // `virtual` tells iotcored to register the filter for on-device routing
+    // without sending a cloud SUBSCRIBE.
     GgMap call_args = GG_MAP(
         gg_kv(GG_STR("topic_filter"), *topic_name_obj),
         gg_kv(GG_STR("qos"), gg_obj_i64(qos)),
+        gg_kv(GG_STR("virtual"), gg_obj_bool(receive_only)),
     );
 
     ret = ggl_ipc_bind_subscription(

--- a/modules/iotcored/src/bus_server.c
+++ b/modules/iotcored/src/bus_server.c
@@ -141,9 +141,13 @@ static GgError rpc_subscribe(void *ctx, GgMap params, uint32_t handle) {
         return GG_ERR_INVALID;
     }
 
-    bool virtual = false;
+    bool is_virtual = false;
     if (gg_map_get(params, GG_STR("virtual"), &val)) {
-        virtual = gg_obj_into_bool(*val);
+        if (gg_obj_type(*val) != GG_TYPE_BOOLEAN) {
+            GG_LOGE("Subscribe received invalid arguments.");
+            return GG_ERR_INVALID;
+        }
+        is_virtual = gg_obj_into_bool(*val);
     }
 
     for (size_t i = 0; i < topic_filter_count; i++) {
@@ -168,13 +172,13 @@ static GgError rpc_subscribe(void *ctx, GgMap params, uint32_t handle) {
     }
 
     GgError ret = iotcored_register_subscriptions(
-        topic_filters, topic_filter_count, handle, qos
+        topic_filters, topic_filter_count, handle, qos, is_virtual
     );
     if (ret != GG_ERR_OK) {
         return ret;
     }
 
-    if (!virtual) {
+    if (!is_virtual) {
         ret = iotcored_mqtt_subscribe(topic_filters, topic_filter_count, qos);
         if (ret != GG_ERR_OK) {
             iotcored_unregister_subscriptions(handle, false);

--- a/modules/iotcored/src/subscription_dispatch.c
+++ b/modules/iotcored/src/subscription_dispatch.c
@@ -34,6 +34,10 @@ static uint8_t sub_topic_filters[IOTCORED_MAX_SUBSCRIPTIONS]
                                 [AWS_IOT_MAX_TOPIC_SIZE];
 static uint32_t handles[IOTCORED_MAX_SUBSCRIPTIONS];
 static uint8_t topic_qos[IOTCORED_MAX_SUBSCRIPTIONS];
+/// True if the slot is a virtual registration: routed to like any other slot,
+/// but with no cloud subscription behind it (never subscribed, unsubscribed,
+/// or re-subscribed with AWS IoT Core).
+static bool sub_virtual[IOTCORED_MAX_SUBSCRIPTIONS];
 static pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
 
 static uint32_t mqtt_status_handles[IOTCORED_MAX_SUBSCRIPTIONS];
@@ -46,7 +50,11 @@ static GgBuffer topic_filter_buf(size_t index) {
 }
 
 GgError iotcored_register_subscriptions(
-    GgBuffer *topic_filters, size_t count, uint32_t handle, uint8_t qos
+    GgBuffer *topic_filters,
+    size_t count,
+    uint32_t handle,
+    uint8_t qos,
+    bool is_virtual
 ) {
     for (size_t i = 0; i < count; i++) {
         if (topic_filters[i].len == 0) {
@@ -76,6 +84,7 @@ GgError iotcored_register_subscriptions(
             );
             handles[i] = handle;
             topic_qos[i] = qos;
+            sub_virtual[i] = is_virtual;
             filter_index += 1;
             if (filter_index == count) {
                 return GG_ERR_OK;
@@ -87,61 +96,71 @@ GgError iotcored_register_subscriptions(
     for (size_t i = 0; i < IOTCORED_MAX_SUBSCRIPTIONS; i++) {
         if (handles[i] == handle) {
             topic_filter_len[i] = 0;
+            sub_virtual[i] = false;
         }
     }
 
     return GG_ERR_NOMEM;
 }
 
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+/// True if another slot holds a cloud subscription to the same topic filter.
+/// Virtual slots don't count, as they have no cloud subscription.
+static bool cloud_sub_shares_filter(size_t index) {
+    for (size_t i = 0; i < IOTCORED_MAX_SUBSCRIPTIONS; i++) {
+        if ((i == index) || (topic_filter_len[i] == 0) || sub_virtual[i]) {
+            continue;
+        }
+        if ((topic_filter_len[i] == topic_filter_len[index])
+            && (memcmp(
+                    sub_topic_filters[index],
+                    sub_topic_filters[i],
+                    topic_filter_len[index]
+                )
+                == 0)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void iotcored_unregister_subscriptions(uint32_t handle, bool unsubscribe) {
     GG_MTX_SCOPE_GUARD(&mtx);
 
     for (size_t i = 0; i < IOTCORED_MAX_SUBSCRIPTIONS; i++) {
-        if (handles[i] == handle) {
-            if (unsubscribe) {
-                size_t j;
-                for (j = 0; j < IOTCORED_MAX_SUBSCRIPTIONS; j++) {
-                    if (i == j) {
-                        continue;
-                    }
-                    if ((topic_filter_len[j] != 0)
-                        && (topic_filter_len[i] == topic_filter_len[j])
-                        && (memcmp(
-                                sub_topic_filters[i],
-                                sub_topic_filters[j],
-                                topic_filter_len[i]
-                            )
-                            == 0)) {
-                        // Found a matching topic filter. No need to check
-                        // further.
-                        break;
-                    }
-                }
-
-                // This is the only subscription to this topic. Send an
-                // unsubscribe.
-                if (j == IOTCORED_MAX_SUBSCRIPTIONS) {
-                    GgBuffer buf[] = { topic_filter_buf(i) };
-                    // TODO: Should these be retried? If offline, should be
-                    // queued up until online?
-                    (void) iotcored_mqtt_unsubscribe(buf, 1U);
-                }
-            }
-
-            topic_filter_len[i] = 0;
+        // A freed slot keeps its stale handle, so only act on live slots.
+        if ((topic_filter_len[i] == 0) || (handles[i] != handle)) {
+            continue;
         }
+
+        // Send an MQTT unsubscribe only if this slot was the last cloud
+        // subscription on the filter. Virtual slots never subscribed, so
+        // there is nothing to unsubscribe.
+        if (unsubscribe && !sub_virtual[i] && !cloud_sub_shares_filter(i)) {
+            GgBuffer buf[] = { topic_filter_buf(i) };
+            // TODO: Should these be retried? If offline, should be
+            // queued up until online?
+            (void) iotcored_mqtt_unsubscribe(buf, 1U);
+        }
+
+        topic_filter_len[i] = 0;
+        sub_virtual[i] = false;
     }
 }
 
 void iotcored_mqtt_receive(const IotcoredMsg *msg) {
     GG_MTX_SCOPE_GUARD(&mtx);
 
+    bool matched = false;
+
+    // Matching is by topic filter alone; virtual slots receive the same way
+    // as cloud ones. This is how a virtual registration receives AWS IoT Core
+    // direct messages, which arrive without any cloud subscription.
     for (size_t i = 0; i < IOTCORED_MAX_SUBSCRIPTIONS; i++) {
         if ((topic_filter_len[i] != 0)
             && iotcored_mqtt_topic_filter_match(
                 topic_filter_buf(i), msg->topic
             )) {
+            matched = true;
             ggl_sub_respond(
                 handles[i],
                 gg_obj_map(GG_MAP(
@@ -150,6 +169,14 @@ void iotcored_mqtt_receive(const IotcoredMsg *msg) {
                 ))
             );
         }
+    }
+
+    if (!matched) {
+        GG_LOGW(
+            "Dropping message on topic %.*s: no matching subscription.",
+            (int) msg->topic.len,
+            msg->topic.data
+        );
     }
 }
 
@@ -188,19 +215,27 @@ void iotcored_re_register_all_subs(void) {
     GG_MTX_SCOPE_GUARD(&mtx);
 
     for (size_t i = 0; i < IOTCORED_MAX_SUBSCRIPTIONS; i++) {
-        if (topic_filter_len[i] != 0) {
-            GgBuffer buffer
-                = { .data = sub_topic_filters[i], .len = topic_filter_len[i] };
-            GG_LOGD(
-                "Subscribing again to:  %.*s",
-                (int) topic_filter_len[i],
-                sub_topic_filters[i]
-            );
-            if (iotcored_mqtt_subscribe(&buffer, 1, topic_qos[i])
-                != GG_ERR_OK) {
-                topic_filter_len[i] = 0;
-                GG_LOGE("Failed to subscribe to topic filter.");
-            }
+        if (topic_filter_len[i] == 0) {
+            continue;
+        }
+
+        // A virtual slot has no cloud subscription to restore; it keeps
+        // receiving without any action. Subscribing it here would silently
+        // turn it into a cloud subscription.
+        if (sub_virtual[i]) {
+            continue;
+        }
+
+        GgBuffer buffer
+            = { .data = sub_topic_filters[i], .len = topic_filter_len[i] };
+        GG_LOGD(
+            "Subscribing again to:  %.*s",
+            (int) topic_filter_len[i],
+            sub_topic_filters[i]
+        );
+        if (iotcored_mqtt_subscribe(&buffer, 1, topic_qos[i]) != GG_ERR_OK) {
+            topic_filter_len[i] = 0;
+            GG_LOGE("Failed to subscribe to topic filter.");
         }
     }
 }

--- a/modules/iotcored/src/subscription_dispatch.h
+++ b/modules/iotcored/src/subscription_dispatch.h
@@ -11,8 +11,16 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/// Register topic filters for on-device routing under `handle`.
+/// `is_virtual` marks the registration as having no cloud subscription:
+/// matching inbound messages are still routed to `handle`, but the filter is
+/// never subscribed, unsubscribed, or re-subscribed with AWS IoT Core.
 GgError iotcored_register_subscriptions(
-    GgBuffer *topic_filters, size_t count, uint32_t handle, uint8_t qos
+    GgBuffer *topic_filters,
+    size_t count,
+    uint32_t handle,
+    uint8_t qos,
+    bool is_virtual
 );
 
 void iotcored_unregister_subscriptions(uint32_t handle, bool unsubscribe);


### PR DESCRIPTION
## Description

Adds an on-device path for AWS IoT Core direct messages. A component can
subscribe over IPC with `subscriptionMode=RECEIVE_ONLY`; iotcored registers the
topic filter for local routing only and never issues a cloud SUBSCRIBE. Any
message that reaches the device on a matching filter — including direct messages
addressed to the device by client id, which arrive over the existing connection
with no subscription — is delivered to the subscribing component. A message
matching no subscriber is now dropped and logged instead of silently discarded.

Changes by component:

- **ggipcd (`SubscribeToIoTCore`)**: new optional `subscriptionMode`.
  `RECEIVE_ONLY` maps to a routing-only (virtual) subscription; absent, null,
  and `SUBSCRIBE_AND_RECEIVE` keep the existing cloud-subscribe path unchanged;
  any other value is rejected with `InvalidArgumentsError` (fail closed rather
  than silently creating a paid cloud subscription). `qos` is ignored for
  `RECEIVE_ONLY` since there is no cloud subscription to configure.

- **iotcored + core bus (`aws_iot_mqtt` `subscribe`)**: new `virtual` flag.
  A virtual registration sends no cloud SUBSCRIBE, sends no UNSUBSCRIBE on close,
  is not re-subscribed on MQTT reconnect, and does not keep a cloud subscription
  alive for a filter it shares with a cloud subscription. Inbound dispatch
  matches virtual and cloud slots identically (by topic filter), which is what
  lets a virtual slot receive direct messages. A message matching no slot is
  dropped with a warning log.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [ ] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [x] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [ ] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
