### PR TITLE
Retry TES credential retrieval during cloud deployments

### DIFF
--- a/modules/ggdeploymentd/src/deployment_handler.c
+++ b/modules/ggdeploymentd/src/deployment_handler.c
@@ -15,6 +15,7 @@
 #include "iotcored_instance.h"
 #include "priv_io.h"
 #include "stale_component.h"
+#include "tes_getter.h"
 #include <assert.h>
 #include <dirent.h>
 #include <errno.h>
@@ -85,13 +86,6 @@ static atomic_bool deployment_in_progress;
 bool ggl_deployment_in_progress(void) {
     return atomic_load(&deployment_in_progress);
 }
-
-typedef struct TesCredentials {
-    GgBuffer aws_region;
-    GgBuffer access_key_id;
-    GgBuffer secret_access_key;
-    GgBuffer session_token;
-} TesCredentials;
 
 // vector to track successfully deployed components to be saved for bootstrap
 // component name -> map of lifecycle state and version
@@ -366,59 +360,6 @@ static GgError get_rootca_path(GgByteVec *rootca_path) {
     gg_byte_vec_chain_append(&ret, rootca_path, gg_obj_into_buf(resp));
     gg_byte_vec_chain_push(&ret, rootca_path, '\0');
     return ret;
-}
-
-static GgError get_tes_credentials(TesCredentials *tes_creds) {
-    GgObject *aws_access_key_id = NULL;
-    GgObject *aws_secret_access_key = NULL;
-    GgObject *aws_session_token = NULL;
-
-    static uint8_t credentials_alloc[1500];
-    static GgBuffer tesd = GG_STR("aws_iot_tes");
-    GgObject result;
-    GgMap params = { 0 };
-    GgArena credential_alloc = gg_arena_init(GG_BUF(credentials_alloc));
-
-    GgError ret = ggl_call(
-        tesd,
-        GG_STR("request_credentials"),
-        params,
-        NULL,
-        &credential_alloc,
-        &result
-    );
-    if (ret != GG_ERR_OK) {
-        GG_LOGE("Failed to get TES credentials.");
-        return GG_ERR_FAILURE;
-    }
-
-    ret = gg_map_validate(
-        gg_obj_into_map(result),
-        GG_MAP_SCHEMA(
-            { GG_STR("accessKeyId"),
-              GG_REQUIRED,
-              GG_TYPE_BUF,
-              &aws_access_key_id },
-            { GG_STR("secretAccessKey"),
-              GG_REQUIRED,
-              GG_TYPE_BUF,
-              &aws_secret_access_key },
-            { GG_STR("sessionToken"),
-              GG_REQUIRED,
-              GG_TYPE_BUF,
-              &aws_session_token },
-        )
-    );
-    if (ret != GG_ERR_OK) {
-        GG_LOGE("Failed to validate TES credentials."
-
-        );
-        return GG_ERR_FAILURE;
-    }
-    tes_creds->access_key_id = gg_obj_into_buf(*aws_access_key_id);
-    tes_creds->secret_access_key = gg_obj_into_buf(*aws_secret_access_key);
-    tes_creds->session_token = gg_obj_into_buf(*aws_session_token);
-    return GG_ERR_OK;
 }
 
 typedef struct {
@@ -3179,7 +3120,23 @@ static void handle_deployment(
             .gghttplib_root_ca_path = config.rootca_path };
 
     TesCredentials tes_credentials = { .aws_region = region.buf };
-    ret = get_tes_credentials(&tes_credentials);
+
+    // Local deployments are not required to use TES; however,
+    // some local deployments may attempt to use them.
+    // Do not retry TES for local deployments.
+    // Instead, allow the device operator to programatically retry using
+    // ggl-cli.
+    if (deployment->type == LOCAL_DEPLOYMENT) {
+        ret = get_tes_credentials(&tes_credentials);
+    } else {
+        ret = get_tes_credentials_with_retry(
+            &tes_credentials,
+            get_tes_credentials,
+            TES_CREDENTIAL_RETRY_BASE_MS,
+            TES_CREDENTIAL_RETRY_MAX_MS
+        );
+    }
+
     bool tes_creds_retrieved = (ret == GG_ERR_OK);
     if (!tes_creds_retrieved) {
         GG_LOGW(

--- a/modules/ggdeploymentd/src/tes_getter.c
+++ b/modules/ggdeploymentd/src/tes_getter.c
@@ -1,0 +1,184 @@
+#include "tes_getter.h"
+#include <gg/arena.h>
+#include <gg/backoff.h>
+#include <gg/buffer.h>
+#include <gg/flags.h>
+#include <gg/log.h>
+#include <gg/map.h>
+#include <gg/object.h>
+#include <ggl/core_bus/client.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+    TesCredentials *tes_creds;
+    TesCredentialsGetter get_credentials;
+    GgError result;
+} TesCredentialsRetryCtx;
+
+static GgError retry_get_tes_credentials(void *ctx);
+static bool is_tes_credentials_error_retryable(GgError error);
+
+static bool is_tes_credentials_error_retryable(GgError error) {
+    return (error == GG_ERR_NOCONN) || (error == GG_ERR_TIMEOUT)
+        || (error == GG_ERR_RETRY);
+}
+
+static GgError retry_get_tes_credentials(void *ctx) {
+    TesCredentialsRetryCtx *retry_ctx = ctx;
+    retry_ctx->result = retry_ctx->get_credentials(retry_ctx->tes_creds);
+    if (is_tes_credentials_error_retryable(retry_ctx->result)) {
+        GG_LOGW(
+            "TES credential retrieval failed due to a transient error (%s); retrying with backoff.",
+            gg_strerror(retry_ctx->result)
+        );
+        return retry_ctx->result;
+    }
+    return GG_ERR_OK;
+}
+
+GgError get_tes_credentials_with_retry(
+    TesCredentials *tes_creds,
+    TesCredentialsGetter get_credentials,
+    uint32_t base_ms,
+    uint32_t max_ms
+) {
+    TesCredentialsRetryCtx ctx = { .tes_creds = tes_creds,
+                                   .get_credentials = get_credentials,
+                                   .result = GG_ERR_OK };
+    GgError ret
+        = gg_backoff(base_ms, max_ms, 0, retry_get_tes_credentials, &ctx);
+    if (ret != GG_ERR_OK) {
+        return ret;
+    }
+    return ctx.result;
+}
+
+GgError get_tes_credentials(TesCredentials *tes_creds) {
+    GgObject *aws_access_key_id = NULL;
+    GgObject *aws_secret_access_key = NULL;
+    GgObject *aws_session_token = NULL;
+
+    static uint8_t credentials_alloc[1500];
+    static GgBuffer tesd = GG_STR("aws_iot_tes");
+    GgObject result;
+    GgMap params = { 0 };
+    GgArena credential_alloc = gg_arena_init(GG_BUF(credentials_alloc));
+    GgError service_error = GG_ERR_OK;
+
+    GgError ret = ggl_call(
+        tesd,
+        GG_STR("request_credentials"),
+        params,
+        &service_error,
+        &credential_alloc,
+        &result
+    );
+    if (ret != GG_ERR_OK) {
+        if (ret == GG_ERR_REMOTE) {
+            ret = service_error;
+        }
+        GG_LOGE("Failed to get TES credentials: %s.", gg_strerror(ret));
+        return ret;
+    }
+
+    ret = gg_map_validate(
+        gg_obj_into_map(result),
+        GG_MAP_SCHEMA(
+            { GG_STR("accessKeyId"),
+              GG_REQUIRED,
+              GG_TYPE_BUF,
+              &aws_access_key_id },
+            { GG_STR("secretAccessKey"),
+              GG_REQUIRED,
+              GG_TYPE_BUF,
+              &aws_secret_access_key },
+            { GG_STR("sessionToken"),
+              GG_REQUIRED,
+              GG_TYPE_BUF,
+              &aws_session_token },
+        )
+    );
+    if (ret != GG_ERR_OK) {
+        GG_LOGE("Failed to validate TES credentials.");
+        return GG_ERR_FAILURE;
+    }
+    tes_creds->access_key_id = gg_obj_into_buf(*aws_access_key_id);
+    tes_creds->secret_access_key = gg_obj_into_buf(*aws_secret_access_key);
+    tes_creds->session_token = gg_obj_into_buf(*aws_session_token);
+    return GG_ERR_OK;
+}
+
+#ifdef GG_SDK_TESTING
+
+#include <assert.h>
+#include <gg/test.h>
+#include <string.h>
+#include <unity.h>
+
+static GgError tes_credentials_test_results[4];
+static size_t tes_credentials_test_result_count;
+static size_t tes_credentials_test_attempts;
+
+static GgError get_test_tes_credentials(TesCredentials *tes_creds) {
+    (void) tes_creds;
+    size_t result_index = tes_credentials_test_attempts;
+    tes_credentials_test_attempts += 1;
+    if (result_index >= tes_credentials_test_result_count) {
+        return GG_ERR_FATAL;
+    }
+    return tes_credentials_test_results[result_index];
+}
+
+static void set_tes_credentials_test_results(
+    const GgError *results, size_t result_count
+) {
+    assert(
+        result_count
+        <= (sizeof(tes_credentials_test_results)
+            / sizeof(tes_credentials_test_results[0]))
+    );
+    memcpy(
+        tes_credentials_test_results,
+        results,
+        result_count * sizeof(tes_credentials_test_results[0])
+    );
+    tes_credentials_test_result_count = result_count;
+    tes_credentials_test_attempts = 0;
+}
+
+GG_TEST_DEFINE(tes_credentials_cloud_retries_transient_errors) {
+    const GgError RESULTS[]
+        = { GG_ERR_NOCONN, GG_ERR_TIMEOUT, GG_ERR_RETRY, GG_ERR_OK };
+    set_tes_credentials_test_results(
+        RESULTS, (sizeof(RESULTS) / sizeof(RESULTS[0]))
+    );
+
+    TesCredentials credentials = { 0 };
+    TEST_ASSERT_EQUAL(
+        GG_ERR_OK,
+        get_tes_credentials_with_retry(
+            &credentials, get_test_tes_credentials, 1, 1
+        )
+    );
+    TEST_ASSERT_EQUAL_UINT32(4, tes_credentials_test_attempts);
+}
+
+GG_TEST_DEFINE(tes_credentials_cloud_does_not_retry_permanent_error) {
+    const GgError RESULTS[] = { GG_ERR_INVALID, GG_ERR_OK };
+    set_tes_credentials_test_results(
+        RESULTS, (sizeof(RESULTS) / sizeof(RESULTS[0]))
+    );
+
+    TesCredentials credentials = { 0 };
+    TEST_ASSERT_EQUAL(
+        GG_ERR_INVALID,
+        get_tes_credentials_with_retry(
+            &credentials, get_test_tes_credentials, 1, 1
+        )
+    );
+    TEST_ASSERT_EQUAL_UINT32(1, tes_credentials_test_attempts);
+}
+
+#endif

--- a/modules/ggdeploymentd/src/tes_getter.h
+++ b/modules/ggdeploymentd/src/tes_getter.h
@@ -1,0 +1,33 @@
+#ifndef GGL_TES_GETTER_H
+#define GGL_TES_GETTER_H
+
+#define TES_CREDENTIAL_RETRY_BASE_MS 1000
+#define TES_CREDENTIAL_RETRY_MAX_MS 60000
+
+#include <gg/attr.h>
+#include <gg/error.h>
+#include <gg/types.h>
+#include <stdint.h>
+
+typedef struct TesCredentials {
+    GgBuffer aws_region;
+    GgBuffer access_key_id;
+    GgBuffer secret_access_key;
+    GgBuffer session_token;
+} TesCredentials;
+
+NONNULL(1)
+typedef GgError (*TesCredentialsGetter)(TesCredentials *tes_creds);
+
+ACCESS(write_only, 1) NONNULL(1)
+GgError get_tes_credentials(TesCredentials *tes_creds);
+
+ACCESS(write_only, 1) NONNULL(1) NONNULL(2)
+GgError get_tes_credentials_with_retry(
+    TesCredentials *tes_creds,
+    TesCredentialsGetter get_credentials,
+    uint32_t base_ms,
+    uint32_t max_ms
+);
+
+#endif

--- a/modules/ggl-http/src/gghttp_util.c
+++ b/modules/ggl-http/src/gghttp_util.c
@@ -50,12 +50,21 @@ static GgError translate_curl_code(CURLcode code) {
     switch (code) {
     case CURLE_OK:
         return GG_ERR_OK;
+    case CURLE_COULDNT_CONNECT:
+    case CURLE_NO_CONNECTION_AVAILABLE:
+    case CURLE_RECV_ERROR:
+    case CURLE_SEND_ERROR:
+        return GG_ERR_NOCONN;
+    case CURLE_OPERATION_TIMEDOUT:
+        return GG_ERR_TIMEOUT;
     case CURLE_AGAIN:
         return GG_ERR_RETRY;
     case CURLE_URL_MALFORMAT:
         return GG_ERR_PARSE;
     case CURLE_ABORTED_BY_CALLBACK:
     case CURLE_WRITE_ERROR:
+    case CURLE_UNSUPPORTED_PROTOCOL:
+    case CURLE_FAILED_INIT:
         return GG_ERR_FAILURE;
     default:
         return GG_ERR_REMOTE;


### PR DESCRIPTION
## Description

Add TES retry behavior when processing cloud deployments.
Cloud deployments which fetch S3 artifacts or EC2 images require TES.

## Related Issue

Fixes an edge-case race condition on deployment receipt and tesd bring-up where credential retrieval may spuriously fail, resulting in eventual failure of a cloud deployment.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] Code passes all the quality test. Can try `nix flake check -L` locally
- [ ] **Documentation updated** (if applicable)
- [ ] **Tests added/updated in
      [aws-greengrass-testing](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)**
      (if applicable)

## Documentation Updates

- [ ] Updated README.md if needed
- [ ] Updated relevant documentation in `docs/` folder
- [ ] Requested to update public documentation if applicable (aws internal only)

## Testing

- [ ] Existing tests pass
- [ ] Added tests to
      [aws-greengrass-testing repository](https://github.com/aws-greengrass/aws-greengrass-testing/tree/python_testing)
- [x] New functionality is covered by tests

## Additional Notes

Any additional information, context, or screenshots that would be helpful for
reviewers.

_By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice._
